### PR TITLE
feat(input): forward numeric keypad keys into the simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Added
+- **Numpad forwarding.** The browser keyboard capture now recognises the Mac's physical numeric keypad — `Numpad0`–`Numpad9`, `NumpadDecimal`, `NumpadAdd` / `NumpadSubtract` / `NumpadMultiply` / `NumpadDivide`, keypad `NumpadEnter`, and `NumpadEqual` — and forwards each keystroke into the focused simulator with its **own** HID keypad usage (page 7, `0x54`–`0x63` plus `0x67`), distinct from the top-row digits. No wire or CLI change: numpad keys ride the existing `key` envelope (`{ "type": "key", "code": "Numpad5" }`) down the same `IndigoHIDMessageForHIDArbitrary(target, page:7, usage, op)` path already used for letters and digits, so `baguette key --code Numpad5` works from the CLI too. `Numpad0` takes `0x62` (last in the keypad block, the same last-place quirk as the top-row `Digit0`). `NumLock`/Clear is deliberately left out — iOS has no num-lock concept, so forwarding it would be a device no-op that needlessly swallowed the host key. See [`docs/features/keyboard.md`](docs/features/keyboard.md).
+
 ---
 
 ## [0.1.77] - 2026-06-24

--- a/Sources/Baguette/Domain/Input/Keyboard.swift
+++ b/Sources/Baguette/Domain/Input/Keyboard.swift
@@ -85,9 +85,10 @@ struct KeyboardKey: Equatable, Hashable, Sendable {
         m["Digit0"] = 0x27
         // Numpad / keypad block (HID page 7, keypad section). Same
         // last-place quirk as the top row: Numpad1..Numpad9 = 0x59..0x61,
-        // Numpad0 = 0x62, then decimal = 0x63. Operators / Enter / Equal
-        // sit just above the digits. NumLock is deliberately omitted —
-        // iOS has no num-lock concept, so it would be a device no-op.
+        // Numpad0 = 0x62, then decimal = 0x63. Divide..Enter (0x54..0x58)
+        // sit just below the digit block; Equal (0x67) sits above the
+        // digits / decimal. NumLock is deliberately omitted — iOS has
+        // no num-lock concept, so it would be a device no-op.
         for i in 1...9 {
             m["Numpad\(i)"] = UInt32(0x59 + i - 1)
         }

--- a/Sources/Baguette/Domain/Input/Keyboard.swift
+++ b/Sources/Baguette/Domain/Input/Keyboard.swift
@@ -83,6 +83,22 @@ struct KeyboardKey: Equatable, Hashable, Sendable {
             m["Digit\(i)"] = UInt32(0x1E + i - 1)
         }
         m["Digit0"] = 0x27
+        // Numpad / keypad block (HID page 7, keypad section). Same
+        // last-place quirk as the top row: Numpad1..Numpad9 = 0x59..0x61,
+        // Numpad0 = 0x62, then decimal = 0x63. Operators / Enter / Equal
+        // sit just above the digits. NumLock is deliberately omitted —
+        // iOS has no num-lock concept, so it would be a device no-op.
+        for i in 1...9 {
+            m["Numpad\(i)"] = UInt32(0x59 + i - 1)
+        }
+        m["Numpad0"]        = 0x62
+        m["NumpadDecimal"]  = 0x63
+        m["NumpadDivide"]   = 0x54
+        m["NumpadMultiply"] = 0x55
+        m["NumpadSubtract"] = 0x56
+        m["NumpadAdd"]      = 0x57
+        m["NumpadEnter"]    = 0x58
+        m["NumpadEqual"]    = 0x67
         return m
     }()
 

--- a/Sources/Baguette/Resources/Web/baguette/parts/keyboard.js
+++ b/Sources/Baguette/Resources/Web/baguette/parts/keyboard.js
@@ -23,6 +23,10 @@
     'KeyU','KeyV','KeyW','KeyX','KeyY','KeyZ',
     // Digits
     'Digit0','Digit1','Digit2','Digit3','Digit4','Digit5','Digit6','Digit7','Digit8','Digit9',
+    // Numpad (physical numeric keypad — distinct HID keypad usages;
+    // NumLock is omitted, iOS has no num-lock concept)
+    'Numpad0','Numpad1','Numpad2','Numpad3','Numpad4','Numpad5','Numpad6','Numpad7','Numpad8','Numpad9',
+    'NumpadDecimal','NumpadDivide','NumpadMultiply','NumpadSubtract','NumpadAdd','NumpadEnter','NumpadEqual',
     // Named specials
     'Enter','Escape','Backspace','Tab','Space',
     'ArrowUp','ArrowDown','ArrowLeft','ArrowRight',

--- a/Tests/BaguetteTests/Input/KeyboardTests.swift
+++ b/Tests/BaguetteTests/Input/KeyboardTests.swift
@@ -19,6 +19,25 @@ struct KeyboardKeyTests {
         #expect(KeyboardKey.from(wireCode: "Digit0")?.hidUsage == HIDUsage(page: 7, usage: 0x27))
     }
 
+    @Test func `parses numpad wire codes onto HID keypad usages`() {
+        // Keypad block on HID page 7: 1-9 = 0x59..0x61, 0 = 0x62 (last,
+        // like the top-row digit quirk), decimal = 0x63; the operators,
+        // Enter and Equal sit just below the digits. NumLock is out of
+        // scope — iOS has no num-lock concept.
+        let pairs: [(String, UInt32)] = [
+            ("Numpad1", 0x59), ("Numpad2", 0x5A), ("Numpad3", 0x5B),
+            ("Numpad4", 0x5C), ("Numpad5", 0x5D), ("Numpad6", 0x5E),
+            ("Numpad7", 0x5F), ("Numpad8", 0x60), ("Numpad9", 0x61),
+            ("Numpad0", 0x62), ("NumpadDecimal", 0x63),
+            ("NumpadDivide", 0x54), ("NumpadMultiply", 0x55),
+            ("NumpadSubtract", 0x56), ("NumpadAdd", 0x57),
+            ("NumpadEnter", 0x58), ("NumpadEqual", 0x67),
+        ]
+        for (code, expected) in pairs {
+            #expect(KeyboardKey.from(wireCode: code)?.hidUsage == HIDUsage(page: 7, usage: expected))
+        }
+    }
+
     @Test func `parses named special keys`() {
         let pairs: [(String, UInt32)] = [
             ("Enter", 0x28), ("Escape", 0x29), ("Backspace", 0x2A),

--- a/Tests/BaguetteTests/Input/KeyboardTests.swift
+++ b/Tests/BaguetteTests/Input/KeyboardTests.swift
@@ -21,9 +21,10 @@ struct KeyboardKeyTests {
 
     @Test func `parses numpad wire codes onto HID keypad usages`() {
         // Keypad block on HID page 7: 1-9 = 0x59..0x61, 0 = 0x62 (last,
-        // like the top-row digit quirk), decimal = 0x63; the operators,
-        // Enter and Equal sit just below the digits. NumLock is out of
-        // scope — iOS has no num-lock concept.
+        // like the top-row digit quirk), decimal = 0x63; the operators
+        // and Enter (0x54..0x58) sit just below the digits, Equal (0x67)
+        // above the decimal. NumLock is out of scope — iOS has no
+        // num-lock concept.
         let pairs: [(String, UInt32)] = [
             ("Numpad1", 0x59), ("Numpad2", 0x5A), ("Numpad3", 0x5B),
             ("Numpad4", 0x5C), ("Numpad5", 0x5D), ("Numpad6", 0x5E),

--- a/docs/features/keyboard.md
+++ b/docs/features/keyboard.md
@@ -24,6 +24,7 @@ looking for the side buttons (volume / power / action), that's
 |---------------------|-----------------------------------------------|
 | Letters             | `KeyA` … `KeyZ`                                |
 | Digits              | `Digit0` … `Digit9`                            |
+| Numpad              | `Numpad0` … `Numpad9`, `NumpadDecimal`, `NumpadAdd`, `NumpadSubtract`, `NumpadMultiply`, `NumpadDivide`, `NumpadEnter`, `NumpadEqual` |
 | Named specials      | `Enter`, `Escape`, `Backspace`, `Tab`, `Space` |
 | Arrows              | `ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight` |
 | Punctuation (US)    | `Minus`, `Equal`, `BracketLeft`, `BracketRight`, `Backslash`, `Semicolon`, `Quote`, `Backquote`, `Comma`, `Period`, `Slash` |
@@ -101,6 +102,13 @@ hardcoded in `KeyboardKey.from(wireCode:)` and
 
 - Letters: `KeyA` … `KeyZ` → `0x04` … `0x1D`
 - Digits: HID quirk — `Digit1` … `Digit9` = `0x1E` … `0x26`, `Digit0` = `0x27` (last)
+- Keypad: same last-place quirk — `Numpad1` … `Numpad9` = `0x59` … `0x61`,
+  `Numpad0` = `0x62`, `NumpadDecimal` = `0x63`; `NumpadDivide` = `0x54`,
+  `NumpadMultiply` = `0x55`, `NumpadSubtract` = `0x56`, `NumpadAdd` = `0x57`,
+  `NumpadEnter` = `0x58`, `NumpadEqual` = `0x67`. These are the keypad
+  section of page 7 — distinct usages from the top-row digits, so iOS
+  can tell a numpad `5` from a main-row `5`. `NumLock` is omitted (iOS
+  has no num-lock concept).
 - Specials: `Enter` = `0x28`, `Escape` = `0x29`, `Backspace` = `0x2A`,
   `Tab` = `0x2B`, `Space` = `0x2C`
 - Arrows: `ArrowRight` = `0x4F`, `ArrowLeft` = `0x50`,


### PR DESCRIPTION
## What

Adds physical-numpad support to the web UI's keyboard forwarding. When the device screen has focus, keystrokes from the Mac's numeric keypad — `Numpad0`–`Numpad9`, `NumpadDecimal`, `NumpadAdd` / `NumpadSubtract` / `NumpadMultiply` / `NumpadDivide`, `NumpadEnter`, `NumpadEqual` — now forward into the focused simulator with their own HID page-7 keypad usages, distinct from the top-row digits.

## Why

The keyboard capture whitelisted only the top-row `Digit*` codes, so pressing keys on an external numeric keypad fell through to the host browser instead of landing on the device.

## How

- **`KeyboardKey.wireCodeMap`** (Domain) gains the keypad block: usages `0x54`–`0x63` plus `0x67`. `Numpad0` = `0x62` (last in the block, mirroring the top-row `Digit0` quirk).
- **`parts/keyboard.js`** mirrors the codes into the `FORWARDED` set — the single frontend whitelist, shared by focus mode and the farm tiles.
- **No wire or CLI change.** Numpad keys ride the existing `key` envelope (`{"type":"key","code":"Numpad5"}`) down the same `IndigoHIDMessageForHIDArbitrary(target, page:7, usage, op)` path already used for letters and digits, and `baguette key --code Numpad5` works too since `KeyCommand` already routes through `KeyboardKey.from(wireCode:)`.
- **`NumLock`/Clear is deliberately omitted** — iOS has no num-lock concept, so forwarding it would be a device no-op that needlessly swallowed the host key.

## Testing

- **TDD:** failing `KeyboardKey` test first (all 17 codes resolved to `nil`), green after the map edit.
- **Full suite:** 592 tests pass.
- **End-to-end** on a booted iPhone 17 Pro sim: `baguette key --code Numpad5` dispatches as `page=7 usage=93` (`0x5D`) with `{"ok":true}`, and a bogus code is rejected; typing Numpad `1 2 3 . 4 5` into Spotlight rendered `123.45`.

See [`docs/features/keyboard.md`](docs/features/keyboard.md) and the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for physical numpad keys (digits, keypad arithmetic, Decimal, Enter, and Equal), forwarded as distinct keypad usages.
* **Documentation**
  * Updated keyboard documentation and the changelog to list the supported numpad keys and clarify that NumLock/Clear are not forwarded.
* **Tests**
  * Added tests to verify numpad wire-code mappings resolve to the expected HID keypad usages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->