### PR TITLE
fix: actionable Homebrew error when brew runs under Rosetta on Apple Silicon

### DIFF
--- a/.github/homebrew/baguette.rb.template
+++ b/.github/homebrew/baguette.rb.template
@@ -4,7 +4,7 @@
 class ArmBrewRequirement < Requirement
   fatal true
 
-  satisfy { Hardware::CPU.arm? }
+  satisfy(build_env: false) { Hardware::CPU.arm? }
 
   def message
     if Hardware::CPU.in_rosetta2?

--- a/.github/homebrew/baguette.rb.template
+++ b/.github/homebrew/baguette.rb.template
@@ -1,19 +1,47 @@
 # typed: false
 # frozen_string_literal: true
 
+class ArmBrewRequirement < Requirement
+  fatal true
+
+  satisfy { Hardware::CPU.arm? }
+
+  def message
+    if Hardware::CPU.in_rosetta2?
+      <<~EOS
+        baguette requires Apple Silicon Homebrew running natively as arm64.
+
+        Your brew process is running under Rosetta 2, usually from Intel
+        Homebrew in /usr/local. Intel Homebrew cannot install baguette.
+
+        Install with native Homebrew instead:
+
+          /opt/homebrew/bin/brew install baguette
+
+        If /opt/homebrew/bin/brew does not exist, install native Homebrew
+        from https://brew.sh, then run the command above.
+      EOS
+    else
+      "baguette supports Apple Silicon Macs only."
+    end
+  end
+
+  def display_s
+    "Apple Silicon Homebrew"
+  end
+end
+
 class Baguette < Formula
   desc "Headless iOS Simulator manager + host-side input injection for iOS 26"
   homepage "https://github.com/tddworks/baguette"
   version "__VERSION__"
   license "Apache-2.0"
 
-  on_arm do
-    url "https://github.com/tddworks/baguette/releases/download/__VERSION__/baguette___VERSION___macOS_arm64.tar.gz"
-    sha256 "__SHA256_ARM64__"
-  end
+  url "https://github.com/tddworks/baguette/releases/download/__VERSION__/baguette___VERSION___macOS_arm64.tar.gz"
+  sha256 "__SHA256_ARM64__"
 
   depends_on :macos
-  depends_on arch: :arm64
+  depends_on ArmBrewRequirement
   depends_on xcode: ["26.0", :build]
 
   def install

--- a/README.md
+++ b/README.md
@@ -110,7 +110,17 @@ SimulatorKit / CoreSimulator frameworks shipped with Xcode.
 If `brew install baguette` reports this on an Apple Silicon Mac:
 
 ```text
-baguette: The arm64 architecture is required for this software. Error: An unsatisfied requirement failed this build.
+baguette requires Apple Silicon Homebrew running natively as arm64.
+
+Your brew process is running under Rosetta 2, usually from Intel
+Homebrew in /usr/local. Intel Homebrew cannot install baguette.
+
+Install with native Homebrew instead:
+
+  /opt/homebrew/bin/brew install baguette
+
+If /opt/homebrew/bin/brew does not exist, install native Homebrew
+from https://brew.sh, then run the command above.
 ```
 
 Your `brew` is likely Intel Homebrew running under Rosetta 2 from

--- a/README.md
+++ b/README.md
@@ -105,6 +105,24 @@ brew install baguette
 Apple Silicon only. Requires Xcode 26 — `baguette` links against private
 SimulatorKit / CoreSimulator frameworks shipped with Xcode.
 
+### Troubleshooting
+
+If `brew install baguette` reports this on an Apple Silicon Mac:
+
+```text
+baguette: The arm64 architecture is required for this software. Error: An unsatisfied requirement failed this build.
+```
+
+Your `brew` is likely Intel Homebrew running under Rosetta 2 from
+`/usr/local`. Install with native Homebrew instead:
+
+```bash
+/opt/homebrew/bin/brew install baguette
+```
+
+If that path does not exist, install native Apple Silicon Homebrew from
+https://brew.sh first, then run the command above.
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
## Summary

Installing baguette from Intel Homebrew (or any brew running under Rosetta 2 on Apple Silicon) fails with an opaque bottle error, because the formula only ships arm64 binaries. The formula template now declares an `ArmBrewRequirement` that fails fast with an actionable message: it detects the Rosetta case, explains that Intel Homebrew in /usr/local cannot install baguette, and prints the exact `/opt/homebrew/bin/brew install baguette` command to run instead. README gains a short troubleshooting note for the same situation.

## Why this matters

The reporter in #23 hit this on an M-series Mac where the default `brew` on PATH was the Intel one under Rosetta, and the failure gave no hint about the cause. Setups migrated from Intel Macs commonly carry Intel Homebrew on PATH, so this failure mode recurs; the requirement turns a confusing bottle error into a one-line fix.

## Testing

Rendered the template with placeholder substitutions and checked the generated formula with `ruby -c` (syntax OK). The requirement uses only stock Homebrew APIs (`Requirement`, `Hardware::CPU.arm?`, `Hardware::CPU.in_rosetta2?`).

Fixes #23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Troubleshooting section for Apple Silicon Homebrew failures when using Intel Homebrew under Rosetta.
  * Improved installation guidance with the native Homebrew install command for Apple Silicon.

* **Bug Fixes**
  * Enhanced platform compatibility checks so installs fail fast with clear, actionable messaging on unsupported Intel/Rosetta Homebrew setups.
  * Updated the package’s download selection and requirements to better match Apple Silicon-only Homebrew behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->