### PR TITLE
Add Claude Code plugin manifest for marketplace install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "baguette",
+  "description": "Baguette — headless iOS simulator control for Claude Code",
+  "owner": {
+    "name": "tddworks"
+  },
+  "plugins": [
+    {
+      "name": "baguette",
+      "source": "./",
+      "description": "Drive iOS simulators programmatically via the baguette CLI — taps, swipes, multi-finger gestures, hardware buttons, keyboard, and frame capture without opening Xcode.",
+      "version": "0.1.75",
+      "author": {
+        "name": "tddworks",
+        "url": "https://github.com/tddworks"
+      },
+      "homepage": "https://tddworks.github.io/baguette/",
+      "license": "Apache-2.0",
+      "category": "development",
+      "keywords": ["ios", "simulator", "automation", "testing", "agent"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "baguette",
+  "description": "Drive iOS simulators programmatically via the baguette CLI — taps, swipes, multi-finger gestures, hardware buttons, keyboard, and frame capture without opening Xcode.",
+  "version": "0.1.75",
+  "author": {
+    "name": "tddworks",
+    "url": "https://github.com/tddworks"
+  },
+  "homepage": "https://tddworks.github.io/baguette/",
+  "repository": "https://github.com/tddworks/baguette",
+  "license": "Apache-2.0",
+  "keywords": ["ios", "simulator", "automation", "testing", "agent", "baguette"]
+}


### PR DESCRIPTION
## What

Adds `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` so `baguette` can be installed as a **Claude Code plugin** straight from this repo:

```
/plugin marketplace add tddworks/baguette
/plugin install baguette@baguette
```

(or interactively: `/plugin` → Discover → search "baguette")

## Why

The repo already ships a ready-to-use Claude Code skill at `skills/baguette/SKILL.md`, but without the `.claude-plugin/` manifests the only way to install it is to hand-copy the folder into `~/.claude/skills/`. These manifests make it installable and updatable through the standard marketplace flow, so agents pairing with `baguette` get the skill (and its `references/`) with one command.

## Details

- **Metadata only** — no code, build, or CI changes. The Swift package (`Package.swift`, `Sources/`, `Tests/`) is untouched; the plugin loader is purely manifest-driven.
- The existing `skills/baguette` skill is auto-discovered (plugins load skills from `skills/*/SKILL.md`).
- The internal `.claude/skills/baguette-implement-feature` dev skill is **not** shipped — it lives under `.claude/`, outside the plugin's `skills/` directory.
- `version` is pinned to the current release (`0.1.75`). If you'd rather the plugin track every push automatically, drop the `version` field and Claude Code falls back to the git commit SHA — your call.

Refs: [Claude Code plugins](https://code.claude.com/docs/en/plugins.md) · [plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 0.1.75
  * Added marketplace configuration for the plugin

<!-- end of auto-generated comment: release notes by coderabbit.ai -->