### PR TITLE
Harden localhost simulator control server

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ https://github.com/user-attachments/assets/65dc62ee-f0c7-48fb-9c57-5bd267c8c02f
   out of Simulator.app.
 - **Live unified-log stream** — `baguette logs --udid <X>` streams the
   booted simulator's `os_log` output line-by-line to stdout; `WS
-  /simulators/:udid/logs` does the same to a browser. Predicate /
+/simulators/:udid/logs` does the same to a browser. Predicate /
   bundle-id filters supported.
 - **Standalone web UI** — `baguette serve` opens `http://localhost:8421/simulators`
   with a list page, live stream, gesture input, and DeviceKit-sourced
@@ -191,22 +191,22 @@ served root for live-iteration without rebuilding.
 
 ### Routes (single resource tree, no `/api/` prefix)
 
-| Method | Path                                       | Backed by                    |
-|--------|--------------------------------------------|------------------------------|
-| `GET`  | `/`                                        | 302 → `/simulators`          |
-| `GET`  | `/simulators`                              | list HTML                    |
-| `GET`  | `/simulators.json`                         | list JSON `{running, available}` |
-| `GET`  | `/simulators/:udid`                        | stream HTML                  |
-| `POST` | `/simulators/:udid/boot`                   | `simulator.boot()`           |
-| `POST` | `/simulators/:udid/shutdown`               | `simulator.shutdown()`       |
-| `GET`  | `/simulators/:udid/chrome.json`            | DeviceKit bezel layout       |
-| `GET`  | `/simulators/:udid/bezel.png`              | rasterized bezel PNG         |
-| `GET`  | `/simulators/:udid/screenshot.jpg`         | one-shot JPEG of the framebuffer (`?quality=&scale=`) |
-| `WS`   | `/simulators/:udid/stream?format=mjpeg|avcc` | live frames + control + input + `describe_ui` |
+| Method | Path                                                        | Backed by                                                                    |
+| ------ | ----------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
+| `GET`  | `/`                                                         | 302 → `/simulators`                                                          |
+| `GET`  | `/simulators`                                               | list HTML                                                                    |
+| `GET`  | `/simulators.json`                                          | list JSON `{running, available}`                                             |
+| `GET`  | `/simulators/:udid`                                         | stream HTML                                                                  |
+| `POST` | `/simulators/:udid/boot`                                    | `simulator.boot()`                                                           |
+| `POST` | `/simulators/:udid/shutdown`                                | `simulator.shutdown()`                                                       |
+| `GET`  | `/simulators/:udid/chrome.json`                             | DeviceKit bezel layout                                                       |
+| `GET`  | `/simulators/:udid/bezel.png`                               | rasterized bezel PNG                                                         |
+| `GET`  | `/simulators/:udid/screenshot.jpg`                          | one-shot JPEG of the framebuffer (`?quality=&scale=`)                        |
+| `WS`   | `/simulators/:udid/stream?format=mjpeg                      | avcc`                                                                        | live frames + control + input + `describe_ui` |
 | `WS`   | `/simulators/:udid/logs?level=&style=&predicate=&bundleId=` | live unified-log stream (one `{"type":"log","line":…}` text frame per entry) |
-| `GET`  | `/farm`                                    | device-farm HTML             |
-| `GET`  | `/farm/:file`                              | farm UI asset (`farm.css`, `farm-*.js`, …) |
-| `GET`  | `/<file>.{html,js,css}`                    | static UI asset              |
+| `GET`  | `/farm`                                                     | device-farm HTML                                                             |
+| `GET`  | `/farm/:file`                                               | farm UI asset (`farm.css`, `farm-*.js`, …)                                   |
+| `GET`  | `/<file>.{html,js,css}`                                     | static UI asset                                                              |
 
 ### One bidirectional WebSocket per stream
 
@@ -260,13 +260,13 @@ device renders in a single page; the same WebSocket pipeline that powers
 `/farm` is a thin HTML shell at `Resources/Web/farm/farm.html` that
 loads five IIFE component scripts from `/farm/<name>.js`:
 
-| Script           | Job                                             |
-|------------------|-------------------------------------------------|
-| `farm-views.js`  | Grid / Wall / List renderers (pure DOM)         |
-| `farm-tile.js`   | `FarmTile` — per-device thumbnail StreamSession |
-| `farm-focus.js`  | `FarmFocus` — focused-device pane               |
-| `farm-filter.js` | `FarmFilter` — filter state + sidebar wiring    |
-| `farm-app.js`    | `FarmApp` — orchestrator (boot, fetch, dispatch)|
+| Script           | Job                                              |
+| ---------------- | ------------------------------------------------ |
+| `farm-views.js`  | Grid / Wall / List renderers (pure DOM)          |
+| `farm-tile.js`   | `FarmTile` — per-device thumbnail StreamSession  |
+| `farm-focus.js`  | `FarmFocus` — focused-device pane                |
+| `farm-filter.js` | `FarmFilter` — filter state + sidebar wiring     |
+| `farm-app.js`    | `FarmApp` — orchestrator (boot, fetch, dispatch) |
 
 `BAGUETTE_WEB_DIR` overrides the served root, so you can iterate on the
 farm UI without rebuilding — point it at `Sources/Baguette/Resources/Web`
@@ -330,12 +330,12 @@ baguette stream --udid <UDID> --format avcc --fps 60 | ffplay -
 Outputs length-prefixed binary frames on stdout. AVCC carries a 1-byte
 type prefix per chunk:
 
-| Prefix | Meaning |
-|--------|---------|
+| Prefix | Meaning                                             |
+| ------ | --------------------------------------------------- |
 | `0x01` | avcC description — feed to `VideoDecoder.configure` |
-| `0x02` | Keyframe (IDR) AVCC payload |
-| `0x03` | Delta frame |
-| `0x04` | JPEG seed — paints before H.264 IDR lands |
+| `0x02` | Keyframe (IDR) AVCC payload                         |
+| `0x03` | Delta frame                                         |
+| `0x04` | JPEG seed — paints before H.264 IDR lands           |
 
 Runtime control: while streaming, write one JSON line per command to
 stdin to retune without restarting.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ served root for live-iteration without rebuilding.
 | `GET`  | `/simulators/:udid/chrome.json`            | DeviceKit bezel layout       |
 | `GET`  | `/simulators/:udid/bezel.png`              | rasterized bezel PNG         |
 | `GET`  | `/simulators/:udid/screenshot.jpg`         | one-shot JPEG of the framebuffer (`?quality=&scale=`) |
-| `WS`   | `/simulators/:udid/stream?format=mjpeg|avcc` | live frames + control + input + `describe_ui` |
+| `WS`   | `/simulators/:udid/stream?format=mjpeg\|avcc` | live frames + control + input + `describe_ui` |
 | `WS`   | `/simulators/:udid/logs?level=&style=&predicate=&bundleId=` | live unified-log stream (one `{"type":"log","line":…}` text frame per entry) |
 | `GET`  | `/farm`                                    | device-farm HTML             |
 | `GET`  | `/farm/:file`                              | farm UI asset (`farm.css`, `farm-*.js`, …) |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ https://github.com/user-attachments/assets/65dc62ee-f0c7-48fb-9c57-5bd267c8c02f
   out of Simulator.app.
 - **Live unified-log stream** — `baguette logs --udid <X>` streams the
   booted simulator's `os_log` output line-by-line to stdout; `WS
-/simulators/:udid/logs` does the same to a browser. Predicate /
+  /simulators/:udid/logs` does the same to a browser. Predicate /
   bundle-id filters supported.
 - **Standalone web UI** — `baguette serve` opens `http://localhost:8421/simulators`
   with a list page, live stream, gesture input, and DeviceKit-sourced
@@ -191,22 +191,22 @@ served root for live-iteration without rebuilding.
 
 ### Routes (single resource tree, no `/api/` prefix)
 
-| Method | Path                                                        | Backed by                                                                    |
-| ------ | ----------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
-| `GET`  | `/`                                                         | 302 → `/simulators`                                                          |
-| `GET`  | `/simulators`                                               | list HTML                                                                    |
-| `GET`  | `/simulators.json`                                          | list JSON `{running, available}`                                             |
-| `GET`  | `/simulators/:udid`                                         | stream HTML                                                                  |
-| `POST` | `/simulators/:udid/boot`                                    | `simulator.boot()`                                                           |
-| `POST` | `/simulators/:udid/shutdown`                                | `simulator.shutdown()`                                                       |
-| `GET`  | `/simulators/:udid/chrome.json`                             | DeviceKit bezel layout                                                       |
-| `GET`  | `/simulators/:udid/bezel.png`                               | rasterized bezel PNG                                                         |
-| `GET`  | `/simulators/:udid/screenshot.jpg`                          | one-shot JPEG of the framebuffer (`?quality=&scale=`)                        |
-| `WS`   | `/simulators/:udid/stream?format=mjpeg                      | avcc`                                                                        | live frames + control + input + `describe_ui` |
+| Method | Path                                       | Backed by                    |
+|--------|--------------------------------------------|------------------------------|
+| `GET`  | `/`                                        | 302 → `/simulators`          |
+| `GET`  | `/simulators`                              | list HTML                    |
+| `GET`  | `/simulators.json`                         | list JSON `{running, available}` |
+| `GET`  | `/simulators/:udid`                        | stream HTML                  |
+| `POST` | `/simulators/:udid/boot`                   | `simulator.boot()`           |
+| `POST` | `/simulators/:udid/shutdown`               | `simulator.shutdown()`       |
+| `GET`  | `/simulators/:udid/chrome.json`            | DeviceKit bezel layout       |
+| `GET`  | `/simulators/:udid/bezel.png`              | rasterized bezel PNG         |
+| `GET`  | `/simulators/:udid/screenshot.jpg`         | one-shot JPEG of the framebuffer (`?quality=&scale=`) |
+| `WS`   | `/simulators/:udid/stream?format=mjpeg|avcc` | live frames + control + input + `describe_ui` |
 | `WS`   | `/simulators/:udid/logs?level=&style=&predicate=&bundleId=` | live unified-log stream (one `{"type":"log","line":…}` text frame per entry) |
-| `GET`  | `/farm`                                                     | device-farm HTML                                                             |
-| `GET`  | `/farm/:file`                                               | farm UI asset (`farm.css`, `farm-*.js`, …)                                   |
-| `GET`  | `/<file>.{html,js,css}`                                     | static UI asset                                                              |
+| `GET`  | `/farm`                                    | device-farm HTML             |
+| `GET`  | `/farm/:file`                              | farm UI asset (`farm.css`, `farm-*.js`, …) |
+| `GET`  | `/<file>.{html,js,css}`                    | static UI asset              |
 
 ### One bidirectional WebSocket per stream
 
@@ -260,13 +260,13 @@ device renders in a single page; the same WebSocket pipeline that powers
 `/farm` is a thin HTML shell at `Resources/Web/farm/farm.html` that
 loads five IIFE component scripts from `/farm/<name>.js`:
 
-| Script           | Job                                              |
-| ---------------- | ------------------------------------------------ |
-| `farm-views.js`  | Grid / Wall / List renderers (pure DOM)          |
-| `farm-tile.js`   | `FarmTile` — per-device thumbnail StreamSession  |
-| `farm-focus.js`  | `FarmFocus` — focused-device pane                |
-| `farm-filter.js` | `FarmFilter` — filter state + sidebar wiring     |
-| `farm-app.js`    | `FarmApp` — orchestrator (boot, fetch, dispatch) |
+| Script           | Job                                             |
+|------------------|-------------------------------------------------|
+| `farm-views.js`  | Grid / Wall / List renderers (pure DOM)         |
+| `farm-tile.js`   | `FarmTile` — per-device thumbnail StreamSession |
+| `farm-focus.js`  | `FarmFocus` — focused-device pane               |
+| `farm-filter.js` | `FarmFilter` — filter state + sidebar wiring    |
+| `farm-app.js`    | `FarmApp` — orchestrator (boot, fetch, dispatch)|
 
 `BAGUETTE_WEB_DIR` overrides the served root, so you can iterate on the
 farm UI without rebuilding — point it at `Sources/Baguette/Resources/Web`
@@ -330,12 +330,12 @@ baguette stream --udid <UDID> --format avcc --fps 60 | ffplay -
 Outputs length-prefixed binary frames on stdout. AVCC carries a 1-byte
 type prefix per chunk:
 
-| Prefix | Meaning                                             |
-| ------ | --------------------------------------------------- |
+| Prefix | Meaning |
+|--------|---------|
 | `0x01` | avcC description — feed to `VideoDecoder.configure` |
-| `0x02` | Keyframe (IDR) AVCC payload                         |
-| `0x03` | Delta frame                                         |
-| `0x04` | JPEG seed — paints before H.264 IDR lands           |
+| `0x02` | Keyframe (IDR) AVCC payload |
+| `0x03` | Delta frame |
+| `0x04` | JPEG seed — paints before H.264 IDR lands |
 
 Runtime control: while streaming, write one JSON line per command to
 stdin to retune without restarting.

--- a/Sources/Baguette/App/GestureDispatcher.swift
+++ b/Sources/Baguette/App/GestureDispatcher.swift
@@ -32,8 +32,31 @@ final class GestureDispatcher {
 
     private func ack(ok: Bool, error: String? = nil) -> String {
         if let error {
-            return "{\"ok\":\(ok),\"error\":\"\(error)\"}"
+            return "{\"ok\":\(ok),\"error\":\"\(Self.jsonEscape(error))\"}"
         }
         return "{\"ok\":\(ok)}"
+    }
+
+    private static func jsonEscape(_ s: String) -> String {
+        var out = ""
+        out.reserveCapacity(s.count + 8)
+        for ch in s.unicodeScalars {
+            switch ch {
+            case "\"":  out.append("\\\"")
+            case "\\":  out.append("\\\\")
+            case "\n":  out.append("\\n")
+            case "\r":  out.append("\\r")
+            case "\t":  out.append("\\t")
+            case "\u{08}": out.append("\\b")
+            case "\u{0C}": out.append("\\f")
+            default:
+                if ch.value < 0x20 {
+                    out.append(String(format: "\\u%04x", ch.value))
+                } else {
+                    out.append(Character(ch))
+                }
+            }
+        }
+        return out
     }
 }

--- a/Sources/Baguette/Infrastructure/Server/Server.swift
+++ b/Sources/Baguette/Infrastructure/Server/Server.swift
@@ -244,11 +244,14 @@ struct Server: Sendable {
 
     // MARK: - handlers
 
-    private static func staticAsset(_ name: String) -> Response {
+    static func staticAsset(_ name: String) -> Response {
         guard let data = WebRoot.data(named: name) else {
             return Response(
                 status: .notFound,
-                headers: [.contentType: "text/plain; charset=utf-8"],
+                headers: [
+                    .contentType: "text/plain; charset=utf-8",
+                    .contentSecurityPolicy: "frame-ancestors 'none'",
+                ],
                 body: .init(byteBuffer: ByteBuffer(string:
                     "missing \(name) — set BAGUETTE_WEB_DIR or rebuild"
                 ))
@@ -256,7 +259,11 @@ struct Server: Sendable {
         }
         return Response(
             status: .ok,
-            headers: [.contentType: contentType(for: name), .cacheControl: "no-cache"],
+            headers: [
+                .contentType: contentType(for: name),
+                .cacheControl: "no-cache",
+                .contentSecurityPolicy: "frame-ancestors 'none'",
+            ],
             body: .init(byteBuffer: ByteBuffer(data: data))
         )
     }
@@ -983,4 +990,5 @@ private func contentType(for filename: String) -> String {
 
 private extension HTTPField.Name {
     static let secFetchSite = Self("Sec-Fetch-Site")!
+    static let contentSecurityPolicy = Self("Content-Security-Policy")!
 }

--- a/Sources/Baguette/Infrastructure/Server/Server.swift
+++ b/Sources/Baguette/Infrastructure/Server/Server.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HTTPTypes
 import Hummingbird
 import HummingbirdWebSocket
 import NIOCore
@@ -71,26 +72,47 @@ struct Server: Sendable {
     // MARK: - routes
 
     private func registerRoutes(on router: Router<BasicWebSocketRequestContext>) {
+        let bindHost = self.host
+        let bindPort = self.port
+        let rejectUntrustedBrowser: @Sendable (Request) -> Response? = { request in
+            Self.rejectUntrustedBrowserRequest(
+                request, bindHost: bindHost, bindPort: bindPort
+            )
+        }
+        let trustedWebSocketUpgrade:
+            @Sendable (Request, BasicWebSocketRequestContext) async throws -> RouterShouldUpgrade = {
+                request, _ in
+                Self.isTrustedBrowserRequest(
+                    request, bindHost: bindHost, bindPort: bindPort
+                ) ? .upgrade([:]) : .dontUpgrade
+            }
+
         // List page (HTML + sibling assets).
         router.get("/") { _, _ in Self.redirect(to: "/simulators") }
         router.get("/simulators") { _, _ in Self.staticAsset("sim.html") }
-        router.get("/simulators.json") { [simulators] _, _ in Self.listJSON(simulators) }
+        router.get("/simulators.json") { [simulators] r, _ in
+            if let rejected = rejectUntrustedBrowser(r) { return rejected }
+            return Self.listJSON(simulators)
+        }
 
         // Stream page — same sim.html, JS routes the inner view based on URL.
         router.get("/simulators/:udid") { _, _ in Self.staticAsset("sim.html") }
 
         // Simulator actions.
         router.post("/simulators/:udid/boot")     { [simulators] r, _ in
-            Self.lifecycle(udid: Self.udidParam(r), simulators: simulators) { try $0.boot() }
+            if let rejected = rejectUntrustedBrowser(r) { return rejected }
+            return Self.lifecycle(udid: Self.udidParam(r), simulators: simulators) { try $0.boot() }
         }
         router.post("/simulators/:udid/shutdown") { [simulators] r, _ in
-            Self.lifecycle(udid: Self.udidParam(r), simulators: simulators) { try $0.shutdown() }
+            if let rejected = rejectUntrustedBrowser(r) { return rejected }
+            return Self.lifecycle(udid: Self.udidParam(r), simulators: simulators) { try $0.shutdown() }
         }
         // Orientation — `?value=portrait|landscape-left|landscape-right|portrait-upside-down`.
         // Routes through `simulator.orientation().set(...)` which fires
         // a GSEvent over `PurpleWorkspacePort`. Pure parse + dispatch
         // logic lives in `Server.applyOrientation` for unit testing.
         router.post("/simulators/:udid/orientation") { [simulators] r, _ in
+            if let rejected = rejectUntrustedBrowser(r) { return rejected }
             let value = r.uri.queryParameters.get("value") ?? ""
             switch Self.applyOrientation(
                 udid: Self.udidParam(r), value: value, simulators: simulators
@@ -114,9 +136,11 @@ struct Server: Sendable {
 
         // Chrome / bezel — DeviceKit-sourced layout + rasterized PNG.
         router.get("/simulators/:udid/chrome.json") { [simulators, chromes] r, _ in
-            Self.chromeJSON(udid: Self.udidParam(r), simulators: simulators, chromes: chromes)
+            if let rejected = rejectUntrustedBrowser(r) { return rejected }
+            return Self.chromeJSON(udid: Self.udidParam(r), simulators: simulators, chromes: chromes)
         }
         router.get("/simulators/:udid/bezel.png") { [simulators, chromes] r, _ in
+            if let rejected = rejectUntrustedBrowser(r) { return rejected }
             // ?buttons=false → bare device body (no buttons baked in).
             // The actionable-bezel front end layers per-button images on
             // top via the /chrome-button/<name>.png route below.
@@ -142,6 +166,7 @@ struct Server: Sendable {
         // a 3-segment path and grabs the second-to-last component,
         // which breaks for this 4-segment template.
         router.get("/simulators/:udid/chrome-button/:file") { [simulators, chromes] r, _ in
+            if let rejected = rejectUntrustedBrowser(r) { return rejected }
             let parts = r.uri.path.split(separator: "/")
             let udid = parts.count >= 4
                 ? String(parts[1]).removingPercentEncoding ?? ""
@@ -160,7 +185,8 @@ struct Server: Sendable {
         // awaits one IOSurface, encodes, and tears down — `?quality=`
         // and `?scale=` mirror the WS stream knobs for parity.
         router.get("/simulators/:udid/screenshot.jpg") { [simulators] r, _ in
-            await Self.screenshotJPEG(
+            if let rejected = rejectUntrustedBrowser(r) { return rejected }
+            return await Self.screenshotJPEG(
                 udid: Self.udidParam(r),
                 quality: r.uri.queryParameters.get("quality").flatMap(Double.init) ?? 0.85,
                 scale: r.uri.queryParameters.get("scale").flatMap(Int.init) ?? 1,
@@ -186,7 +212,10 @@ struct Server: Sendable {
         // snapshot). One bidirectional channel per session means no
         // POST /event side-route, no UDID-keyed registry — the WS
         // closure already owns the live stream + sim handles.
-        router.ws("/simulators/:udid/stream") { [simulators] inbound, outbound, context in
+        router.ws(
+            "/simulators/:udid/stream",
+            shouldUpgrade: trustedWebSocketUpgrade
+        ) { [simulators] inbound, outbound, context in
             await Self.streamWS(
                 udid: Self.udidParam(context.request),
                 format: context.request.uri.queryParameters.get("format")
@@ -475,7 +504,7 @@ struct Server: Sendable {
             try stream.start(on: screen)
         } catch {
             try? await outbound.write(.text(
-                #"{"ok":false,"error":"\#(String(describing: error))"}"#
+                #"{"ok":false,"error":"\#(jsonEscape(String(describing: error)))"}"#
             ))
             return
         }
@@ -532,7 +561,7 @@ struct Server: Sendable {
             }
         } catch {
             try? await outbound.write(.text(
-                #"{"type":"describe_ui_result","ok":false,"error":"\#(String(describing: error))"}"#
+                #"{"type":"describe_ui_result","ok":false,"error":"\#(jsonEscape(String(describing: error)))"}"#
             ))
             return true
         }
@@ -554,7 +583,19 @@ struct Server: Sendable {
     /// `router.get` closures share a single function body.
     private func registerLogsRoute(on router: Router<BasicWebSocketRequestContext>) {
         let simulators = self.simulators
-        router.ws("/simulators/:udid/logs") { inbound, outbound, context in
+        let bindHost = self.host
+        let bindPort = self.port
+        let trustedWebSocketUpgrade:
+            @Sendable (Request, BasicWebSocketRequestContext) async throws -> RouterShouldUpgrade = {
+                request, _ in
+                Self.isTrustedBrowserRequest(
+                    request, bindHost: bindHost, bindPort: bindPort
+                ) ? .upgrade([:]) : .dontUpgrade
+            }
+        router.ws(
+            "/simulators/:udid/logs",
+            shouldUpgrade: trustedWebSocketUpgrade
+        ) { inbound, outbound, context in
             let req = context.request
             let opts = LogsRouteOptions.from(request: req)
             await Self.logsWS(
@@ -745,6 +786,94 @@ struct Server: Sendable {
             body: .init(byteBuffer: ByteBuffer(string: ""))
         )
     }
+
+    private static func rejectUntrustedBrowserRequest(
+        _ request: Request,
+        bindHost: String,
+        bindPort: Int
+    ) -> Response? {
+        guard !isTrustedBrowserRequest(request, bindHost: bindHost, bindPort: bindPort) else {
+            return nil
+        }
+        return errorJSON("forbidden origin", status: .forbidden)
+    }
+
+    /// Browsers can drive localhost services from another site unless the
+    /// service checks `Origin`. For a loopback bind, also reject DNS-rebind
+    /// style `Host` values that are not loopback names.
+    static func isTrustedBrowserRequest(
+        _ request: Request,
+        bindHost: String,
+        bindPort: Int
+    ) -> Bool {
+        if isLoopbackBind(bindHost),
+           let authority = request.head.authority,
+           let requestHost = parseAuthority(authority)?.host,
+           !isLoopbackHost(requestHost) {
+            return false
+        }
+
+        if let fetchSite = request.headers[.secFetchSite]?.lowercased(),
+           fetchSite == "cross-site" {
+            return false
+        }
+
+        guard let origin = request.headers[.origin] else { return true }
+        guard let originURL = URLComponents(string: origin),
+              let originHost = originURL.host else {
+            return false
+        }
+
+        let authority = request.head.authority ?? "\(bindHost):\(bindPort)"
+        guard let requestAuthority = parseAuthority(authority) else { return false }
+        let requestPort = requestAuthority.port ?? bindPort
+        let originPort = originURL.port ?? defaultPort(for: originURL.scheme)
+
+        if isLoopbackBind(bindHost) {
+            return isLoopbackHost(originHost)
+                && isLoopbackHost(requestAuthority.host)
+                && (originPort ?? requestPort) == requestPort
+        }
+
+        return originHost.caseInsensitiveCompare(requestAuthority.host) == .orderedSame
+            && (originPort ?? requestPort) == requestPort
+    }
+
+    private static func parseAuthority(_ raw: String) -> (host: String, port: Int?)? {
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+
+        if value.hasPrefix("["),
+           let close = value.firstIndex(of: "]") {
+            let host = String(value[value.index(after: value.startIndex)..<close])
+            let rest = value[value.index(after: close)...]
+            let port = rest.hasPrefix(":") ? Int(rest.dropFirst()) : nil
+            return (host, port)
+        }
+
+        let parts = value.split(separator: ":", omittingEmptySubsequences: false)
+        if parts.count == 1 { return (String(parts[0]), nil) }
+        guard let last = parts.last, let port = Int(last) else { return (value, nil) }
+        return (parts.dropLast().joined(separator: ":"), port)
+    }
+
+    private static func defaultPort(for scheme: String?) -> Int? {
+        switch scheme?.lowercased() {
+        case "http", "ws": return 80
+        case "https", "wss": return 443
+        default: return nil
+        }
+    }
+
+    private static func isLoopbackBind(_ host: String) -> Bool {
+        let lower = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
+        return lower == "localhost" || lower == "::1" || lower.hasPrefix("127.")
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
+        let lower = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
+        return lower == "localhost" || lower == "::1" || lower.hasPrefix("127.")
+    }
 }
 
 // MARK: - tiny response helpers
@@ -756,12 +885,11 @@ private let jsonOK = Response(
 )
 
 private func errorJSON(_ message: String, status: HTTPResponse.Status) -> Response {
-    let escaped = message.replacingOccurrences(of: "\"", with: "\\\"")
     return Response(
         status: status,
         headers: [.contentType: "application/json"],
         body: .init(byteBuffer: ByteBuffer(string:
-            "{\"ok\":false,\"error\":\"\(escaped)\"}"
+            "{\"ok\":false,\"error\":\"\(jsonEscape(message))\"}"
         ))
     )
 }
@@ -851,4 +979,8 @@ private func contentType(for filename: String) -> String {
     if filename.hasSuffix(".png")  { return "image/png" }
     if filename.hasSuffix(".jpg") || filename.hasSuffix(".jpeg") { return "image/jpeg" }
     return "application/octet-stream"
+}
+
+private extension HTTPField.Name {
+    static let secFetchSite = Self("Sec-Fetch-Site")!
 }

--- a/Sources/Baguette/Infrastructure/Server/WebRoot.swift
+++ b/Sources/Baguette/Infrastructure/Server/WebRoot.swift
@@ -30,6 +30,7 @@ struct WebRoot {
     /// Read a file by name (e.g. `"simulators.html"`). Returns nil
     /// when the asset is missing across every lookup path.
     static func data(named filename: String) -> Data? {
+        guard let filename = safeRelativeAssetPath(filename) else { return nil }
         if let path = ProcessInfo.processInfo.environment["BAGUETTE_WEB_DIR"],
            let data = read(URL(fileURLWithPath: path).appendingPathComponent(filename)) {
             return data
@@ -46,6 +47,26 @@ struct WebRoot {
     }
 
     // MARK: - private
+
+    /// Keep static asset lookups inside the web root even when a route
+    /// passes a percent-decoded path segment such as `..%2FPackage.swift`.
+    private static func safeRelativeAssetPath(_ filename: String) -> String? {
+        guard !filename.isEmpty, !filename.hasPrefix("/") else { return nil }
+        let scalars = filename.unicodeScalars
+        guard scalars.allSatisfy({ scalar in
+            scalar == "/" || scalar == "." || scalar == "-" || scalar == "_"
+                || ("a"..."z").contains(scalar)
+                || ("A"..."Z").contains(scalar)
+                || ("0"..."9").contains(scalar)
+        }) else { return nil }
+
+        let parts = filename.split(separator: "/", omittingEmptySubsequences: false)
+        guard !parts.isEmpty else { return nil }
+        for part in parts {
+            guard !part.isEmpty, part != ".", part != ".." else { return nil }
+        }
+        return parts.joined(separator: "/")
+    }
 
     private static func read(_ url: URL) -> Data? {
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }

--- a/Tests/BaguetteTests/App/GestureDispatcherTests.swift
+++ b/Tests/BaguetteTests/App/GestureDispatcherTests.swift
@@ -73,6 +73,17 @@ struct GestureDispatcherTests {
 
         #expect(ack == #"{"ok":false,"error":"boom"}"#)
     }
+
+    @Test func `escapes thrown error strings in JSON acks`() {
+        let input = MockInput()
+        let registry = GestureRegistry()
+        registry.register(EscapingGesture.self)
+        let dispatcher = GestureDispatcher(input: input, registry: registry)
+
+        let ack = dispatcher.dispatch(line: #"{"type":"escape-error"}"#)
+
+        #expect(ack == #"{"ok":false,"error":"quote \" backslash \\ newline \n tab \t backspace \b formfeed \f control \u0001"}"#)
+    }
 }
 
 private struct ThrowingGesture: Gesture {
@@ -84,4 +95,16 @@ private struct ThrowingGesture: Gesture {
 private enum OtherError: Error, CustomStringConvertible {
     case boom
     var description: String { "boom" }
+}
+
+private struct EscapingGesture: Gesture {
+    static var wireType: String { "escape-error" }
+    static func parse(_ dict: [String: Any]) throws -> Self { throw EscapingError() }
+    func execute(on input: any Input) -> Bool { true }
+}
+
+private struct EscapingError: Error, CustomStringConvertible {
+    var description: String {
+        "quote \" backslash \\ newline \n tab \t backspace \u{08} formfeed \u{0C} control \u{01}"
+    }
 }

--- a/Tests/BaguetteTests/Server/ServerSecurityTests.swift
+++ b/Tests/BaguetteTests/Server/ServerSecurityTests.swift
@@ -60,6 +60,16 @@ struct ServerSecurityTests {
         ))
     }
 
+    @Test func `static asset responses deny foreign framing`() {
+        let csp = HTTPField.Name("Content-Security-Policy")!
+
+        for asset in ["sim.html", "farm/farm.html"] {
+            let response = Server.staticAsset(asset)
+
+            #expect(response.headers[csp] == "frame-ancestors 'none'")
+        }
+    }
+
     private static func request(
         host: String,
         origin: String? = nil,

--- a/Tests/BaguetteTests/Server/ServerSecurityTests.swift
+++ b/Tests/BaguetteTests/Server/ServerSecurityTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import Hummingbird
+import HTTPTypes
+import NIOCore
+@testable import Baguette
+
+@Suite("Server browser security")
+struct ServerSecurityTests {
+
+    @Test func `allows direct loopback requests without an Origin header`() {
+        let request = Self.request(host: "127.0.0.1:8421")
+
+        #expect(Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421
+        ))
+    }
+
+    @Test func `allows same-origin browser requests on loopback`() {
+        let request = Self.request(
+            host: "localhost:8421",
+            origin: "http://localhost:8421"
+        )
+
+        #expect(Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421
+        ))
+    }
+
+    @Test func `rejects cross-site browser requests to loopback control routes`() {
+        let request = Self.request(
+            host: "127.0.0.1:8421",
+            origin: "https://example.test"
+        )
+
+        #expect(!Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421
+        ))
+    }
+
+    @Test func `rejects DNS rebind shaped hosts on loopback binds`() {
+        let request = Self.request(
+            host: "attacker.test:8421",
+            origin: "http://attacker.test:8421"
+        )
+
+        #expect(!Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421
+        ))
+    }
+
+    @Test func `rejects Fetch Metadata cross-site requests`() {
+        let request = Self.request(
+            host: "127.0.0.1:8421",
+            origin: "http://127.0.0.1:8421",
+            fetchSite: "cross-site"
+        )
+
+        #expect(!Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421
+        ))
+    }
+
+    private static func request(
+        host: String,
+        origin: String? = nil,
+        fetchSite: String? = nil
+    ) -> Request {
+        var headers: HTTPFields = [:]
+        if let origin { headers[.origin] = origin }
+        if let fetchSite { headers[HTTPField.Name("Sec-Fetch-Site")!] = fetchSite }
+
+        let head = HTTPRequest(
+            method: .post,
+            scheme: nil,
+            authority: host,
+            path: "/simulators/UDID/boot",
+            headerFields: headers
+        )
+        return Request(head: head, body: .init(buffer: ByteBuffer()))
+    }
+}

--- a/Tests/BaguetteTests/Server/WebRootSubdirTests.swift
+++ b/Tests/BaguetteTests/Server/WebRootSubdirTests.swift
@@ -7,7 +7,7 @@ import Foundation
 /// instead of bloating the flat root. These tests pin the lookup
 /// behavior so a future refactor of `Bundle.url(forResource:…)` or the
 /// source-tree fallback can't silently break the `/farm` route.
-@Suite("WebRoot subdirectory lookup")
+@Suite("WebRoot subdirectory lookup", .serialized)
 struct WebRootSubdirTests {
 
     @Test("resolves a file in a subdirectory via BAGUETTE_WEB_DIR")
@@ -36,6 +36,27 @@ struct WebRootSubdirTests {
         defer { unsetenv("BAGUETTE_WEB_DIR") }
 
         #expect(WebRoot.data(named: "farm/does-not-exist.js") == nil)
+    }
+
+    @Test("rejects traversal outside BAGUETTE_WEB_DIR")
+    func rejectsTraversalOutsideEnvOverride() throws {
+        let tmp = try makeTempWebTree(files: [
+            "farm/farm.html": "<!doctype html><title>farm</title>",
+        ])
+        let outside = tmp.deletingLastPathComponent()
+            .appendingPathComponent("baguette-outside-\(UUID().uuidString).txt")
+        defer {
+            try? FileManager.default.removeItem(at: tmp)
+            try? FileManager.default.removeItem(at: outside)
+        }
+        try "outside".write(to: outside, atomically: true, encoding: .utf8)
+
+        setenv("BAGUETTE_WEB_DIR", tmp.path, 1)
+        defer { unsetenv("BAGUETTE_WEB_DIR") }
+
+        #expect(WebRoot.string(named: "../\(outside.lastPathComponent)") == nil)
+        #expect(WebRoot.string(named: "farm/../../\(outside.lastPathComponent)") == nil)
+        #expect(WebRoot.string(named: "farm/%2e%2e/\(outside.lastPathComponent)") == nil)
     }
 
     // MARK: - helpers


### PR DESCRIPTION
## Summary

This change hardens the local simulator control server against browser-driven abuse and unsafe static asset lookup. The server is intended for local development, but it exposes powerful simulator actions such as boot, shutdown, orientation changes, screen streaming, screenshots, logs, and input dispatch. Those endpoints should not be reachable through a malicious browser context or via path traversal through the static file layer.

## Issues Identified

### 1. Cross-origin browser control of local simulator actions

The HTTP and WebSocket control routes accepted browser requests without checking the request origin. Because the default service binds to loopback, another website loaded in the user's browser could attempt to send requests to the local service. This is especially sensitive for routes that can boot or shut down simulators, change orientation, open streams, read logs, capture screenshots, or dispatch input.

### 2. DNS rebinding risk on loopback binds

Loopback services are also exposed to DNS rebinding style attacks when a request reaches `127.0.0.1` but carries a non-loopback authority. Without authority validation, a browser-origin check alone does not fully protect a local service.

### 3. Static asset path traversal

Static assets were resolved by appending a route-supplied filename to the web root. Percent-decoded values containing path separators or `..` segments could escape the intended static asset directory, especially when `BAGUETTE_WEB_DIR` points at a development tree.

### 4. JSON error string escaping

Some JSON error responses interpolated error text directly. This could produce malformed JSON when the error string contained quotes, backslashes, or control characters.

## Resolution

- Added browser request validation for control and data-bearing routes.
- Rejects cross-site requests using `Origin` and `Sec-Fetch-Site`.
- Rejects non-loopback authorities when the server is bound to loopback.
- Applies the same trust check to WebSocket upgrade routes for stream and log sockets.
- Constrains static asset lookup to safe relative paths only.
- Rejects empty segments, absolute paths, `.` segments, `..` segments, and unexpected characters.
- Escapes JSON error strings consistently before embedding them in response bodies.
- Added targeted tests for same-origin, cross-origin, DNS rebinding shaped requests, Fetch Metadata rejection, and static asset traversal rejection.
- Serialized the web-root test suite because it mutates `BAGUETTE_WEB_DIR`, which is process-global state.

## Validation

- `swift test` passes: 389 tests.
- `make` passes and produces `./Baguette`.
- `./Baguette --help` runs successfully.
- `./Baguette list --json` returns simulator inventory from CoreSimulator.
- Local smoke test against `baguette serve --port 18421`:
  - `/simulators.json` returns HTTP 200 for normal loopback access.
  - Cross-origin POST to `/simulators/NOPE/boot` returns HTTP 403.
  - DNS rebinding shaped GET with `Host: attacker.test:18421` returns HTTP 403.
  - Traversal attempt `/%2e%2e%2FPackage.swift` returns HTTP 404.
- OSV batch query for pinned Swift package dependencies returned no known advisories.

## Operational Impact

Normal local usage through `http://127.0.0.1:<port>` and `http://localhost:<port>` continues to work. Browser requests from unrelated origins and non-loopback authorities are denied. Static UI assets continue to resolve from the bundled resource directory, source-tree fallback, and `BAGUETTE_WEB_DIR` when the requested path is a safe relative asset path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Escape JSON error strings to ensure valid error payloads.
  * Tighten origin/trust checks and block untrusted browser requests for sensitive HTTP and WebSocket endpoints.
  * Add Content-Security-Policy (frame-ancestors 'none') for static assets.
  * Reject unsafe or path-traversal file requests for served assets.

* **Tests**
  * New/expanded tests for origin/trust rules, WebSocket upgrades, path-safety, and JSON error escaping.

* **Documentation**
  * Adjusted README routing table formatting for stream route.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tddworks/baguette/pull/7)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->