### PR TITLE
perf(stream): low-latency H.264 so the AVCC sim tab stops lagging input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Changed
+- **Lower-latency H.264 (AVCC) streaming.** The single-sim tab (`/simulators/:udid`) defaults to H.264/AVCC while the device-farm grid uses MJPEG, and the AVCC path's felt "input latency" was dominated by frames sitting in the browser's WebCodecs `VideoDecoder` queue — the same decoder-hold the `AVCCStream` idle-pump already exists to work around. The `VTCompressionSession` now runs VideoToolbox's low-latency rate-control path (`kVTVideoEncoderSpecification_EnableLowLatencyRateControl`) with `MaxFrameDelayCount = 0`, which shrinks the encode pipeline and signals a minimal decoded-picture buffer so the decoder emits each frame immediately instead of buffering — noticeably tighter interaction with no change to bitrate, fps, or scale. The encoder's tuning knobs are lifted into a pure, unit-tested `H264Tuning` value (`.lowLatency` preset) so the "what config do we want" decision is covered apart from the irreducible VideoToolbox calls that apply it. The AVCC decoder also gained a **non-blocking diagnostic**: on configure it logs whether the negotiated profile/level decodes in hardware (`mediaCapabilities.decodingInfo().powerEfficient`), so a silent software-decode fallback — brutal at full-res 60 fps — surfaces in the console instead of masquerading as input lag. MJPEG is unaffected.
+
 ---
 
 ## [0.1.80] - 2026-07-13

--- a/Sources/Baguette/Domain/Stream/H264Tuning.swift
+++ b/Sources/Baguette/Domain/Stream/H264Tuning.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Encoder-latency knobs for the H.264 (AVCC) stream, as a pure value so
+/// the "what config do we want" decision is testable apart from the
+/// irreducible VideoToolbox calls that apply it (`H264Encoder`). The
+/// `lowLatency` preset targets frames stalling in the browser's WebCodecs
+/// decoder queue: no reordering + low-latency rate control signal a
+/// minimal DPB, so the decoder stops holding frames back.
+struct H264Tuning: Equatable, Sendable {
+    /// VideoToolbox real-time encode path.
+    let realTime: Bool
+
+    /// B-frames off — reordering adds decode-side buffering latency.
+    let allowFrameReordering: Bool
+
+    /// Frames the encoder may hold before emitting. `0` = emit immediately;
+    /// `nil` = VideoToolbox default.
+    let maxFrameDelayCount: Int?
+
+    /// VideoToolbox's low-latency rate-control mode (the FaceTime /
+    /// screen-share path) — shrinks the pipeline and signals a minimal DPB.
+    let lowLatencyRateControl: Bool
+
+    /// Seconds between forced IDRs; a long GOP keeps big keyframes rare.
+    let keyFrameIntervalSeconds: Int
+
+    static let lowLatency = H264Tuning(
+        realTime: true,
+        allowFrameReordering: false,
+        maxFrameDelayCount: 0,
+        lowLatencyRateControl: true,
+        keyFrameIntervalSeconds: 5
+    )
+
+    /// Frames between forced IDRs at a given capture rate. Guards fps 0 so
+    /// a misconfigured stream still forces periodic keyframes.
+    func maxKeyFrameInterval(fps: Int) -> Int {
+        keyFrameIntervalSeconds * max(1, fps)
+    }
+}

--- a/Sources/Baguette/Infrastructure/Stream/H264Encoder.swift
+++ b/Sources/Baguette/Infrastructure/Stream/H264Encoder.swift
@@ -31,12 +31,15 @@ final class H264Encoder: @unchecked Sendable {
     private var height: Int32 = 0
     private let fps: Int32
     private var bitrate: Int
+    private let tuning: H264Tuning
     private var emittedDescription = false
     private var frameCount: Int64 = 0
 
-    init(fps: Int, bitrate: Int = 2_000_000, onEncoded: (@Sendable (Encoded) -> Void)? = nil) {
+    init(fps: Int, bitrate: Int = 2_000_000, tuning: H264Tuning = .lowLatency,
+         onEncoded: (@Sendable (Encoded) -> Void)? = nil) {
         self.fps = Int32(fps)
         self.bitrate = bitrate
+        self.tuning = tuning
         self.onEncoded = onEncoded
     }
 
@@ -116,12 +119,18 @@ final class H264Encoder: @unchecked Sendable {
             self.session = nil
         }
 
+        // Low-latency rate control is a create-time spec, not a settable
+        // property; everything else below is a post-create property.
+        let encoderSpec: CFDictionary? = tuning.lowLatencyRateControl
+            ? [kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue!] as CFDictionary
+            : nil
+
         var sess: VTCompressionSession?
         let status = VTCompressionSessionCreate(
             allocator: kCFAllocatorDefault,
             width: width, height: height,
             codecType: kCMVideoCodecType_H264,
-            encoderSpecification: nil,
+            encoderSpecification: encoderSpec,
             imageBufferAttributes: nil,
             compressedDataAllocator: kCFAllocatorDefault,
             outputCallback: nil,
@@ -130,20 +139,21 @@ final class H264Encoder: @unchecked Sendable {
         )
         guard status == noErr, let sess else { return }
 
-        let props: [(CFString, Any)] = [
-            (kVTCompressionPropertyKey_RealTime, kCFBooleanTrue!),
+        // Values from `H264Tuning` (unit-tested); mapping to VT keys is the
+        // irreducible call. Rejected properties return a non-noErr status
+        // we intentionally ignore.
+        var props: [(CFString, Any)] = [
+            (kVTCompressionPropertyKey_RealTime, (tuning.realTime ? kCFBooleanTrue : kCFBooleanFalse)!),
             (kVTCompressionPropertyKey_ProfileLevel, kVTProfileLevel_H264_High_AutoLevel),
-            (kVTCompressionPropertyKey_AllowFrameReordering, kCFBooleanFalse!),
+            (kVTCompressionPropertyKey_AllowFrameReordering, (tuning.allowFrameReordering ? kCFBooleanTrue : kCFBooleanFalse)!),
             (kVTCompressionPropertyKey_AverageBitRate, NSNumber(value: bitrate)),
             (kVTCompressionPropertyKey_ExpectedFrameRate, NSNumber(value: fps)),
-            // 5-second keyframe interval — IDRs are ~5–10× larger than
-            // P-frames, so a forced IDR mid-stream causes a visible
-            // encode/transport stall. Spacing them out by 5s keeps the
-            // typical pinch / scroll gesture inside one P-frame run, so
-            // motion stays smooth. Late-joiner resync waits up to 5s,
-            // which we sidestep by emitting a JPEG seed on first frame.
-            (kVTCompressionPropertyKey_MaxKeyFrameInterval, NSNumber(value: fps * 5)),
+            (kVTCompressionPropertyKey_MaxKeyFrameInterval,
+             NSNumber(value: tuning.maxKeyFrameInterval(fps: Int(fps)))),
         ]
+        if let maxDelay = tuning.maxFrameDelayCount {
+            props.append((kVTCompressionPropertyKey_MaxFrameDelayCount, NSNumber(value: maxDelay)))
+        }
         for (key, value) in props {
             VTSessionSetProperty(sess, key: key, value: value as CFTypeRef)
         }

--- a/Sources/Baguette/Resources/Web/frame-decoder.js
+++ b/Sources/Baguette/Resources/Web/frame-decoder.js
@@ -53,13 +53,43 @@
 
         if (type === 0x01) {
           // avcC description — configure the decoder.
+          const config = {
+            codec: 'avc1.' + hex2(payload[1]) + hex2(payload[2]) + hex2(payload[3]),
+            description: payload.buffer,
+            optimizeFor: 'latency',
+            hardwareAcceleration: 'prefer-hardware',
+          };
+          // Diagnostic only: `prefer-hardware` silently falls back to a
+          // software decoder — brutal at full-res 60fps — with no error.
+          // `decodingInfo().powerEfficient` flags the hardware path so a
+          // fallback shows up in the log instead of as mystery lag.
+          const mc = navigator.mediaCapabilities;
+          if (mc && typeof mc.decodingInfo === 'function') {
+            mc.decodingInfo({
+              type: 'file',
+              video: {
+                contentType: 'video/mp4; codecs="' + config.codec + '"',
+                width: 1170, height: 2532, bitrate: 8000000, framerate: 60,
+              },
+            })
+              .then((info) => {
+                onLog && onLog(
+                  'decode: ' + (info.powerEfficient ? 'hardware' : 'SOFTWARE fallback')
+                  + ' (' + config.codec + ' — supported=' + info.supported
+                  + ' smooth=' + info.smooth + ' powerEfficient=' + info.powerEfficient + ')'
+                  + (info.powerEfficient ? '' : ' — H.264 latency will be poor'),
+                  !info.powerEfficient);
+              })
+              .catch((err) => {
+                onLog && onLog('decode: HW probe failed for ' + config.codec
+                  + ' — ' + ((err && err.message) || err), true);
+              });
+          } else {
+            onLog && onLog('decode: mediaCapabilities unavailable ('
+              + config.codec + ')', true);
+          }
           try {
-            decoder.configure({
-              codec: 'avc1.' + hex2(payload[1]) + hex2(payload[2]) + hex2(payload[3]),
-              description: payload.buffer,
-              optimizeFor: 'latency',
-              hardwareAcceleration: 'prefer-hardware',
-            });
+            decoder.configure(config);
           } catch (ex) { onLog && onLog('config: ' + ex.message, true); }
         } else if ((type === 0x02 || type === 0x03) && decoder.state === 'configured') {
           // 0x02 = key (IDR), 0x03 = delta.

--- a/Sources/Baguette/Resources/Web/frame-decoder.js
+++ b/Sources/Baguette/Resources/Web/frame-decoder.js
@@ -56,7 +56,7 @@
           const config = {
             codec: 'avc1.' + hex2(payload[1]) + hex2(payload[2]) + hex2(payload[3]),
             description: payload.buffer,
-            optimizeFor: 'latency',
+            optimizeForLatency: true,
             hardwareAcceleration: 'prefer-hardware',
           };
           // Diagnostic only: `prefer-hardware` silently falls back to a

--- a/Tests/BaguetteTests/Stream/H264TuningTests.swift
+++ b/Tests/BaguetteTests/Stream/H264TuningTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import Baguette
+
+@Suite("H264Tuning")
+struct H264TuningTests {
+
+    @Test func `low-latency preset holds no frames and disables reordering`() {
+        let t = H264Tuning.lowLatency
+        #expect(t.realTime == true)
+        #expect(t.allowFrameReordering == false)
+        #expect(t.maxFrameDelayCount == 0)
+        #expect(t.lowLatencyRateControl == true)
+    }
+
+    @Test func `keyframe interval is five seconds of frames at 60fps`() {
+        #expect(H264Tuning.lowLatency.maxKeyFrameInterval(fps: 60) == 300)
+    }
+
+    @Test func `keyframe interval scales with capture rate`() {
+        #expect(H264Tuning.lowLatency.maxKeyFrameInterval(fps: 30) == 150)
+    }
+
+    @Test func `keyframe interval never collapses on a zero capture rate`() {
+        #expect(H264Tuning.lowLatency.maxKeyFrameInterval(fps: 0) == 5)
+    }
+}


### PR DESCRIPTION
## What & why

Opening a sim in a new tab (`/simulators/:udid`) felt laggy to interact with, while the device-farm grid felt near-instant. The two paths share the **same** input transport (the Baguette SDK over the stream WebSocket) — the difference is the **video codec**: the farm hardcodes **MJPEG** (`farm-tile.js`), the single-sim tab defaults to **H.264/AVCC** (`sim-native.js` `pickFormat()`). Because the input send path is identical, the perceived "input latency" is really glass-to-glass **video** latency, and H.264's encode→decode pipeline buffers frames where MJPEG (independent per-frame JPEGs) doesn't.

The AVCC delay is the browser's WebCodecs `VideoDecoder` holding frames in its queue before emitting them — the exact behaviour `AVCCStream`'s idle-pump already exists to work around.

## Changes

- **Encoder low-latency mode** (`H264Encoder.swift`): create the `VTCompressionSession` with `kVTVideoEncoderSpecification_EnableLowLatencyRateControl` and set `MaxFrameDelayCount = 0`. Shrinks the encode pipeline and signals a minimal DPB so the decoder stops buffering. No change to bitrate / fps / scale.
- **`H264Tuning` domain value** (new, unit-tested): lifts the encoder's tuning knobs into a pure value (`.lowLatency` preset) so the "what config do we want" decision is testable apart from the irreducible VideoToolbox calls, per the repo's adapter-split convention.
- **Decoder HW/SW diagnostic** (`frame-decoder.js`): on configure, log whether the negotiated profile/level decodes in hardware via `mediaCapabilities.decodingInfo().powerEfficient`, so a silent software-decode fallback (brutal at full-res 60 fps) surfaces in the console instead of masquerading as lag. Non-blocking — decode still starts on the first chunk.

MJPEG is unaffected.

## Testing

- New `H264TuningTests` (4 tests) — `.lowLatency` preset values + keyframe-interval math (including the fps-0 guard). Written test-first (red → green).
- Full suite green — **678 tests**.
- Verified on a booted sim: AVCC interaction is noticeably tighter, and the new decoder diagnostic reports the decode path (`avc1.640033` — High @ L5.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WG7NitEqov6fhyWaDqgps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved H.264/AVCC streaming latency by enabling low-latency encoder rate control and reducing frame delays for faster delivery (single-simulator path).
* **Diagnostics**
  * Added non-blocking diagnostics to report whether AVCC decoding is using hardware decoding or falling back to software.
* **Bug Fixes**
  * Improved visibility when AVCC decoder configuration or diagnostics checks fail.
* **Tests**
  * Added coverage for the new H.264 low-latency tuning preset and keyframe interval behavior.
* **Documentation**
  * Updated the unreleased changelog to reflect the streaming improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->