### PR TITLE
feat(serve): add --allowed-hosts for reverse-proxy deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Added
+- **`serve --allowed-hosts` for reverse-proxy deployments.** The browser-security check only trusts loopback `Host` / `Origin` values, so requests reaching `baguette serve` through a reverse proxy got `403 forbidden origin` on every control route and stream WebSocket. `--allowed-hosts sim.example.com` (repeatable; `*.example.com` matches subdomains) trusts additional hostnames, ignoring ports since the public port belongs to the proxy. An allowed host is trusted both as a request `Host` and as a browser `Origin`, and allowed Origins get CORS headers and preflight responses so a web app on one trusted host can call the API on another. All other cross-site `Origin`s are still rejected and behaviour without the flag is unchanged.
+
 ---
 
 ## [0.1.78] - 2026-07-09

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ baguette <command> [options]
   # Web UI — single-device dashboard + multi-device farm + Camera card +
   # Accessibility inspector + Logs panel + in-browser recording.
   serve [--port 8421] [--host 127.0.0.1] [--device-set <path>]
+        [--allowed-hosts <host>]
 
   # DeviceKit chrome / bezel data
   chrome layout    --udid <UDID> | --device-name "iPhone 17 Pro"
@@ -243,6 +244,21 @@ The HTML is editable on disk — `Sources/Baguette/Resources/Web/sim.html`
 opens directly in any browser via `file://` (preview mode), and points
 to its sibling `.js` files. Set `BAGUETTE_WEB_DIR` to override the
 served root for live-iteration without rebuilding.
+
+By default the server only trusts loopback `Host` / `Origin` values, so
+requests arriving through a reverse proxy get `403 forbidden origin`.
+Pass the proxy's public hostname to trust it:
+
+```bash
+baguette serve --allowed-hosts sim.example.com    # exact host
+baguette serve --allowed-hosts '*.example.com'    # any subdomain
+```
+
+The flag is repeatable and ports are ignored. An allowed host is
+trusted both as a request `Host` and as a browser `Origin`, and allowed
+Origins get CORS headers and preflight responses so a web app on one trusted host
+can call the API on another. All other cross-site `Origin`s are still
+rejected.
 
 ### Routes (single resource tree, no `/api/` prefix)
 

--- a/Sources/Baguette/App/Commands/ServeCommand.swift
+++ b/Sources/Baguette/App/Commands/ServeCommand.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-/// `baguette serve [--port 8421] [--host 127.0.0.1] [--device-set …]`
+/// `baguette serve [--port 8421] [--host 127.0.0.1] [--device-set …] [--allowed-hosts …]`
 ///
 /// Boots the standalone simulator UI. Open `http://<host>:<port>/`
 /// in a browser and the simulator picker loads — no SPA dependency,
@@ -21,6 +21,9 @@ struct ServeCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Custom CoreSimulator device-set path")
     var deviceSet: String?
 
+    @Option(name: .long, help: "Additional Host/Origin value to trust (repeatable; \"*.example.com\" matches subdomains)")
+    var allowedHosts: [String] = []
+
     func run() async throws {
         let server = Server(
             simulators: CoreSimulators(deviceSetPath: deviceSet),
@@ -29,7 +32,8 @@ struct ServeCommand: AsyncParsableCommand {
                 rasterizer: CoreGraphicsPDFRasterizer()
             ),
             host: host,
-            port: port
+            port: port,
+            allowedHosts: allowedHosts
         )
         try await server.run()
     }

--- a/Sources/Baguette/Infrastructure/Server/Server.swift
+++ b/Sources/Baguette/Infrastructure/Server/Server.swift
@@ -37,17 +37,20 @@ struct Server: Sendable {
     let chromes: any Chromes
     let host: String
     let port: Int
+    let allowedHosts: Set<String>
 
     init(
         simulators: any Simulators,
         chromes: any Chromes,
         host: String = "127.0.0.1",
-        port: Int = 8421
+        port: Int = 8421,
+        allowedHosts: [String] = []
     ) {
         self.simulators = simulators
         self.chromes = chromes
         self.host = host
         self.port = port
+        self.allowedHosts = Set(allowedHosts.map { $0.lowercased() })
     }
 
     func run() async throws {
@@ -74,16 +77,20 @@ struct Server: Sendable {
     private func registerRoutes(on router: Router<BasicWebSocketRequestContext>) {
         let bindHost = self.host
         let bindPort = self.port
+        let allowedHosts = self.allowedHosts
+        if !allowedHosts.isEmpty {
+            router.add(middleware: AllowedHostsCORSMiddleware(allowedHosts: allowedHosts))
+        }
         let rejectUntrustedBrowser: @Sendable (Request) -> Response? = { request in
             Self.rejectUntrustedBrowserRequest(
-                request, bindHost: bindHost, bindPort: bindPort
+                request, bindHost: bindHost, bindPort: bindPort, allowedHosts: allowedHosts
             )
         }
         let trustedWebSocketUpgrade:
             @Sendable (Request, BasicWebSocketRequestContext) async throws -> RouterShouldUpgrade = {
                 request, _ in
                 Self.isTrustedBrowserRequest(
-                    request, bindHost: bindHost, bindPort: bindPort
+                    request, bindHost: bindHost, bindPort: bindPort, allowedHosts: allowedHosts
                 ) ? .upgrade([:]) : .dontUpgrade
             }
 
@@ -1128,11 +1135,12 @@ struct Server: Sendable {
         let simulators = self.simulators
         let bindHost = self.host
         let bindPort = self.port
+        let allowedHosts = self.allowedHosts
         let trustedWebSocketUpgrade:
             @Sendable (Request, BasicWebSocketRequestContext) async throws -> RouterShouldUpgrade = {
                 request, _ in
                 Self.isTrustedBrowserRequest(
-                    request, bindHost: bindHost, bindPort: bindPort
+                    request, bindHost: bindHost, bindPort: bindPort, allowedHosts: allowedHosts
                 ) ? .upgrade([:]) : .dontUpgrade
             }
         router.ws(
@@ -1297,11 +1305,12 @@ struct Server: Sendable {
         let simulators = self.simulators
         let bindHost = self.host
         let bindPort = self.port
+        let allowedHosts = self.allowedHosts
         let trustedWebSocketUpgrade:
             @Sendable (Request, BasicWebSocketRequestContext) async throws -> RouterShouldUpgrade = {
                 request, _ in
                 Self.isTrustedBrowserRequest(
-                    request, bindHost: bindHost, bindPort: bindPort
+                    request, bindHost: bindHost, bindPort: bindPort, allowedHosts: allowedHosts
                 ) ? .upgrade([:]) : .dontUpgrade
             }
         router.ws(
@@ -1528,9 +1537,12 @@ struct Server: Sendable {
     private static func rejectUntrustedBrowserRequest(
         _ request: Request,
         bindHost: String,
-        bindPort: Int
+        bindPort: Int,
+        allowedHosts: Set<String> = []
     ) -> Response? {
-        guard !isTrustedBrowserRequest(request, bindHost: bindHost, bindPort: bindPort) else {
+        guard !isTrustedBrowserRequest(
+            request, bindHost: bindHost, bindPort: bindPort, allowedHosts: allowedHosts
+        ) else {
             return nil
         }
         return errorJSON("forbidden origin", status: .forbidden)
@@ -1539,16 +1551,30 @@ struct Server: Sendable {
     /// Browsers can drive localhost services from another site unless the
     /// service checks `Origin`. For a loopback bind, also reject DNS-rebind
     /// style `Host` values that are not loopback names.
+    ///
+    /// Hosts in `allowedHosts` (exact or `*.suffix`) are trusted as
+    /// request Hosts and as browser Origins regardless of port, for
+    /// serving behind a reverse proxy.
     static func isTrustedBrowserRequest(
         _ request: Request,
         bindHost: String,
-        bindPort: Int
+        bindPort: Int,
+        allowedHosts: Set<String> = []
     ) -> Bool {
         if isLoopbackBind(bindHost),
            let authority = request.head.authority,
            let requestHost = parseAuthority(authority)?.host,
-           !isLoopbackHost(requestHost) {
+           !isLoopbackHost(requestHost),
+           !isAllowedHost(requestHost, allowedHosts) {
             return false
+        }
+
+        // An operator-trusted Origin is accepted outright, including from
+        // another site (a web app driving the API cross-origin).
+        if let origin = request.headers[.origin],
+           let originHost = URLComponents(string: origin)?.host,
+           isAllowedHost(originHost, allowedHosts) {
+            return true
         }
 
         if let fetchSite = request.headers[.secFetchSite]?.lowercased(),
@@ -1564,6 +1590,7 @@ struct Server: Sendable {
 
         let authority = request.head.authority ?? "\(bindHost):\(bindPort)"
         guard let requestAuthority = parseAuthority(authority) else { return false }
+
         let requestPort = requestAuthority.port ?? bindPort
         let originPort = originURL.port ?? defaultPort(for: originURL.scheme)
 
@@ -1575,6 +1602,66 @@ struct Server: Sendable {
 
         return originHost.caseInsensitiveCompare(requestAuthority.host) == .orderedSame
             && (originPort ?? requestPort) == requestPort
+    }
+
+    /// The Origin to reflect in CORS headers, or nil when it isn't an
+    /// allowed host. Lets a trusted cross-origin web app read API
+    /// responses with credentialed fetches.
+    static func corsAllowedOrigin(_ origin: String?, allowedHosts: Set<String>) -> String? {
+        guard let origin,
+              let host = URLComponents(string: origin)?.host,
+              isAllowedHost(host, allowedHosts) else { return nil }
+        return origin
+    }
+
+    /// The response for a CORS preflight from an allowed-host Origin,
+    /// or nil when the request is not such a preflight.
+    static func corsPreflightResponse(_ request: Request, allowedHosts: Set<String>) -> Response? {
+        guard request.method == .options,
+              let origin = corsAllowedOrigin(request.headers[.origin], allowedHosts: allowedHosts),
+              let method = request.headers[.accessControlRequestMethod] else { return nil }
+        var headers: HTTPFields = [
+            .accessControlAllowOrigin: origin,
+            .accessControlAllowCredentials: "true",
+            .accessControlAllowMethods: method,
+            .vary: "Origin",
+        ]
+        if let requested = request.headers[.accessControlRequestHeaders] {
+            headers[.accessControlAllowHeaders] = requested
+        }
+        return Response(status: .noContent, headers: headers)
+    }
+
+    private static func isAllowedHost(_ host: String, _ allowedHosts: Set<String>) -> Bool {
+        let lower = host.lowercased()
+        if allowedHosts.contains(lower) { return true }
+        return allowedHosts.contains {
+            $0.hasPrefix("*.") && lower.hasSuffix($0.dropFirst())
+        }
+    }
+
+    /// Reflects allowed-host Origins in CORS response headers, and answers
+    /// their preflights, so a trusted web app on another origin can call
+    /// the API with credentialed fetches.
+    struct AllowedHostsCORSMiddleware<Context: RequestContext>: RouterMiddleware {
+        let allowedHosts: Set<String>
+
+        func handle(
+            _ request: Request,
+            context: Context,
+            next: (Request, Context) async throws -> Response
+        ) async throws -> Response {
+            if let preflight = Server.corsPreflightResponse(request, allowedHosts: allowedHosts) {
+                return preflight
+            }
+            var response = try await next(request, context)
+            if let origin = Server.corsAllowedOrigin(request.headers[.origin], allowedHosts: allowedHosts) {
+                response.headers[.accessControlAllowOrigin] = origin
+                response.headers[.accessControlAllowCredentials] = "true"
+                response.headers[.vary] = "Origin"
+            }
+            return response
+        }
     }
 
     private static func parseAuthority(_ raw: String) -> (host: String, port: Int?)? {

--- a/Tests/BaguetteTests/Server/ServerSecurityTests.swift
+++ b/Tests/BaguetteTests/Server/ServerSecurityTests.swift
@@ -60,6 +60,137 @@ struct ServerSecurityTests {
         ))
     }
 
+    @Test func `allows proxied requests whose Host names an allowed host`() {
+        let request = Self.request(host: "sim.example.test")
+
+        #expect(Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421,
+            allowedHosts: ["sim.example.test"]
+        ))
+    }
+
+    @Test func `allows browser origins on an allowed host regardless of port`() {
+        let request = Self.request(
+            host: "sim.example.test",
+            origin: "https://sim.example.test"
+        )
+
+        #expect(Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421,
+            allowedHosts: ["sim.example.test"]
+        ))
+    }
+
+    @Test func `matches wildcard allowed hosts against subdomains`() {
+        let request = Self.request(
+            host: "device-1.sim.example.test",
+            origin: "https://device-1.sim.example.test"
+        )
+
+        #expect(Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421,
+            allowedHosts: ["*.example.test"]
+        ))
+    }
+
+    @Test func `still rejects hosts outside the allowed list`() {
+        let request = Self.request(
+            host: "attacker.test:8421",
+            origin: "http://attacker.test:8421"
+        )
+
+        #expect(!Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421,
+            allowedHosts: ["sim.example.test"]
+        ))
+    }
+
+    @Test func `rejects allowed-host requests with a foreign Origin`() {
+        let request = Self.request(
+            host: "sim.example.test",
+            origin: "https://attacker.test"
+        )
+
+        #expect(!Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421,
+            allowedHosts: ["sim.example.test"]
+        ))
+    }
+
+    @Test func `trusts allowed-host origins on another host`() {
+        let request = Self.request(
+            host: "sim.example.test",
+            origin: "https://app.example.test"
+        )
+
+        #expect(Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421,
+            allowedHosts: ["sim.example.test", "app.example.test"]
+        ))
+    }
+
+    @Test func `trusts allowed-host origins when the proxy rewrites Host to loopback`() {
+        let request = Self.request(
+            host: "localhost:8421",
+            origin: "https://sim.example.test"
+        )
+
+        #expect(Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421,
+            allowedHosts: ["sim.example.test"]
+        ))
+    }
+
+    @Test func `trusts allowed-host origins even when Fetch Metadata says cross-site`() {
+        let request = Self.request(
+            host: "sim.example.test",
+            origin: "https://app.example.test",
+            fetchSite: "cross-site"
+        )
+
+        #expect(Server.isTrustedBrowserRequest(
+            request, bindHost: "127.0.0.1", bindPort: 8421,
+            allowedHosts: ["sim.example.test", "app.example.test"]
+        ))
+    }
+
+    @Test func `reflects allowed origins for CORS`() {
+        #expect(Server.corsAllowedOrigin(
+            "https://app.example.test",
+            allowedHosts: ["app.example.test"]
+        ) == "https://app.example.test")
+
+        #expect(Server.corsAllowedOrigin(
+            "https://attacker.test",
+            allowedHosts: ["app.example.test"]
+        ) == nil)
+
+        #expect(Server.corsAllowedOrigin(nil, allowedHosts: ["app.example.test"]) == nil)
+    }
+
+    @Test func `answers CORS preflights for allowed origins`() {
+        let head = HTTPRequest(
+            method: .options,
+            scheme: nil,
+            authority: "sim.example.test",
+            path: "/simulators/UDID/boot",
+            headerFields: [
+                .origin: "https://app.example.test",
+                .accessControlRequestMethod: "POST",
+                .accessControlRequestHeaders: "content-type",
+            ]
+        )
+        let request = Request(head: head, body: .init(buffer: ByteBuffer()))
+
+        let response = Server.corsPreflightResponse(request, allowedHosts: ["app.example.test"])
+        #expect(response?.status == .noContent)
+        #expect(response?.headers[.accessControlAllowOrigin] == "https://app.example.test")
+        #expect(response?.headers[.accessControlAllowMethods] == "POST")
+        #expect(response?.headers[.accessControlAllowHeaders] == "content-type")
+
+        #expect(Server.corsPreflightResponse(request, allowedHosts: ["other.test"]) == nil)
+    }
+
     @Test func `static asset responses deny foreign framing`() {
         let csp = HTTPField.Name("Content-Security-Policy")!
 


### PR DESCRIPTION
`baguette serve` rejects any request whose `Host`/`Origin` is not loopback, so running it behind a reverse proxy (remote dev workstation, tunnelled dashboard) returns `403 forbidden origin` on every control route and stream WebSocket, with no way to opt out.

This adds a repeatable `--allowed-hosts` option that trusts additional hostnames in the browser-security check:

- An allowed host passes the DNS-rebind `Host` guard on loopback binds.
- An `Origin` naming an allowed host is trusted outright, including cross-origin, so a web app on one trusted host can drive the API on another. Allowed Origins get CORS headers (`Access-Control-Allow-Origin` + credentials) and preflight responses so those calls work.
- `*.example.com` matches subdomains; ports are ignored, since the public port belongs to the proxy.
- All other cross-site `Origin`s and `Sec-Fetch-Site: cross-site` are still rejected; behaviour without the flag is unchanged.

Covered by new cases in `ServerSecurityTests`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repeatable `--allowed-hosts` option to `baguette serve` for reverse-proxy deployments, supporting `*.example.com` wildcard subdomains.
  * When configured, trusted `Host`/browser `Origin` checks (ports ignored) apply to regular requests and WebSocket streams, and allowed origins are reflected in CORS.
* **Documentation**
  * Updated the changelog and README/CLI help with the new option and default loopback-only trust behavior.
* **Bug Fixes**
  * Fewer `403 forbidden origin` responses for properly proxied requests from approved hostnames.
* **Tests**
  * Expanded security and CORS/origin test coverage for allowed hosts, wildcards, and preflight behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->