### PR TITLE
[docs] Add newlines between commands on homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -838,10 +838,11 @@
 <span class="cm">  ==> Installing baguette from tddworks/tap</span>
 <span class="cm">  ==> Pouring baguette--0.x.arm64_sequoia.bottle.tar.gz</span>
 <span class="ok">  🍺  /opt/homebrew/Cellar/baguette/0.x: 12 files, 4.2MB</span>
-
+<br>
 <span class="pr">$</span> baguette serve
 <span class="cm">  [baguette] listening on</span> <span class="hi">http://127.0.0.1:8421/simulators</span>
 
+<br>
 <span class="pr">$</span> open http://localhost:8421/farm<span class="blink"></span>
         </div>
       </div>


### PR DESCRIPTION
The current page does not have newlines between the commands:
<img width="659" height="328" alt="image" src="https://github.com/user-attachments/assets/ba1a4dbb-6a6d-42b4-85d6-a288188f2a73" />

This PR adds them!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quickstart terminal example with improved formatting and spacing for enhanced readability and clearer command output presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tddworks/baguette/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->