### PR TITLE
Remove tap instructions, move to Homebrew Core

### DIFF
--- a/docs/home2.html
+++ b/docs/home2.html
@@ -442,8 +442,8 @@
     <!-- ticker -->
     <div class="ticker" style="margin-left:-32px;margin-right:-32px;padding-left:32px;padding-right:32px">
       <div class="row">
-        <span><b>Swift 6.1</b><span class="dot"></span> Apple Silicon only<span class="dot"></span> Xcode 26<span class="dot"></span> 60 fps streams<span class="dot"></span> 9-arg HID recipe<span class="dot"></span> 110+ tests<span class="dot"></span> Apache 2.0<span class="dot"></span> brew install tddworks/tap/baguette</span>
-        <span><b>Swift 6.1</b><span class="dot"></span> Apple Silicon only<span class="dot"></span> Xcode 26<span class="dot"></span> 60 fps streams<span class="dot"></span> 9-arg HID recipe<span class="dot"></span> 110+ tests<span class="dot"></span> Apache 2.0<span class="dot"></span> brew install tddworks/tap/baguette</span>
+        <span><b>Swift 6.1</b><span class="dot"></span> Apple Silicon only<span class="dot"></span> Xcode 26<span class="dot"></span> 60 fps streams<span class="dot"></span> 9-arg HID recipe<span class="dot"></span> 110+ tests<span class="dot"></span> Apache 2.0<span class="dot"></span> brew install baguette</span>
+        <span><b>Swift 6.1</b><span class="dot"></span> Apple Silicon only<span class="dot"></span> Xcode 26<span class="dot"></span> 60 fps streams<span class="dot"></span> 9-arg HID recipe<span class="dot"></span> 110+ tests<span class="dot"></span> Apache 2.0<span class="dot"></span> brew install baguette</span>
       </div>
     </div>
   </section>
@@ -588,7 +588,7 @@
       <div class="step">
         <div class="n">i.</div>
         <div class="what">Install <small>Apple Silicon · Xcode 26</small></div>
-        <pre><span class="c">$</span> brew install tddworks/tap/baguette</pre>
+        <pre><span class="c">$</span> brew install baguette</pre>
       </div>
       <div class="step">
         <div class="n">ii.</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -835,7 +835,7 @@
         </div>
         <div class="body">
 <span class="pr">$</span> brew install baguette
-<span class="cm">  ==> Installing baguette from tddworks/tap</span>
+<span class="cm">  ==> Installing baguette from Homebrew</span>
 <span class="cm">  ==> Pouring baguette--0.x.arm64_sequoia.bottle.tar.gz</span>
 <span class="ok">  🍺  /opt/homebrew/Cellar/baguette/0.x: 12 files, 4.2MB</span>
 <br>

--- a/docs/index.html
+++ b/docs/index.html
@@ -651,8 +651,8 @@
           <a class="btn primary" href="https://github.com/tddworks/baguette">
             View on GitHub →
           </a>
-          <button class="btn copy" onclick="navigator.clipboard?.writeText('brew install tddworks/tap/baguette')">
-            <span class="pre">$</span> brew install tddworks/tap/baguette
+          <button class="btn copy" onclick="navigator.clipboard?.writeText('brew install baguette')">
+            <span class="pre">$</span> brew install baguette
           </button>
         </div>
       </div>
@@ -834,7 +834,7 @@
           <span class="ttl">~/projects · zsh</span>
         </div>
         <div class="body">
-<span class="pr">$</span> brew install tddworks/tap/baguette
+<span class="pr">$</span> brew install baguette
 <span class="cm">  ==> Installing baguette from tddworks/tap</span>
 <span class="cm">  ==> Pouring baguette--0.x.arm64_sequoia.bottle.tar.gz</span>
 <span class="ok">  🍺  /opt/homebrew/Cellar/baguette/0.x: 12 files, 4.2MB</span>
@@ -874,7 +874,7 @@
         </div>
         <div class="col">
           <h5>Install</h5>
-          <a>brew install tddworks/tap/baguette</a>
+          <a>brew install baguette</a>
           <a>Apple Silicon · Xcode 26</a>
           <a>Apache 2.0</a>
         </div>

--- a/skills/baguette/SKILL.md
+++ b/skills/baguette/SKILL.md
@@ -268,7 +268,7 @@ read `wire-protocol.md`; debugging which subcommand to use → read
 ## Install (only when missing)
 
 ```bash
-brew install tddworks/tap/baguette
+brew install baguette
 baguette --version
 ```
 


### PR DESCRIPTION
Baguette is now [available](https://github.com/Homebrew/homebrew-core/commit/b2ad49db42aab164efdad4282db08a07e11a9ac4) to install directly via [Homebrew](https://brew.sh).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified Homebrew install text across the site and Quickstart to use the standard package name, improving copy-to-clipboard and install guidance.
  * Added an explicit "Install (only when missing)" section in the skill guide and clarified to skip reinstallation if the tool already works; retained platform/requirements notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->