### PR TITLE
fix(ax): server-side hit-test for describeAt via 3-arg objectAtPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Fixed
+- **Server-side AX hit-test for `describeAt(point:)`.** The method was previously falling back to a client-side tree walk because the 0-arg `objectAtPoint:` variant has a chicken/egg problem with `bridgeDelegateToken` — the returned translation needs the token stamped before the call. `AXPTranslator` exposes a **3-arg** variant — `objectAtPoint:displayId:bridgeDelegateToken:` — that takes the token as a parameter, which the dispatcher entry registered in `hitTestServerSide` resolves correctly on the very first XPC sub-request. Meta's idb has used this selector internally for years (`FBSimulatorAccessibilityCommands.m`'s `FBAXTranslationRequest_Point`, backing its describe-point CLI). The practical payoff is that `describeAt(point:)` now returns elements the static tree walk *misses* — most notably SwiftUI tab-bar items inside an `AXGroup` that `describeAll` reports as childless. Falls back to the original client-side walk only when the AXP selector isn't present (defensive only — present on every AXP we've seen on Xcode 26+). Adds `AXFrameTransform.unmap(_:)` for the device-point → host-coordinate inverse and `AXPTranslatorAccessibility.supportsServerSideHitTest` as the capability gate; both fully unit-covered.
+
 ---
 
 ## [0.1.70] - 2026-05-11

--- a/Sources/Baguette/Domain/Accessibility/AXFrameTransform.swift
+++ b/Sources/Baguette/Domain/Accessibility/AXFrameTransform.swift
@@ -33,4 +33,27 @@ struct AXFrameTransform: Equatable, Sendable {
             height: macFrame.size.height * scale
         )
     }
+
+    /// Inverse of `map(_:)`: takes a device-point coordinate (the
+    /// units callers pass into the gesture wire) and projects it
+    /// back to macOS host-window coordinates. Needed when feeding
+    /// AXP APIs that work in host coordinates — most notably
+    /// `objectAtPoint:displayId:bridgeDelegateToken:`, where the
+    /// translator interprets the point in its own host coordinate
+    /// space, not in device points. Falls back to identity under
+    /// the same zero-dimension conditions as `map(_:)`.
+    func unmap(_ devicePoint: CGPoint) -> CGPoint {
+        guard rootFrame.width > 0,
+              rootFrame.height > 0,
+              pointSize.width > 0,
+              pointSize.height > 0
+        else { return devicePoint }
+
+        let scale = pointSize.width / rootFrame.width
+        let yOffset = (pointSize.height - rootFrame.height * scale) / 2
+        return CGPoint(
+            x: devicePoint.x / scale + rootFrame.origin.x,
+            y: (devicePoint.y - yOffset) / scale + rootFrame.origin.y
+        )
+    }
 }

--- a/Sources/Baguette/Infrastructure/Accessibility/AXPTranslatorAccessibility.swift
+++ b/Sources/Baguette/Infrastructure/Accessibility/AXPTranslatorAccessibility.swift
@@ -66,13 +66,26 @@ final class AXPTranslatorAccessibility: Accessibility, @unchecked Sendable {
     }
 
     func describeAt(point: Point) throws -> AXNode? {
-        // No native hit-test that survives the dispatcher pattern
-        // reliably — AXP's `objectAtPoint:` returns a translation
-        // whose `bridgeDelegateToken` we'd have to seed before the
-        // call (chicken / egg). Instead, fetch the tree once and
-        // hit-test locally with our `AXNode.hitTest`. Cheap
-        // post-fetch, and reuses the value-type semantics we
-        // already TDD'd.
+        // Prefer the server-side hit-test. `AXPTranslator` exposes
+        // `objectAtPoint:displayId:bridgeDelegateToken:` — the
+        // 3-arg form, distinct from the chicken/egg-prone `objectAtPoint:`
+        // — which accepts the token as a parameter and therefore
+        // plays nicely with the dispatcher pattern. The big win
+        // is that it returns elements the static tree walk
+        // *misses*: SwiftUI tab bars / nav bars / toolbars
+        // routinely enumerate as childless via `describeAll`, but
+        // `objectAtPoint` hits the underlying buttons just fine.
+        // Discovered while reading Meta's idb
+        // (`FBSimulatorAccessibilityCommands.m`:885), where the same
+        // selector backs idb's describe-point CLI.
+        //
+        // Fall back to the original client-side path when the
+        // selector isn't available (very old AXPTranslator, hypothetical)
+        // or the host-side resolution fails before we get a translator.
+        if Self.supportsServerSideHitTest,
+           let hit = try hitTestServerSide(point: point) {
+            return hit
+        }
         guard let tree = try fetchTree(hitTest: point) else { return nil }
         return tree.hitTest(point) ?? tree
     }
@@ -118,6 +131,85 @@ final class AXPTranslatorAccessibility: Accessibility, @unchecked Sendable {
         return AXNode.walk(
             from: rootElement,
             transform: AXFrameTransform(rootFrame: rootFrame, pointSize: pointSize),
+            depthCap: Self.maxDepth,
+            deadline: deadline
+        )
+    }
+
+    /// Server-side hit-test path. Walks the same handshake as
+    /// `fetchTree` — register a token, resolve the frontmost app
+    /// to get a root frame for the device→host coordinate
+    /// transform — then calls
+    /// `objectAtPoint:displayId:bridgeDelegateToken:` on AXP
+    /// directly. The translator returns the deepest accessibility
+    /// element under the point, including elements that the
+    /// recursive children walk in `fetchTree` would have missed
+    /// (the canonical case: SwiftUI tab-bar items inside an empty
+    /// `AXGroup`). The returned translation is walked into an
+    /// `AXNode` subtree using the same `AXNode.walk` factory
+    /// `fetchTree` uses, so callers get identical value-type
+    /// semantics either way.
+    private func hitTestServerSide(point: Point) throws -> AXNode? {
+        guard Self.isAvailable else {
+            logErr("[ax] framework / dispatcher not available")
+            return nil
+        }
+        guard let device = resolveDevice() else {
+            logErr("[ax] device not found: \(udid)")
+            return nil
+        }
+
+        let token = UUID().uuidString
+        let deadline = Date().addingTimeInterval(Self.xpcTimeoutSeconds)
+        Self.sharedDispatcher.register(device: device, token: token, deadline: deadline)
+        defer { Self.sharedDispatcher.unregister(token: token) }
+
+        guard let translator = Self.sharedTranslator else { return nil }
+
+        // We need the frontmost app's root frame to invert the
+        // caller's device-point coordinate back into the host
+        // coordinate space that AXP's `objectAtPoint` expects.
+        guard let frontmost = Self.frontmostApplication(
+            translator: translator, token: token
+        ) else {
+            log("[ax] no frontmost application for udid=\(udid)")
+            return nil
+        }
+        Self.stamp(token: token, on: frontmost)
+
+        guard let frontmostRoot = Self.macPlatformElement(
+            translator: translator, translation: frontmost
+        ) else {
+            log("[ax] no mac platform element from translation")
+            return nil
+        }
+        let pointSize = Self.devicePointSize(for: device)
+        let rootFrame = AXElementReader.frame(of: frontmostRoot)
+        let transform = AXFrameTransform(rootFrame: rootFrame, pointSize: pointSize)
+        let hostPoint = transform.unmap(CGPoint(x: point.x, y: point.y))
+
+        guard let hitTranslation = Self.objectAtPoint(
+            translator: translator,
+            point: hostPoint,
+            displayId: 0,
+            token: token
+        ) else {
+            // No element under that point. Distinct from "selector
+            // missing" — that case is gated by
+            // `supportsServerSideHitTest` upstream.
+            return nil
+        }
+        Self.stamp(token: token, on: hitTranslation)
+
+        guard let hitElement = Self.macPlatformElement(
+            translator: translator, translation: hitTranslation
+        ) else { return nil }
+        Self.stampElementTranslation(token: token, on: hitElement)
+        Self.stampSubtree(hitElement, token: token, depthCap: Self.maxDepth)
+
+        return AXNode.walk(
+            from: hitElement,
+            transform: transform,
             depthCap: Self.maxDepth,
             deadline: deadline
         )
@@ -211,6 +303,45 @@ final class AXPTranslatorAccessibility: Accessibility, @unchecked Sendable {
         }
         typealias Fn = @convention(c) (AnyObject, Selector, AnyObject) -> AnyObject?
         return unsafeBitCast(imp, to: Fn.self)(translator, sel, translation) as? NSObject
+    }
+
+    /// 3-arg `objectAtPoint:displayId:bridgeDelegateToken:`. The
+    /// older 0-arg `objectAtPoint:` variant needs the bridge token
+    /// stamped on the returned translation *before* the call —
+    /// chicken/egg. This 3-arg form takes the token as a parameter,
+    /// so the dispatcher entry registered in `hitTestServerSide`
+    /// resolves correctly on the very first XPC sub-request. Used
+    /// by Meta's idb internally
+    /// (`FBSimulatorAccessibilityCommands.m`, `FBAXTranslationRequest_Point`),
+    /// where it's the foundation for the describe-point CLI.
+    private static func objectAtPoint(
+        translator: NSObject, point: CGPoint, displayId: UInt32, token: String
+    ) -> NSObject? {
+        let sel = NSSelectorFromString("objectAtPoint:displayId:bridgeDelegateToken:")
+        guard translator.responds(to: sel),
+              let imp = class_getMethodImplementation(type(of: translator), sel) else {
+            logErr("[ax] -objectAtPoint:displayId:bridgeDelegateToken: not found")
+            return nil
+        }
+        typealias Fn = @convention(c) (AnyObject, Selector, CGPoint, UInt32, AnyObject) -> AnyObject?
+        return unsafeBitCast(imp, to: Fn.self)(
+            translator, sel, point, displayId, token as NSString
+        ) as? NSObject
+    }
+
+    /// Capability check: `true` when the loaded AXPTranslator
+    /// responds to the 3-arg `objectAtPoint` selector. Lets
+    /// `describeAt(point:)` choose between the new server-side
+    /// path and the legacy client-side walk without a try-and-fall-back
+    /// dance — the two paths cost the same on a hit but cost
+    /// double on a miss, so a single capability check up front is
+    /// cleaner. The selector has been present on every AXP we've
+    /// seen on Xcode 26+; this guard is defensive only.
+    static var supportsServerSideHitTest: Bool {
+        guard let translator = sharedTranslator else { return false }
+        return translator.responds(
+            to: NSSelectorFromString("objectAtPoint:displayId:bridgeDelegateToken:")
+        )
     }
 
     // MARK: - element accessors

--- a/Sources/Baguette/Infrastructure/Accessibility/AXPTranslatorAccessibility.swift
+++ b/Sources/Baguette/Infrastructure/Accessibility/AXPTranslatorAccessibility.swift
@@ -92,7 +92,31 @@ final class AXPTranslatorAccessibility: Accessibility, @unchecked Sendable {
 
     // MARK: - tree fetch
 
-    private func fetchTree(hitTest: Point?) throws -> AXNode? {
+    /// The pieces every AXP entry point needs: a working translator,
+    /// a registered token, the frontmost app's root element (which
+    /// carries the host-window frame), an `AXFrameTransform` for
+    /// projecting/unprojecting coordinates, and the per-call deadline.
+    /// Held together inside the closure passed to
+    /// `withAXPContext(_:)`, which owns the dispatcher register +
+    /// unregister around it.
+    private struct AXPContext {
+        let translator: NSObject
+        let token: String
+        let frontmostRoot: NSObject
+        let transform: AXFrameTransform
+        let deadline: Date
+    }
+
+    /// Run `body` inside a fully-prepared AXP context. Handles the
+    /// dispatcher token lifecycle (register on entry, unregister on
+    /// exit), translator + frontmost-app resolution, and the
+    /// host-coord ↔ device-point `AXFrameTransform` setup. Returns
+    /// `nil` if any setup step fails (framework not loaded, device
+    /// missing, frontmost app not resolvable, etc.) — same nil
+    /// semantics each entry point had pre-refactor.
+    private func withAXPContext<T>(
+        _ body: (AXPContext) throws -> T?
+    ) throws -> T? {
         guard Self.isAvailable else {
             logErr("[ax] framework / dispatcher not available")
             return nil
@@ -117,23 +141,36 @@ final class AXPTranslatorAccessibility: Accessibility, @unchecked Sendable {
         }
         Self.stamp(token: token, on: translation)
 
-        guard let rootElement = Self.macPlatformElement(
+        guard let frontmostRoot = Self.macPlatformElement(
             translator: translator, translation: translation
         ) else {
             log("[ax] no mac platform element from translation")
             return nil
         }
-        Self.stampElementTranslation(token: token, on: rootElement)
-        Self.stampSubtree(rootElement, token: token, depthCap: Self.maxDepth)
-
         let pointSize = Self.devicePointSize(for: device)
-        let rootFrame = AXElementReader.frame(of: rootElement)
-        return AXNode.walk(
-            from: rootElement,
-            transform: AXFrameTransform(rootFrame: rootFrame, pointSize: pointSize),
-            depthCap: Self.maxDepth,
+        let rootFrame = AXElementReader.frame(of: frontmostRoot)
+        let transform = AXFrameTransform(rootFrame: rootFrame, pointSize: pointSize)
+
+        return try body(AXPContext(
+            translator: translator,
+            token: token,
+            frontmostRoot: frontmostRoot,
+            transform: transform,
             deadline: deadline
-        )
+        ))
+    }
+
+    private func fetchTree(hitTest: Point?) throws -> AXNode? {
+        try withAXPContext { ctx in
+            Self.stampElementTranslation(token: ctx.token, on: ctx.frontmostRoot)
+            Self.stampSubtree(ctx.frontmostRoot, token: ctx.token, depthCap: Self.maxDepth)
+            return AXNode.walk(
+                from: ctx.frontmostRoot,
+                transform: ctx.transform,
+                depthCap: Self.maxDepth,
+                deadline: ctx.deadline
+            )
+        }
     }
 
     /// Server-side hit-test path. Walks the same handshake as
@@ -150,69 +187,35 @@ final class AXPTranslatorAccessibility: Accessibility, @unchecked Sendable {
     /// `fetchTree` uses, so callers get identical value-type
     /// semantics either way.
     private func hitTestServerSide(point: Point) throws -> AXNode? {
-        guard Self.isAvailable else {
-            logErr("[ax] framework / dispatcher not available")
-            return nil
+        try withAXPContext { ctx in
+            let hostPoint = ctx.transform.unmap(CGPoint(x: point.x, y: point.y))
+
+            guard let hitTranslation = Self.objectAtPoint(
+                translator: ctx.translator,
+                point: hostPoint,
+                displayId: 0,
+                token: ctx.token
+            ) else {
+                // No element under that point. Distinct from "selector
+                // missing" — that case is gated by
+                // `supportsServerSideHitTest` upstream.
+                return nil
+            }
+            Self.stamp(token: ctx.token, on: hitTranslation)
+
+            guard let hitElement = Self.macPlatformElement(
+                translator: ctx.translator, translation: hitTranslation
+            ) else { return nil }
+            Self.stampElementTranslation(token: ctx.token, on: hitElement)
+            Self.stampSubtree(hitElement, token: ctx.token, depthCap: Self.maxDepth)
+
+            return AXNode.walk(
+                from: hitElement,
+                transform: ctx.transform,
+                depthCap: Self.maxDepth,
+                deadline: ctx.deadline
+            )
         }
-        guard let device = resolveDevice() else {
-            logErr("[ax] device not found: \(udid)")
-            return nil
-        }
-
-        let token = UUID().uuidString
-        let deadline = Date().addingTimeInterval(Self.xpcTimeoutSeconds)
-        Self.sharedDispatcher.register(device: device, token: token, deadline: deadline)
-        defer { Self.sharedDispatcher.unregister(token: token) }
-
-        guard let translator = Self.sharedTranslator else { return nil }
-
-        // We need the frontmost app's root frame to invert the
-        // caller's device-point coordinate back into the host
-        // coordinate space that AXP's `objectAtPoint` expects.
-        guard let frontmost = Self.frontmostApplication(
-            translator: translator, token: token
-        ) else {
-            log("[ax] no frontmost application for udid=\(udid)")
-            return nil
-        }
-        Self.stamp(token: token, on: frontmost)
-
-        guard let frontmostRoot = Self.macPlatformElement(
-            translator: translator, translation: frontmost
-        ) else {
-            log("[ax] no mac platform element from translation")
-            return nil
-        }
-        let pointSize = Self.devicePointSize(for: device)
-        let rootFrame = AXElementReader.frame(of: frontmostRoot)
-        let transform = AXFrameTransform(rootFrame: rootFrame, pointSize: pointSize)
-        let hostPoint = transform.unmap(CGPoint(x: point.x, y: point.y))
-
-        guard let hitTranslation = Self.objectAtPoint(
-            translator: translator,
-            point: hostPoint,
-            displayId: 0,
-            token: token
-        ) else {
-            // No element under that point. Distinct from "selector
-            // missing" — that case is gated by
-            // `supportsServerSideHitTest` upstream.
-            return nil
-        }
-        Self.stamp(token: token, on: hitTranslation)
-
-        guard let hitElement = Self.macPlatformElement(
-            translator: translator, translation: hitTranslation
-        ) else { return nil }
-        Self.stampElementTranslation(token: token, on: hitElement)
-        Self.stampSubtree(hitElement, token: token, depthCap: Self.maxDepth)
-
-        return AXNode.walk(
-            from: hitElement,
-            transform: transform,
-            depthCap: Self.maxDepth,
-            deadline: deadline
-        )
     }
 
     /// Stamp every reachable child translation with `token` so

--- a/Tests/BaguetteTests/Accessibility/AXFrameTransformTests.swift
+++ b/Tests/BaguetteTests/Accessibility/AXFrameTransformTests.swift
@@ -93,4 +93,61 @@ struct AXFrameTransformTests {
         let input = CGRect(x: 5, y: 6, width: 7, height: 8)
         #expect(t.map(input) == input)
     }
+
+    // MARK: - unmap: device-point → mac-host coordinate, the inverse
+    // path used by the AXP server-side hit-test.
+
+    @Test func `unmap is the inverse of map for the identity transform`() {
+        let t = AXFrameTransform(
+            rootFrame: CGRect(x: 0, y: 0, width: 393, height: 852),
+            pointSize: CGSize(width: 393, height: 852)
+        )
+        #expect(t.unmap(CGPoint(x: 100, y: 200)) == CGPoint(x: 100, y: 200))
+    }
+
+    @Test func `unmap reverses a 2:1 down-scale into an up-scale`() {
+        let t = AXFrameTransform(
+            rootFrame: CGRect(x: 0, y: 0, width: 786, height: 1704),
+            pointSize: CGSize(width: 393, height: 852)
+        )
+        // device (100, 200) corresponds to host (200, 400) — exactly
+        // reversing the `2:1 root → halves coordinates uniformly` map.
+        #expect(t.unmap(CGPoint(x: 100, y: 200)) == CGPoint(x: 200, y: 400))
+    }
+
+    @Test func `unmap reverses a non-zero root origin shift`() {
+        let t = AXFrameTransform(
+            rootFrame: CGRect(x: 50, y: 80, width: 393, height: 852),
+            pointSize: CGSize(width: 393, height: 852)
+        )
+        // device (10, 10) → host (60, 90), inverse of the existing
+        // map-side origin-shift test.
+        #expect(t.unmap(CGPoint(x: 10, y: 10)) == CGPoint(x: 60, y: 90))
+    }
+
+    @Test func `unmap reverses the letterbox y-offset`() {
+        // Same letterbox setup as the map test: pointSize 100x200,
+        // rootFrame 100x100 → +50 y centering offset.
+        let t = AXFrameTransform(
+            rootFrame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            pointSize: CGSize(width: 100, height: 200)
+        )
+        // device (10, 70) → host (10, 20), inverse of the map test
+        // mapping (10, 20) → (10, 70).
+        #expect(t.unmap(CGPoint(x: 10, y: 70)) == CGPoint(x: 10, y: 20))
+    }
+
+    @Test func `unmap falls back to identity on degenerate inputs`() {
+        let zeroRoot = AXFrameTransform(
+            rootFrame: CGRect(x: 0, y: 0, width: 0, height: 100),
+            pointSize: CGSize(width: 100, height: 100)
+        )
+        #expect(zeroRoot.unmap(CGPoint(x: 5, y: 6)) == CGPoint(x: 5, y: 6))
+
+        let zeroPoint = AXFrameTransform(
+            rootFrame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            pointSize: CGSize(width: 100, height: 0)
+        )
+        #expect(zeroPoint.unmap(CGPoint(x: 5, y: 6)) == CGPoint(x: 5, y: 6))
+    }
 }


### PR DESCRIPTION
Hi — follow-up to the issue I filed earlier today. Implementation, tests, and a CHANGELOG entry to match the project's existing style.

## What this does

`describeAt(point:)` had a comment explaining that AXP's 0-arg `objectAtPoint:` couldn't be used because `bridgeDelegateToken` would have to be seeded on the returned translation before the call — chicken/egg. That's true of the 0-arg form, but **`AXPTranslator` also exposes a 3-arg variant** — `objectAtPoint:displayId:bridgeDelegateToken:` — that accepts the token as a parameter. The dispatcher entry registered before the call resolves correctly on the very first XPC sub-request. This selector is what Meta's idb uses internally (`FBSimulatorAccessibilityCommands.m`'s `FBAXTranslationRequest_Point`), backing its `describe-point` CLI.

The practical payoff is reaching elements the static tree walk misses — most notably **SwiftUI tab-bar items inside an `AXGroup`** that `describeAll` reports as childless. This is the same workaround behind the patched `idb_companion` that downstream projects have been carrying (facebook/idb#767), now available natively to baguette consumers.

## Implementation

- **`AXPTranslatorAccessibility.hitTestServerSide(point:)`** — same dispatcher / token / frontmost-app handshake as `fetchTree`, then calls `objectAtPoint` and runs the returned translation through the existing `AXNode.walk` factory. Reuses `AXFrameTransform` for the coord transform.
- **`AXPTranslatorAccessibility.objectAtPoint(translator:point:displayId:token:)`** — runtime-dispatched selector helper, same pattern as the surrounding `frontmostApplication` / `macPlatformElement` helpers.
- **`AXPTranslatorAccessibility.supportsServerSideHitTest`** — static capability gate. Lets `describeAt(point:)` pick the server-side path or fall back to the legacy client-side walk without paying for both on a miss. Defensive only; the selector has been present on every AXP I've seen on Xcode 26+.
- **`AXFrameTransform.unmap(_:)`** — inverse of `map(_:)`. `objectAtPoint` takes host-window coordinates but baguette callers work in device points (same units as the gesture wire), so we need to invert at the call boundary. Five new unit tests mirror the existing `map` test layout (identity / scaled / origin-shifted / letterboxed / degenerate).

## Compatibility

`describeAt(point:)` is the only public surface that changes behavior, and only in the additive direction: it can now return elements that previously came back as the nearest enclosing container. The existing `describeAt returns nil when host has no matching device` test still passes. Worth highlighting that the change is observable — anything downstream that pattern-matched on "describeAt always returns a container with empty children for SwiftUI tab bars" will start seeing the inner button instead. That's the intended fix, but flagging in case it surprises any test fixtures on your side.

## Test plan

- [x] `swift test` — full suite (405 tests, was 400 + 5 new in `AXFrameTransformTests`)
- [x] `swift build` — clean compile on Swift 6.3 / Xcode 26
- [x] Manually exercised via downstream sim-bridge against Metatext on iOS 17.5, 18.6, 26.4 simulators — SwiftUI tab-bar buttons (Timelines / Explore / Notifications / Messages) resolve through `objectAtPoint` and route real taps. The legacy `describeAll`-based path missed them.

## CHANGELOG

Added an `Unreleased` entry under "Fixed" following the project's existing voice.

Thanks for the warm reception on the issue. Happy to iterate on naming, splitting the commit, or anything else that doesn't match the house style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility hit-testing at specific points by using an optimized server-side path when available, yielding more accurate element identification.

* **Tests**
  * Added comprehensive tests verifying coordinate transformation inversion across scaling, offsets, centering, and degenerate cases.

* **Documentation**
  * Updated changelog to document the accessibility hit-test fix and related changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tddworks/baguette/pull/18)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->