### PR TITLE
fix: Xcode 27 support — SimulatorKit and screen dimensions both relocated

### DIFF
--- a/.github/workflows/xcode-27.yml
+++ b/.github/workflows/xcode-27.yml
@@ -68,12 +68,13 @@ jobs:
       - name: Build
         run: swift build -c release
 
-      - name: Unit tests
-        run: swift test
-
       # End-to-end: on a machine with no Xcode 26, an unfixed baguette
       # emits the "SimulatorKit not found" diagnostic and cannot drive a
       # simulator at all. Its absence is the fix working.
+      #
+      # Ordered ahead of the suite because it is what this job exists to
+      # prove — an unrelated regression elsewhere must not cost us the
+      # primary evidence.
       - name: Assert baguette resolves SimulatorKit
         run: |
           OUT=$(.build/release/Baguette list 2>&1) || true
@@ -87,3 +88,29 @@ jobs:
             exit 1
           fi
           echo "SimulatorKit resolved and loaded."
+
+      - name: Unit tests
+        if: always()
+        run: swift test
+
+      # The 9-slice chrome suite passes on the macOS 26 image and fails
+      # on this one — six devices whose .simdevicetype is installed, but
+      # whose DeviceKit chrome bundle no longer resolves. Separate from
+      # the SimulatorKit relocation and not yet understood, so dump the
+      # inputs the store actually reads rather than guessing.
+      - name: Capture DeviceKit layout (chrome suite diagnostics)
+        if: always()
+        run: |
+          echo "=== /Library/Developer/DeviceKit/Chrome ==="
+          ls -1 /Library/Developer/DeviceKit/Chrome 2>&1 | head -40
+          echo
+          for DEVICE in "iPhone 17e" "iPad (9th generation)"; do
+            PLIST="/Library/Developer/CoreSimulator/Profiles/DeviceTypes/$DEVICE.simdevicetype/Contents/Resources/profile.plist"
+            echo "=== $DEVICE ==="
+            if [ -e "$PLIST" ]; then
+              /usr/libexec/PlistBuddy -c 'Print :chromeIdentifier' "$PLIST" 2>&1 || \
+                echo "  (no chromeIdentifier key)"
+            else
+              echo "  no profile.plist"
+            fi
+          done

--- a/.github/workflows/xcode-27.yml
+++ b/.github/workflows/xcode-27.yml
@@ -1,0 +1,89 @@
+name: Xcode 27 compatibility
+
+# Xcode 27 relocated SimulatorKit.framework (issue #28). The `xcode-27`
+# runner image is the only place we can prove the fix: it ships Xcode 27
+# beta 3 and *no* Xcode 26, so `CoreSimulators.developerDir()` has
+# nothing to silently fall back to. On a developer machine with both
+# Xcodes installed, the fallback masks the bug — baguette works via 26
+# whether or not the fix is present, so a green local run proves nothing.
+#
+# The image is a public preview and can queue, so this is opt-in rather
+# than part of the PR gate.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [fix/xcode-27-simulatorkit-path]
+
+jobs:
+  xcode-27:
+    name: SimulatorKit resolves on Xcode 27
+    runs-on: xcode-27
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Record the toolchain under test
+        run: |
+          xcodebuild -version
+          xcode-select -p
+          swift --version
+
+      # The whole fix rests on a relocation reported by third parties.
+      # Assert it directly rather than trusting the report: this step is
+      # the primary evidence, and it fails loudly if Apple moves the
+      # framework again in a later beta.
+      - name: Assert SimulatorKit's location on Xcode 27
+        run: |
+          DEV="$(xcode-select -p)"
+          OLD="$DEV/Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit"
+          NEW="$(dirname "$DEV")/SharedFrameworks/SimulatorKit.framework/SimulatorKit"
+
+          echo "old (Xcode <=26): $OLD"
+          echo "new (Xcode 27):   $NEW"
+          [ -e "$OLD" ] && echo "  present at OLD" || echo "  absent at OLD"
+          [ -e "$NEW" ] && echo "  present at NEW" || echo "  absent at NEW"
+
+          if [ ! -e "$NEW" ]; then
+            echo "::error::SimulatorKit is not at the expected Xcode 27 location."
+            echo "Candidates actually present under the Xcode bundle:"
+            find "$(dirname "$DEV")" -maxdepth 4 -name 'SimulatorKit.framework' 2>/dev/null || true
+            exit 1
+          fi
+
+      # Guards the premise of this job: if a future image adds an
+      # Xcode 26, the fallback returns and every assertion below starts
+      # passing for the wrong reason.
+      - name: Assert no Xcode 26 is installed to fall back to
+        run: |
+          FOUND=$(ls -d /Applications/Xcode*26*.app 2>/dev/null || true)
+          if [ -n "$FOUND" ]; then
+            echo "::error::Xcode 26 present — developerDir() can fall back, so this job no longer tests Xcode 27."
+            echo "$FOUND"
+            exit 1
+          fi
+          echo "Only Xcode 27 installed — no fallback available."
+
+      - name: Build
+        run: swift build -c release
+
+      - name: Unit tests
+        run: swift test
+
+      # End-to-end: on a machine with no Xcode 26, an unfixed baguette
+      # emits the "SimulatorKit not found" diagnostic and cannot drive a
+      # simulator at all. Its absence is the fix working.
+      - name: Assert baguette resolves SimulatorKit
+        run: |
+          OUT=$(.build/release/Baguette list 2>&1) || true
+          echo "$OUT"
+          if echo "$OUT" | grep -q "SimulatorKit not found"; then
+            echo "::error::baguette could not resolve SimulatorKit on Xcode 27."
+            exit 1
+          fi
+          if echo "$OUT" | grep -q "SimulatorKit load failed"; then
+            echo "::error::SimulatorKit was found but failed to dlopen on Xcode 27."
+            exit 1
+          fi
+          echo "SimulatorKit resolved and loaded."

--- a/.github/workflows/xcode-27.yml
+++ b/.github/workflows/xcode-27.yml
@@ -7,17 +7,28 @@ name: Xcode 27 compatibility
 # Xcodes installed, the fallback masks the bug — baguette works via 26
 # whether or not the fix is present, so a green local run proves nothing.
 #
-# The image is a public preview and can queue, so this is opt-in rather
-# than part of the PR gate.
+# Two triggers, for two different ways this can break:
+#
+#   - push / pull_request — our own changes regressing Xcode 27 support.
+#   - schedule — Apple moving things again in a later beta. That breaks
+#     with no commit of ours involved, so nothing else would catch it;
+#     a weekly run turns a silent break into a dated red build.
+#
+# The image is a public preview and can queue, so the scheduled run is
+# weekly rather than nightly.
 
 on:
   workflow_dispatch:
   push:
-    branches: [fix/xcode-27-simulatorkit-path]
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
 
 jobs:
   xcode-27:
-    name: SimulatorKit resolves on Xcode 27
+    name: Xcode 27 compatibility
     runs-on: xcode-27
 
     steps:
@@ -93,24 +104,47 @@ jobs:
         if: always()
         run: swift test
 
-      # The 9-slice chrome suite passes on the macOS 26 image and fails
-      # on this one — six devices whose .simdevicetype is installed, but
-      # whose DeviceKit chrome bundle no longer resolves. Separate from
-      # the SimulatorKit relocation and not yet understood, so dump the
-      # inputs the store actually reads rather than guessing.
-      - name: Capture DeviceKit layout (chrome suite diagnostics)
+      # The second relocation this repo had to absorb: Xcode 27 dropped
+      # mainScreenWidth/Height/Scale from profile.plist and publishes
+      # them in capabilities.plist under an `integrated` display. Only
+      # the 9-slice chrome path reads a screen size, so a regression
+      # here costs every iPad its bezel while composite devices look
+      # fine — a quiet failure worth asserting rather than inferring
+      # from the suite.
+      - name: Assert screen dimensions are where Xcode 27 puts them
         if: always()
         run: |
-          echo "=== /Library/Developer/DeviceKit/Chrome ==="
-          ls -1 /Library/Developer/DeviceKit/Chrome 2>&1 | head -40
-          echo
-          for DEVICE in "iPhone 17e" "iPad (9th generation)"; do
-            PLIST="/Library/Developer/CoreSimulator/Profiles/DeviceTypes/$DEVICE.simdevicetype/Contents/Resources/profile.plist"
-            echo "=== $DEVICE ==="
-            if [ -e "$PLIST" ]; then
-              /usr/libexec/PlistBuddy -c 'Print :chromeIdentifier' "$PLIST" 2>&1 || \
-                echo "  (no chromeIdentifier key)"
-            else
-              echo "  no profile.plist"
-            fi
-          done
+          TYPES=/Library/Developer/CoreSimulator/Profiles/DeviceTypes
+          python3 - "$TYPES" <<'PY'
+          import glob, os, plistlib, sys
+
+          types = sys.argv[1]
+          checked = legacy = modern = 0
+          for d in sorted(glob.glob(f"{types}/*.simdevicetype")):
+              prof, caps = (f"{d}/Contents/Resources/profile.plist",
+                            f"{d}/Contents/Resources/capabilities.plist")
+              if not os.path.exists(prof):
+                  continue
+              checked += 1
+              p = plistlib.load(open(prof, "rb"))
+              if all(k in p for k in
+                     ("mainScreenWidth", "mainScreenHeight", "mainScreenScale")):
+                  legacy += 1
+                  continue
+              if not os.path.exists(caps):
+                  continue
+              displays = (plistlib.load(open(caps, "rb"))
+                          .get("capabilities", {}).get("displays", []))
+              if any(x.get("displayType") == "integrated" for x in displays):
+                  modern += 1
+
+          print(f"device types:            {checked}")
+          print(f"  legacy profile keys:   {legacy}")
+          print(f"  capabilities.plist:    {modern}")
+
+          if checked and legacy + modern == 0:
+              print("::error::No device type exposes a screen size in either "
+                    "known shape — 9-slice chrome would lose every bezel.")
+              raise SystemExit(1)
+          print("Screen dimensions readable in a known shape.")
+          PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ For releases prior to this changelog, see the
   location exists, the raw dyld error is replaced by a message naming both
   paths searched and pointing at `DEVELOPER_DIR`.
 
+- **Xcode 27 support — device chrome renders again on 9-slice devices.**
+  Xcode 27 stopped publishing `mainScreenWidth` / `mainScreenHeight` /
+  `mainScreenScale` on a device type's `profile.plist` (124 of 124 device types
+  carry them on Xcode 26; 0 of 124 on Xcode 27) and moved the same values into
+  a sibling `capabilities.plist`. Only the 9-slice chrome path reads a screen
+  size, so every iPad — plus iPhone 17e — lost its bezel while devices with a
+  baked composite kept theirs. Both shapes are now read, preferring the
+  profile's own keys. The `integrated` display is selected explicitly: the same
+  list carries `tvOut` / `carPlay` entries at 720×480 and a resizable `scene`
+  entry at 7680×4320, any of which would have sized a bezel wrongly ([#28]).
+
 [#28]: https://github.com/tddworks/baguette/issues/28
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Fixed
+
+- **Xcode 27 support — SimulatorKit is found at its new location.** Xcode 27
+  moved `SimulatorKit.framework` out of the developer directory
+  (`Contents/Developer/Library/PrivateFrameworks/`) and up into
+  `Contents/SharedFrameworks/`. Every `dlopen` site hardcoded the old path, so
+  a machine whose only Xcode is 27 failed to load SimulatorKit at all and no
+  simulator control worked ([#28]). Both layouts are now probed, oldest-first,
+  so Xcode ≤26 resolves to exactly the path it always did. When neither
+  location exists, the raw dyld error is replaced by a message naming both
+  paths searched and pointing at `DEVELOPER_DIR`.
+
+[#28]: https://github.com/tddworks/baguette/issues/28
+
 ---
 
 ## [0.1.81] - 2026-07-17

--- a/Sources/Baguette/App/Commands/DiagDigitizerTrackpadCommand.swift
+++ b/Sources/Baguette/App/Commands/DiagDigitizerTrackpadCommand.swift
@@ -287,10 +287,8 @@ struct DiagDigitizerTrackpadCommand: ParsableCommand {
     /// reveals which byte is the edge slot in the message buffer.
     private static func dumpMouseEventMessage(x: Double, y: Double, edge: UInt32) -> String? {
         let dev = CoreSimulators.developerDir()
-        let kitPath = (dev as NSString).appendingPathComponent(
-            "Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit"
-        )
-        guard let kit = dlopen(kitPath, RTLD_NOW) else { return nil }
+        guard let kitPath = SimulatorKitFramework.path(developerDir: dev),
+              let kit = dlopen(kitPath, RTLD_NOW) else { return nil }
         guard let sym = dlsym(kit, "IndigoHIDMessageForMouseNSEvent") else { return nil }
         // 9-arg shape — same `MouseFn` typealias as IndigoHIDInput.
         typealias MouseFn = @convention(c) (
@@ -365,9 +363,11 @@ struct DiagDigitizerTrackpadCommand: ParsableCommand {
         // 1. Open SimulatorKit — same dlopen the production HID input
         //    already does. We need the trackpad wrapper symbol.
         let dev = CoreSimulators.developerDir()
-        let kitPath = (dev as NSString).appendingPathComponent(
-            "Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit"
-        )
+        guard let kitPath = SimulatorKitFramework.path(developerDir: dev) else {
+            return Outcome(accepted: false, messageSize: 0, dispatched: false,
+                           reason: "SimulatorKit not found under \(dev) — see issue #28",
+                           hex: nil)
+        }
         guard let kit = dlopen(kitPath, RTLD_NOW) else {
             return Outcome(accepted: false, messageSize: 0, dispatched: false,
                            reason: "dlopen SimulatorKit failed: \(String(cString: dlerror()))",

--- a/Sources/Baguette/Domain/Chrome/DeviceProfile.swift
+++ b/Sources/Baguette/Domain/Chrome/DeviceProfile.swift
@@ -11,14 +11,21 @@ struct DeviceProfile: Equatable, Sendable {
     /// we strip the prefix at parse time so the rest of the system
     /// works in directory-name space.
     let chromeIdentifier: String
-    /// Screen size in 1x points — `mainScreenWidth × mainScreenHeight`
-    /// divided by `mainScreenScale`. Used by 9-slice chrome composition
-    /// to size the inner canvas area, since DeviceKit's `Screen.pdf` is
-    /// a meaningless 1×1 marker. `nil` when any of the three plist keys
-    /// is absent.
+    /// Screen size in 1x points. Used by 9-slice chrome composition to
+    /// size the inner canvas area, since DeviceKit's `Screen.pdf` is a
+    /// meaningless 1×1 marker. `nil` when neither source carries one.
+    ///
+    /// Two sources, because Xcode 27 moved the numbers. Xcode ≤26 put
+    /// `mainScreenWidth` / `mainScreenHeight` / `mainScreenScale` on the
+    /// profile itself; Xcode 27 dropped all three (124 of 124 device
+    /// types carry them on 26, 0 of 124 on 27) and publishes the same
+    /// values in a sibling `capabilities.plist` instead.
     let screenSize: Size?
 
-    static func parsing(plistData data: Data) throws -> DeviceProfile {
+    static func parsing(
+        plistData data: Data,
+        capabilitiesData: Data? = nil
+    ) throws -> DeviceProfile {
         let raw: Any
         do {
             raw = try PropertyListSerialization.propertyList(
@@ -42,7 +49,40 @@ struct DeviceProfile: Equatable, Sendable {
         return DeviceProfile(
             chromeIdentifier: bare,
             screenSize: parseScreenSize(dict)
+                ?? capabilitiesData.flatMap(parseIntegratedDisplay)
         )
+    }
+
+    /// Xcode 27's `capabilities.plist` → `capabilities.displays`, a list
+    /// describing every panel the device can drive. Only the
+    /// `integrated` entry is the device's own screen: the others are
+    /// `tvOut` and `carPlay` (both 720×480) and a `scene` entry at
+    /// 7680×4320 for resizable windows. Sizing a bezel off any of those
+    /// would be silently, wildly wrong, so the type is matched
+    /// explicitly rather than taking the first element.
+    private static func parseIntegratedDisplay(_ data: Data) -> Size? {
+        guard let raw = try? PropertyListSerialization.propertyList(
+                  from: data, options: [], format: nil
+              ),
+              let root = raw as? [String: Any],
+              let capabilities = root["capabilities"] as? [String: Any],
+              let displays = capabilities["displays"] as? [[String: Any]],
+              let panel = displays.first(where: {
+                  $0["displayType"] as? String == "integrated"
+              })
+        else { return nil }
+        return parseDisplaySize(panel)
+    }
+
+    /// Same arithmetic as `parseScreenSize`, over the capabilities
+    /// spelling of the keys.
+    private static func parseDisplaySize(_ dict: [String: Any]) -> Size? {
+        guard let w = dict["width"] as? Double,
+              let h = dict["height"] as? Double,
+              let s = dict["scale"] as? Double,
+              s > 0
+        else { return nil }
+        return Size(width: w / s, height: h / s)
     }
 
     /// Plist values are NSNumber-bridged; `as? Double` covers integer

--- a/Sources/Baguette/Domain/Simulator/SimulatorKitFramework.swift
+++ b/Sources/Baguette/Domain/Simulator/SimulatorKitFramework.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Where `SimulatorKit.framework` lives inside an Xcode install.
+///
+/// Xcode ≤26 ships it under the developer directory, in
+/// `Contents/Developer/Library/PrivateFrameworks/`. Xcode 27 moved it
+/// up a level into `Contents/SharedFrameworks/` — a *sibling* of
+/// `Contents/Developer`, so it can no longer be reached by appending to
+/// the path `xcode-select -p` reports. Baguette hardcoded the old
+/// location at every `dlopen` site, which is why a machine whose only
+/// Xcode is 27 can't drive a simulator at all (issue #28).
+///
+/// Both layouts are probed here, oldest-first, so an Xcode 26 install
+/// resolves to exactly the path it always did.
+enum SimulatorKitFramework {
+
+    private static let suffix = "SimulatorKit.framework/SimulatorKit"
+
+    /// Every location SimulatorKit is known to occupy, in probe order.
+    ///
+    /// Exposed separately from `path(developerDir:exists:)` so failure
+    /// diagnostics can list what was actually searched rather than
+    /// echoing a single path the user never had.
+    static func candidatePaths(developerDir: String) -> [String] {
+        // `Contents/Developer` → `Contents`. Resolved by trimming rather
+        // than by appending `..` so the path that reaches a log message
+        // is the one a user can paste into `ls`.
+        let contents = (developerDir as NSString).deletingLastPathComponent
+        return [
+            (developerDir as NSString)
+                .appendingPathComponent("Library/PrivateFrameworks/\(suffix)"),
+            (contents as NSString)
+                .appendingPathComponent("SharedFrameworks/\(suffix)"),
+        ]
+    }
+
+    /// The first known location that exists, or `nil` when this Xcode
+    /// carries no SimulatorKit at all.
+    ///
+    /// `exists` is injected so resolution order is unit-provable without
+    /// either Xcode version installed.
+    static func path(
+        developerDir: String,
+        exists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> String? {
+        candidatePaths(developerDir: developerDir).first(where: exists)
+    }
+}

--- a/Sources/Baguette/Infrastructure/Chrome/ChromeStore.swift
+++ b/Sources/Baguette/Infrastructure/Chrome/ChromeStore.swift
@@ -12,6 +12,13 @@ protocol ChromeStore: Sendable {
     /// turns that into a `nil` asset for the caller.
     func profilePlistData(deviceName: String) throws -> Data
 
+    /// Raw `capabilities.plist` from the same device-type bundle.
+    /// Xcode 27 publishes screen dimensions here instead of on the
+    /// profile; Xcode ≤26 has no such file, so throwing is the normal
+    /// path there and `LiveChromes` falls back to the profile's own
+    /// keys.
+    func capabilitiesPlistData(deviceName: String) throws -> Data
+
     /// Raw `chrome.json` for a chrome bundle (bare identifier — no
     /// `com.apple.dt.devicekit.chrome.` prefix).
     func chromeJSONData(chromeIdentifier: String) throws -> Data

--- a/Sources/Baguette/Infrastructure/Chrome/FileSystemChromeStore.swift
+++ b/Sources/Baguette/Infrastructure/Chrome/FileSystemChromeStore.swift
@@ -20,6 +20,11 @@ struct FileSystemChromeStore: ChromeStore {
         return try Data(contentsOf: URL(fileURLWithPath: path))
     }
 
+    func capabilitiesPlistData(deviceName: String) throws -> Data {
+        let path = "\(deviceTypesRoot)/\(deviceName).simdevicetype/Contents/Resources/capabilities.plist"
+        return try Data(contentsOf: URL(fileURLWithPath: path))
+    }
+
     func chromeJSONData(chromeIdentifier: String) throws -> Data {
         let path = "\(chromeRoot)/\(chromeIdentifier).devicechrome/Contents/Resources/chrome.json"
         return try Data(contentsOf: URL(fileURLWithPath: path))

--- a/Sources/Baguette/Infrastructure/Chrome/LiveChromes.swift
+++ b/Sources/Baguette/Infrastructure/Chrome/LiveChromes.swift
@@ -54,7 +54,14 @@ final class LiveChromes: Chromes, @unchecked Sendable {
     private func resolveProfile(deviceName: String) -> DeviceProfile? {
         do {
             let plistData = try store.profilePlistData(deviceName: deviceName)
-            return try DeviceProfile.parsing(plistData: plistData)
+            // Absent on Xcode ≤26 — the profile carries the screen
+            // there, so a missing capabilities file is not an error.
+            let capabilities = try? store.capabilitiesPlistData(
+                deviceName: deviceName
+            )
+            return try DeviceProfile.parsing(
+                plistData: plistData, capabilitiesData: capabilities
+            )
         } catch {
             return nil
         }

--- a/Sources/Baguette/Infrastructure/Input/IOHIDDigitizerDispatch.swift
+++ b/Sources/Baguette/Infrastructure/Input/IOHIDDigitizerDispatch.swift
@@ -276,10 +276,8 @@ enum IOHIDDigitizerDispatch {
     private static func ensureSymbols() -> Bool {
         if symbolsResolved { return true }
         let dev = CoreSimulators.developerDir()
-        let kitPath = (dev as NSString).appendingPathComponent(
-            "Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit"
-        )
-        guard let kit = dlopen(kitPath, RTLD_NOW) else { return false }
+        guard let kitPath = SimulatorKitFramework.path(developerDir: dev),
+              let kit = dlopen(kitPath, RTLD_NOW) else { return false }
         let dyld = UnsafeMutableRawPointer(bitPattern: -2)
         guard let pCreateDig = dlsym(dyld, "IOHIDEventCreateDigitizerEvent"),
               let pCreateFin = dlsym(dyld, "IOHIDEventCreateDigitizerFingerEvent"),

--- a/Sources/Baguette/Infrastructure/Input/IndigoHIDInput.swift
+++ b/Sources/Baguette/Infrastructure/Input/IndigoHIDInput.swift
@@ -611,9 +611,10 @@ final class IndigoHIDInput: Input, @unchecked Sendable {
     private func resolveFunctions() {
         guard mouseFn == nil else { return }
         let dev = CoreSimulators.developerDir()
-        let path = (dev as NSString).appendingPathComponent(
-            "Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit"
-        )
+        guard let path = SimulatorKitFramework.path(developerDir: dev) else {
+            logErr("SimulatorKit not found under \(dev) — see issue #28")
+            return
+        }
         guard let handle = dlopen(path, RTLD_NOW) else {
             logErr("SimulatorKit dlopen failed: \(dlerrorString())")
             return

--- a/Sources/Baguette/Infrastructure/Simulator/CoreSimulators.swift
+++ b/Sources/Baguette/Infrastructure/Simulator/CoreSimulators.swift
@@ -140,11 +140,23 @@ final class CoreSimulators: Simulators, DeviceHost, @unchecked Sendable {
         guard !loaded else { return }
         loaded = true
         let dev = developerDir()
+        // CoreSimulator lives outside Xcode, in a system path that
+        // Xcode 27 left alone.
         let coreSim = "/Library/Developer/PrivateFrameworks/CoreSimulator.framework/CoreSimulator"
-        let simKit = (dev as NSString)
-            .appendingPathComponent("Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit")
         if dlopen(coreSim, RTLD_NOW | RTLD_GLOBAL) == nil {
             logErr("CoreSimulator load failed: \(dlerrorString())")
+        }
+        guard let simKit = SimulatorKitFramework.path(developerDir: dev) else {
+            // No Xcode on this machine carries SimulatorKit at either
+            // known location. Say so — a raw dyld error here names one
+            // path the user never had and reads as a broken install.
+            logErr("SimulatorKit not found. Searched:")
+            for candidate in SimulatorKitFramework.candidatePaths(developerDir: dev) {
+                logErr("  \(candidate)")
+            }
+            logErr("Set DEVELOPER_DIR to an Xcode that has it, or see")
+            logErr("https://github.com/tddworks/baguette/issues/28")
+            return
         }
         if dlopen(simKit, RTLD_NOW | RTLD_GLOBAL) == nil {
             logErr("SimulatorKit load failed: \(dlerrorString())")
@@ -186,9 +198,7 @@ final class CoreSimulators: Simulators, DeviceHost, @unchecked Sendable {
     }
 
     private static func hasSimulatorKit(at developerDir: String) -> Bool {
-        let path = (developerDir as NSString)
-            .appendingPathComponent("Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit")
-        return FileManager.default.fileExists(atPath: path)
+        SimulatorKitFramework.path(developerDir: developerDir) != nil
     }
 
     private static func scanApplications() -> String? {

--- a/Tests/BaguetteTests/Chrome/DeviceProfileCapabilitiesTests.swift
+++ b/Tests/BaguetteTests/Chrome/DeviceProfileCapabilitiesTests.swift
@@ -1,0 +1,128 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// Xcode 27 stopped publishing screen dimensions in `profile.plist`.
+/// The `mainScreenWidth` / `mainScreenHeight` / `mainScreenScale` keys
+/// that every Xcode ≤26 device type carried are gone — 124 of 124
+/// profiles have them on Xcode 26, 0 of 124 on Xcode 27 — and the
+/// numbers moved to a sibling `capabilities.plist` under a `displays`
+/// list.
+///
+/// Only the 9-slice chrome path reads a screen size (the composite path
+/// returns its baked PDF first), so the visible symptom is that every
+/// 9-slice device loses its bezel while composite devices keep theirs.
+///
+/// Each device lists several displays — `tvOut` and `carPlay` at
+/// 720×480, and a `scene` entry at 7680×4320. Only the `integrated`
+/// one describes the device's own screen, so selecting on
+/// `displayType` is what keeps a bezel from being sized off a
+/// resizable-scene canvas.
+@Suite("DeviceProfile screen size across Xcode versions")
+struct DeviceProfileCapabilitiesTests {
+
+    /// Xcode ≤26 shape: dimensions inline on the profile.
+    private func legacyProfile() -> Data {
+        let plist: [String: Any] = [
+            "chromeIdentifier": "com.apple.dt.devicekit.chrome.tablet5",
+            "mainScreenWidth": 1668,
+            "mainScreenHeight": 2420,
+            "mainScreenScale": 2,
+        ]
+        return try! PropertyListSerialization.data(
+            fromPropertyList: plist, format: .binary, options: 0
+        )
+    }
+
+    /// Xcode 27 shape: profile keeps the chrome id, drops the screen.
+    private func modernProfile() -> Data {
+        let plist: [String: Any] = [
+            "chromeIdentifier": "com.apple.dt.devicekit.chrome.tablet5"
+        ]
+        return try! PropertyListSerialization.data(
+            fromPropertyList: plist, format: .binary, options: 0
+        )
+    }
+
+    /// Mirrors the real iPad Pro 11-inch (M4) capabilities: the
+    /// integrated panel plus the decoys that must not be picked.
+    private func capabilities() -> Data {
+        let plist: [String: Any] = [
+            "capabilities": [
+                "displays": [
+                    [
+                        "displayType": "integrated",
+                        "displayName": "LCD",
+                        "width": 1668, "height": 2420, "scale": 2,
+                    ],
+                    [
+                        "displayType": "tvOut",
+                        "displayName": "TVOut",
+                        "width": 720, "height": 480, "scale": 1,
+                    ],
+                    [
+                        "displayType": "scene",
+                        "displayName": "Resizable",
+                        "width": 7680, "height": 4320, "scale": 3,
+                    ],
+                ]
+            ]
+        ]
+        return try! PropertyListSerialization.data(
+            fromPropertyList: plist, format: .binary, options: 0
+        )
+    }
+
+    @Test func `reads the screen size from the profile on Xcode 26`() throws {
+        let profile = try DeviceProfile.parsing(
+            plistData: legacyProfile(), capabilitiesData: nil
+        )
+
+        #expect(profile.screenSize == Size(width: 834, height: 1210))
+    }
+
+    @Test func `reads the screen size from capabilities on Xcode 27`() throws {
+        let profile = try DeviceProfile.parsing(
+            plistData: modernProfile(), capabilitiesData: capabilities()
+        )
+
+        // 1668x2420 @2 — the same points the Xcode 26 profile gave.
+        #expect(profile.screenSize == Size(width: 834, height: 1210))
+    }
+
+    @Test func `ignores non-integrated displays when reading capabilities`() throws {
+        // The scene display is 7680x4320 and listed last; picking it
+        // would size a bezel off a resizable canvas rather than the
+        // device panel.
+        let profile = try DeviceProfile.parsing(
+            plistData: modernProfile(), capabilitiesData: capabilities()
+        )
+
+        #expect(profile.screenSize?.width == 834)
+        #expect(profile.screenSize != Size(width: 2560, height: 1440))
+    }
+
+    @Test func `prefers the profile's own keys when both shapes are present`() throws {
+        let profile = try DeviceProfile.parsing(
+            plistData: legacyProfile(), capabilitiesData: capabilities()
+        )
+
+        #expect(profile.screenSize == Size(width: 834, height: 1210))
+    }
+
+    @Test func `has no screen size when neither shape carries one`() throws {
+        let profile = try DeviceProfile.parsing(
+            plistData: modernProfile(), capabilitiesData: nil
+        )
+
+        #expect(profile.screenSize == nil)
+    }
+
+    @Test func `still reads the chrome identifier on Xcode 27`() throws {
+        let profile = try DeviceProfile.parsing(
+            plistData: modernProfile(), capabilitiesData: capabilities()
+        )
+
+        #expect(profile.chromeIdentifier == "tablet5")
+    }
+}

--- a/Tests/BaguetteTests/Chrome/LiveChromesTests.swift
+++ b/Tests/BaguetteTests/Chrome/LiveChromesTests.swift
@@ -6,10 +6,25 @@ import Mockable
 @Suite("LiveChromes")
 struct LiveChromesTests {
 
+    /// A store shaped like Xcode ≤26: no `capabilities.plist`, so the
+    /// screen size comes from the profile's own `mainScreen*` keys.
+    ///
+    /// Stubbed here rather than in each test because `LiveChromes` asks
+    /// every store for capabilities now, and Mockable traps on any
+    /// requirement the production path reaches without a return value —
+    /// even one the caller wraps in `try?`. Tests that want the Xcode 27
+    /// shape stub it themselves.
+    private func makeChromeStore() -> MockChromeStore {
+        let store = MockChromeStore()
+        given(store).capabilitiesPlistData(deviceName: .any)
+            .willThrow(StubError.notFound)
+        return store
+    }
+
     // MARK: - happy path
 
     @Test func `assets returns parsed chrome and rasterized composite`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let pdf = Data("PDF-COMPOSITE".utf8)
         let png = ChromeImage(data: Data("PNG-DATA".utf8), size: Size(width: 393, height: 852))
@@ -30,7 +45,7 @@ struct LiveChromesTests {
     }
 
     @Test func `assets caches by chrome identifier across repeated lookups`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let pdf = Data("X".utf8)
         let png = ChromeImage(data: Data("Y".utf8), size: Size(width: 1, height: 1))
@@ -56,7 +71,7 @@ struct LiveChromesTests {
     // MARK: - degraded paths — every step gives nil cleanly
 
     @Test func `assets returns nil when profile plist is unreadable`() {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         given(store).profilePlistData(deviceName: .any).willThrow(StubError.notFound)
 
@@ -65,7 +80,7 @@ struct LiveChromesTests {
     }
 
     @Test func `assets returns nil when chrome JSON is unreadable`() {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         given(store).profilePlistData(deviceName: .any).willReturn(Self.fixturePlist)
         given(store).chromeJSONData(chromeIdentifier: .any).willThrow(StubError.notFound)
@@ -75,7 +90,7 @@ struct LiveChromesTests {
     }
 
     @Test func `assets returns nil when chrome has neither composite nor full slice`() {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         given(store).profilePlistData(deviceName: .any).willReturn(Self.fixturePlist)
         given(store).chromeJSONData(chromeIdentifier: .any)
@@ -88,7 +103,7 @@ struct LiveChromesTests {
     }
 
     @Test func `assets composes a 9-slice bezel using screen size from plist`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let composed = ChromeImage(data: Data("9SLICE-PNG".utf8), size: Size(width: 926, height: 1302))
 
@@ -132,7 +147,7 @@ struct LiveChromesTests {
     }
 
     @Test func `assets returns nil for 9-slice bundle when plist lacks screen size`() {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         // chromeIdentifier present but mainScreen* keys missing — the
         // 9-slice path can't size the canvas, so the asset is unloadable.
@@ -148,7 +163,7 @@ struct LiveChromesTests {
     }
 
     @Test func `assets returns nil when a 9-slice piece is unreadable`() {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         given(store).profilePlistData(deviceName: .any).willReturn(Self.fixturePlist)
         given(store).chromeJSONData(chromeIdentifier: .any)
@@ -167,7 +182,7 @@ struct LiveChromesTests {
     }
 
     @Test func `assets returns nil when composite PDF is unreadable`() {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         given(store).profilePlistData(deviceName: .any).willReturn(Self.fixturePlist)
         given(store).chromeJSONData(chromeIdentifier: .any).willReturn(Self.fixtureChromeJSON)
@@ -179,7 +194,7 @@ struct LiveChromesTests {
     }
 
     @Test func `assets returns nil when rasterizer fails`() {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         given(store).profilePlistData(deviceName: .any).willReturn(Self.fixturePlist)
         given(store).chromeJSONData(chromeIdentifier: .any).willReturn(Self.fixtureChromeJSON)
@@ -193,7 +208,7 @@ struct LiveChromesTests {
     // Drives `assemble` end-to-end with all four button anchors so the
     // anchor switch in computeMargins / buttonTopLeft is fully exercised.
     @Test func `assets composes a merged bezel for left right top and bottom buttons`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let composite = ChromeImage(data: Data("composite".utf8), size: Size(width: 100, height: 200))
         let buttonImage = ChromeImage(data: Data("btn".utf8), size: Size(width: 10, height: 20))
@@ -242,7 +257,7 @@ struct LiveChromesTests {
     // accidental `imgW + offX` = -5 → 0 the prior production code
     // would compute.
     @Test func `assets uses chrome devicePadding as button margins`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let composite = ChromeImage(data: Data("composite".utf8), size: Size(width: 100, height: 200))
         let sideBtn = ChromeImage(data: Data("side".utf8), size: Size(width: 20, height: 60))
@@ -296,7 +311,7 @@ struct LiveChromesTests {
     //   y = 2 * 160 - 160 = 160  (TOP-edge convention; y delta is
     //                             zero on horizontal-only animations)
     @Test func `assets positions right-anchor button mirroring rollover delta inward`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let composite = ChromeImage(data: Data("c".utf8), size: Size(width: 100, height: 200))
         let btn = ChromeImage(data: Data("b".utf8), size: Size(width: 36, height: 67))
@@ -333,7 +348,7 @@ struct LiveChromesTests {
     // for the digital crown and side button, so honoring `onTop` fixes
     // every watch family in one go.
     @Test func `assets layers onTop buttons above the composite`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let composite = ChromeImage(data: Data("composite".utf8), size: Size(width: 100, height: 200))
         let behind = ChromeImage(data: Data("behind".utf8), size: Size(width: 10, height: 20))
@@ -377,7 +392,7 @@ struct LiveChromesTests {
     // When every button image fails to rasterize the merged-canvas path
     // is skipped — assets fall back to the bare composite, no compose call.
     @Test func `assets falls back to bare composite when every button image fails`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let composite = ChromeImage(data: Data("c".utf8), size: Size(width: 100, height: 200))
 
@@ -410,7 +425,7 @@ struct LiveChromesTests {
     // being dropped after the merge.
 
     @Test func `assets retains the bare composite separate from the merged composite`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let composite = ChromeImage(data: Data("composite-bare".utf8), size: Size(width: 100, height: 200))
         let buttonImage = ChromeImage(data: Data("btn".utf8), size: Size(width: 10, height: 20))
@@ -439,7 +454,7 @@ struct LiveChromesTests {
     }
 
     @Test func `assets retains every button image keyed by name`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let composite = ChromeImage(data: Data("c".utf8), size: Size(width: 100, height: 200))
         let buttonImage = ChromeImage(data: Data("btn".utf8), size: Size(width: 10, height: 20))
@@ -471,7 +486,7 @@ struct LiveChromesTests {
     }
 
     @Test func `assets falls back bareComposite to composite when chrome has no buttons`() throws {
-        let store = MockChromeStore()
+        let store = makeChromeStore()
         let rasterizer = MockPDFRasterizer()
         let pdf = Data("pdf".utf8)
         let composite = ChromeImage(data: Data("c".utf8), size: Size(width: 1, height: 1))

--- a/Tests/BaguetteTests/Simulator/SimulatorKitFrameworkTests.swift
+++ b/Tests/BaguetteTests/Simulator/SimulatorKitFrameworkTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// Xcode 27 relocated `SimulatorKit.framework` out of the developer
+/// directory: it used to sit under `Contents/Developer/Library/
+/// PrivateFrameworks/`, and now sits under `Contents/SharedFrameworks/`
+/// — a sibling of `Contents/Developer`, not a child of it. Every
+/// `dlopen` site in baguette hardcoded the old path, so a machine whose
+/// only Xcode is 27 fails to load SimulatorKit at all (issue #28).
+///
+/// `SimulatorKitFramework` is the one place that knows both layouts.
+/// The filesystem probe is injected so the resolution order is provable
+/// without either Xcode installed.
+@Suite("SimulatorKit framework location")
+struct SimulatorKitFrameworkTests {
+
+    private static let dev = "/Applications/Xcode.app/Contents/Developer"
+    private static let privatePath =
+        "/Applications/Xcode.app/Contents/Developer/Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit"
+    private static let sharedPath =
+        "/Applications/Xcode.app/Contents/SharedFrameworks/SimulatorKit.framework/SimulatorKit"
+
+    @Test func `finds SimulatorKit under PrivateFrameworks in the Xcode 26 layout`() {
+        let found = SimulatorKitFramework.path(developerDir: Self.dev) {
+            $0 == Self.privatePath
+        }
+
+        #expect(found == Self.privatePath)
+    }
+
+    @Test func `finds SimulatorKit under SharedFrameworks in the Xcode 27 layout`() {
+        let found = SimulatorKitFramework.path(developerDir: Self.dev) {
+            $0 == Self.sharedPath
+        }
+
+        #expect(found == Self.sharedPath)
+    }
+
+    @Test func `prefers the PrivateFrameworks location when both exist`() {
+        // Belt-and-braces: an Xcode carrying both layouts must keep
+        // resolving to the path that shipped working input on 26.
+        let found = SimulatorKitFramework.path(developerDir: Self.dev) { _ in true }
+
+        #expect(found == Self.privatePath)
+    }
+
+    @Test func `finds nothing when neither location exists`() {
+        let found = SimulatorKitFramework.path(developerDir: Self.dev) { _ in false }
+
+        #expect(found == nil)
+    }
+
+    @Test func `offers both known locations as candidates`() {
+        // The diagnostic path prints these, so both the order and the
+        // absence of a `..` segment are part of the contract.
+        #expect(
+            SimulatorKitFramework.candidatePaths(developerDir: Self.dev)
+                == [Self.privatePath, Self.sharedPath]
+        )
+    }
+}


### PR DESCRIPTION
Fixes #28.

Xcode 27 relocated two things baguette depends on. Each breaks a different
feature, and both had to move for simulator control to work again.

## 1. SimulatorKit.framework moved

`Contents/Developer/Library/PrivateFrameworks/` → `Contents/SharedFrameworks/`.
The new location is a *sibling* of `Contents/Developer`, so it can't be reached
by appending to what `xcode-select -p` reports. All six `dlopen` sites hardcoded
the old path — hence the failure in the issue.

Machines with Xcode 26 *also* installed were already fine: `developerDir()`
rejects any Xcode lacking SimulatorKit and scans `/Applications` for one that
has it. Only a 27-exclusive machine — the reporter's — fails.

`SimulatorKitFramework` is now the single place that knows both layouts, probing
oldest-first so Xcode ≤26 resolves exactly as before. When no Xcode carries it,
the raw dyld error is replaced by a message naming both paths searched.

## 2. Screen dimensions moved

Xcode 27 dropped `mainScreenWidth` / `mainScreenHeight` / `mainScreenScale` from
each device type's `profile.plist` — **124 of 124 device types carry them on
Xcode 26, 0 of 124 on Xcode 27** — and publishes the same values in a sibling
`capabilities.plist` under `capabilities.displays`.

Only the 9-slice chrome path reads a screen size; the composite path returns its
baked PDF first. So every iPad plus iPhone 17e lost its bezel while iPhone 17 Pro
kept one. The iPhone in that set is what ruled out an iPad-asset explanation —
the chrome bundles' `Resources` are byte-identical to Xcode 26.

`DeviceProfile` reads both shapes, preferring the profile's own keys. The
`integrated` display is matched explicitly rather than taking `displays.first`:
the same list carries `tvOut` and `carPlay` at 720×480 and a resizable `scene`
entry at 7680×4320, any of which would size a bezel wrongly.

## Evidence

Verified on real Xcode 27 beta 3 (`27A5218g`) — the reporter's build.

| | Xcode 27 (`xcode-27` runner) | Xcode 26 (`macos-latest`) |
|---|---|---|
| SimulatorKit resolves | ✅ | ✅ |
| Tests | ✅ 788/788 | ✅ 788/788 |

The new `xcode-27` workflow asserts the relocation directly, so it fails loudly
if a later beta moves the framework again. That image ships Xcode 27 and **no**
Xcode 26, which matters: on a machine with both, `developerDir()` falls back to
26 and everything passes whether or not the fix is present — a green local run
proves nothing. The job also asserts no Xcode 26 is present, so it can't start
passing for the wrong reason.

Chrome fix verified against real Xcode 27 assets locally: all 7 chrome
integration tests pass where 6 failed.

Input confirmed working end-to-end through Xcode 27's SimulatorKit — the 9-arg
`IndigoHIDMessageForMouseNSEvent` recipe still drives touches, with
`/Applications/Xcode-27.0.0-Beta.3.app/Contents/SharedFrameworks/SimulatorKit.framework`
confirmed as the loaded image in the running server.

## Not affected

Contrary to reports against other simulator tools, baguette never shells out to
`open -a Simulator.app` and never writes the `com.apple.iphonesimulator` prefs
domain, so Xcode 27 removing both changes nothing here. `-[SimDevice booted]`
also doesn't apply — device state is read via KVC (`value(forKey: "state")`).

## Verified on a real iOS 27 runtime

Since opening this, the iOS 27.0 runtime (`24A5380i`) was installed and the
whole surface re-checked against it, under Xcode 27:

| | iOS 27.0 |
|---|---|
| Device enumeration | ✅ 13 devices, correct states |
| Screenshot | ✅ 1206×2622, real frame |
| Chrome / bezel | ✅ composes correctly |
| Input (tap / swipe / gestures) | ✅ driven interactively |
| Paste / clipboard | ✅ |
| Location | ✅ |

Input, paste and location were exercised by hand against a booted iOS 27
simulator — three separate subsystems (Indigo HID, `SimPasteboardPlus`, and the
simctl location route), not just the touch path.

The same surface was also checked against an **iOS 26.5 guest under Xcode 27**,
which is worth calling out separately: that mixed configuration — new toolchain,
runtimes already on disk — is what most people will be in immediately after
upgrading, since runtimes are a deferred multi-GB download.

The chrome result is the load-bearing evidence here, and it holds for a
simpler reason than first claimed. An earlier revision of this description
argued from `iPad Pro 11-inch (M5)` being "a device type that exists only in
Xcode 27" — **that premise was wrong**. Xcode 26.6 ships it too, carrying
legacy keys (`1668x2420 @2x`), as a pre-upgrade snapshot of the machine
confirms.

The conclusion survives without it: at the time that bezel was composed, the
host had **0 of 124** device types carrying `mainScreen*` keys. No legacy
values existed for *any* device, so the screen size can only have come from
`capabilities.plist` — the path this PR adds. The general measurement, not the
device-specific argument, is what carries it.

`-[SimDevice booted]: unrecognized selector`, reported against other tools on
iOS 27 simulators, did not appear: device state is read via KVC.

## Confirmed on macOS 27

The last remaining gap is now closed. Every result above came from macOS 26 — my
machine and GitHub's runners both — leaving macOS 27 as a prediction rather than
a measurement. @bo2themax, who filed #28, has since run this branch on **macOS 27
beta 3 with Xcode 27 beta 3** and reports it working, with the HID symbols
resolving and input reaching the simulator.

## Xcode 26 non-regression

Checked afterwards, on a machine returned to Xcode 26.6 with Xcode 27 removed.

This turned out to need care. Xcode 27's installer had rewritten all 124
`profile.plist` files in the shared `CoreSimulator/Profiles/DeviceTypes` tree,
stripping the legacy keys — and **uninstalling Xcode 27 does not undo that**.
The change is also easy to miss: the installer preserves `mtime` from its
package payload, so those files still date to June; only `ctime` records the
real write. That directory is a DataVault, so it cannot be restored by hand
even as root.

So the legacy tree was rebuilt in userland from a pre-upgrade snapshot —
`profile.plist` carrying `mainScreen*`, no `capabilities.plist` at all — and the
real chain (`LiveChromes` → `FileSystemChromeStore` → rasterizer) driven against
it via the injectable `deviceTypesRoot`. All 7 chrome identifiers compose
correctly, alongside a guard assertion that the fixture really is legacy-shaped,
so those passes cannot be arriving via the capabilities path.

| | Result |
|---|---|
| Chrome chain, legacy shape | 7/7 identifiers compose |
| Fixture-shape guard | legacy keys present, no `capabilities.plist` |
| Full suite, Xcode 26.6 | 788/788 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136DDH2Nfj349K8PPSvGDwz
