### PR TITLE
fix(serve): stop the segfault on non-booted sims, and give them a Boot button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Added
+
+- **Boot a device from its own tab.** Opening `/simulators/<udid>` on a
+  simulator that isn't running used to mount a bezel around a stream that
+  would never carry a frame — a black rectangle with no explanation and no
+  way forward but the back button. The device's screen now carries a Boot
+  button, waits out the boot, and hands the screen to the live stream when
+  the first frame paints. Guest-dependent toolbar controls (rotate, camera,
+  status bar, location, logs, AX, home, screenshot, app switcher) are dimmed
+  until then; the back link and theme toggle stay live. The card also picks
+  up a boot started from anywhere else — `baguette boot`, another tab, Xcode,
+  `simctl` — without a click, and says so plainly when the UDID isn't in the
+  device set at all. No new endpoint: `/simulators.json` already carried
+  `state` and `POST /simulators/<udid>/boot` already existed. See
+  [`docs/features/boot.md`](docs/features/boot.md).
+
 ### Fixed
 
 - **`baguette serve` no longer segfaults when a tab opens on a non-booted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Fixed
+
+- **`baguette serve` no longer segfaults when a tab opens on a non-booted
+  simulator.** The simulator page POSTs `/orientation?value=portrait` on load,
+  which asks CoreSimulator for the device's `PurpleWorkspacePort`. A shutdown
+  device has none, so the lookup writes back an `NSError` — and the adapter's
+  `@convention(c)` thunk typed that ObjC `NSError **` out-parameter as a plain
+  `UnsafeMutablePointer<NSError?>` instead of an
+  `AutoreleasingUnsafeMutablePointer`. ARC then released an autoreleased error
+  it never owned, and the process died at the next autorelease-pool pop —
+  inside an unrelated task, which is why the crash reports pointed at
+  `objc_autoreleasePoolPop` with no baguette frame in sight. Booted devices
+  were never affected: the lookup succeeds and no error is written. Orientation
+  on a non-booted device now fails cleanly with a 500 instead of taking the
+  server down.
+
 ---
 
 ## [0.1.84] - 2026-07-23

--- a/Sources/Baguette/Infrastructure/Orientation/PurpleEventOrientation.swift
+++ b/Sources/Baguette/Infrastructure/Orientation/PurpleEventOrientation.swift
@@ -43,12 +43,24 @@ final class PurpleEventOrientation: Orientation, @unchecked Sendable {
 /// name. Mirrors idb's `[simulator.device lookup:@"…" error:&err]`.
 /// Returns `nil` when CoreSimulator hasn't vended that port (e.g.
 /// device not booted yet) or the selector isn't present.
+///
+/// The out-parameter is typed `AutoreleasingUnsafeMutablePointer` —
+/// the same shape every other `…WithError:` thunk in this codebase
+/// uses (see `invokeBoolWithError` and friends), and the only one that
+/// matches ObjC's `NSError * __autoreleasing *` ownership. What comes
+/// back through it is a **+0, autoreleased** error: it belongs to the
+/// surrounding pool, not to us. A plain `UnsafeMutablePointer<NSError?>`
+/// would let ARC release it on our behalf as well, and the process
+/// would die at the next pool pop — far from here, in whatever task
+/// happened to be draining. Booted devices never hit this: the lookup
+/// succeeds and CoreSimulator writes no error at all, which is why it
+/// only ever crashed on a *shutdown* simulator.
 private func lookupMachPort(on device: NSObject, named name: String) -> UInt32? {
     let sel = NSSelectorFromString("lookup:error:")
     guard device.responds(to: sel) else { return nil }
     let imp = device.method(for: sel)
     typealias Lookup = @convention(c) (
-        AnyObject, Selector, NSString, UnsafeMutablePointer<NSError?>?
+        AnyObject, Selector, NSString, AutoreleasingUnsafeMutablePointer<NSError?>
     ) -> UInt32
     let fn = unsafeBitCast(imp, to: Lookup.self)
     var err: NSError?

--- a/Sources/Baguette/Resources/Web/sim-native.html
+++ b/Sources/Baguette/Resources/Web/sim-native.html
@@ -196,6 +196,112 @@
     max-height: min(calc(100dvh - 68px), calc(100vw - 32px)) !important;
   }
 
+  /* --- Power card ---------------------------------------------------
+     Shown on the device's own screen when the simulator isn't booted.
+     The bezel renders normally (chrome comes from `definition.json`,
+     which doesn't need a running guest), so the tab still looks like
+     the device it is — the glass just carries a Boot button instead of
+     a live framebuffer.
+
+     Deliberately black in BOTH themes: a powered-off phone screen is
+     black, and the card sits inside the screen cutout, not on the
+     page. Built by `sim-native.js` and appended to the SDK's
+     screenArea, so it inherits the bezel's border-radius clip. */
+  #simNativeView .power-card {
+    position: absolute; inset: 0;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    gap: 14px;
+    padding: 8% 12%;
+    box-sizing: border-box;
+    text-align: center;
+    background: radial-gradient(120% 90% at 50% 40%, #17171c 0%, #08080a 100%);
+    cursor: default;
+    z-index: 5;
+    animation: nv-power-in 0.24s ease both;
+    /* Type scales with the rendered screen, not the viewport — the
+       bezel shrinks on narrow windows and on landscape rotation, and
+       `cqw` on the children resolves against this box. */
+    container-type: inline-size;
+  }
+  @keyframes nv-power-in { from { opacity: 0; } to { opacity: 1; } }
+
+  /* No definition for this udid — there's no bezel to sit inside, so
+     the card supplies its own phone-shaped silhouette in the empty
+     device slot rather than collapsing to nothing.
+
+     Sized from the height so it can never overflow the viewport: the
+     width follows from the aspect ratio, the way the real bezel does. */
+  #simNativeView .power-card--bare {
+    position: relative; inset: auto;
+    height: min(640px, calc(100vh - 110px));
+    height: min(640px, calc(100dvh - 110px));
+    aspect-ratio: 9 / 19.5;
+    width: auto;
+    max-width: 78vw;
+    border-radius: 44px;
+    border: 1px solid rgba(255, 255, 255, 0.09);
+  }
+
+  #simNativeView .power-card .power-glyph {
+    color: rgba(245, 245, 247, 0.85);
+    flex-shrink: 0;
+  }
+  /* Spins while a boot is in flight. */
+  #simNativeView .power-card[data-phase="booting"] .power-glyph,
+  #simNativeView .power-card[data-phase="starting"] .power-glyph {
+    animation: nv-power-spin 1.4s linear infinite;
+    color: rgba(245, 245, 247, 0.6);
+  }
+  @keyframes nv-power-spin { to { transform: rotate(360deg); } }
+
+  #simNativeView .power-card .power-title {
+    color: #f5f5f7;
+    font: 600 clamp(13px, 4.2cqw, 17px)/1.25 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+    letter-spacing: 0.01em;
+  }
+  #simNativeView .power-card .power-sub {
+    color: rgba(245, 245, 247, 0.5);
+    font: 500 clamp(10px, 3.2cqw, 12px)/1.4 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+    max-width: 26ch;
+  }
+  /* Boot failures — the message from the server, not a generic retry
+     prompt. Amber rather than red: the device is fine, the boot isn't. */
+  #simNativeView .power-card .power-sub[data-error] {
+    color: #fbbf24;
+  }
+
+  #simNativeView .power-card .power-btn {
+    appearance: none;
+    margin-top: 2px;
+    padding: 9px 26px;
+    border: 0; border-radius: 999px;
+    background: var(--nv-accent); color: var(--nv-accent-text);
+    font: 600 clamp(11px, 3.4cqw, 13px)/1 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+    cursor: pointer;
+    transition: filter 0.12s ease, transform 0.12s ease;
+  }
+  #simNativeView .power-card .power-btn:hover:not(:disabled) { filter: brightness(1.12); }
+  #simNativeView .power-card .power-btn:active:not(:disabled) { transform: scale(0.97); }
+  #simNativeView .power-card .power-btn:disabled {
+    opacity: 0.45; cursor: default;
+  }
+
+  /* Toolbar gating. Every control in the scroll strip (rotate, AX,
+     status bar, location, camera, logs, home, screenshot, app
+     switcher) and the format picker needs a live guest — dim and
+     disable them until the stream is up. The back link, theme
+     toggle and sidebar-view toggle stay reachable: those are how the
+     user leaves a device that won't boot. */
+  #simNativeView[data-power] #nativeToolScroll,
+  #simNativeView[data-power] #nativeFormatPicker {
+    opacity: 0.35;
+    pointer-events: none;
+  }
+  #simNativeView[data-power] #nativeStatus {
+    color: var(--nv-text-faint);
+  }
+
   /* Label group — clickable, returns to the simulator list. The
      chevron + device name + OS subtitle read as one breadcrumb. */
   #simNativeView .tb-label {

--- a/Sources/Baguette/Resources/Web/sim-native.js
+++ b/Sources/Baguette/Resources/Web/sim-native.js
@@ -40,6 +40,9 @@
   let locationPanel = null;  // LocationPanel — simctl location map picker
   let lastPaintedSize = { w: 0, h: 0 };
   let deviceName = '';
+  let powerCard = null;      // boot affordance shown on an unbooted device's screen
+  let bootPollTimer = null;  // /simulators.json poll while a boot is in flight
+  let firstFrameTimer = null; // fallback so the card can't outlive a live stream
 
   // CW rotation cycle. Two flavours — iPhone UIKit refuses
   // `portrait-upside-down` for apps that don't opt in (which is
@@ -286,23 +289,43 @@
     //    edge flags from the rotated visual frame to portrait
     //    (iOS expects portrait coords regardless of the bezel's
     //    CSS rotation).
-    sim = await window.Baguette.use({
-      host: location.origin,
-      udid,
-      send: (payload) => {
-        if (!session) return;
-        const out = currentOrientation === 'portrait'
-          ? payload
-          : remapEnvelopeToPortrait(payload);
-        session.send(out);
-      },
-      getOrientation: () => currentOrientation,
-      log: (msg) => console.log('[native]', msg),
-    });
-    sim.mount(document.getElementById('nativeDeviceFrame'));
+    //
+    //    `use` rejects when `definition.json` 404s — the udid isn't in
+    //    the device set (deep link to a deleted device, typo'd UDID) or
+    //    the model has no DeviceKit chrome. Without the catch the whole
+    //    bootstrap unwinds and the tab sits blank; the power card says
+    //    so instead.
+    try {
+      sim = await window.Baguette.use({
+        host: location.origin,
+        udid,
+        send: (payload) => {
+          if (!session) return;
+          const out = currentOrientation === 'portrait'
+            ? payload
+            : remapEnvelopeToPortrait(payload);
+          session.send(out);
+        },
+        getOrientation: () => currentOrientation,
+        log: (msg) => console.log('[native]', msg),
+      });
+      sim.mount(document.getElementById('nativeDeviceFrame'));
+    } catch (e) {
+      console.warn('[native] no device definition:', (e && e.message) || e);
+      sim = null;
+    }
 
-    // 4. Open stream — paints frames into sim.canvas.
-    startSession(pickFormat());
+    // 4. Open stream — but only if there's a guest to stream. A
+    //    shutdown device has no framebuffer, no HID, and no
+    //    PurpleWorkspacePort; opening the socket would just paint
+    //    black forever with no hint as to why. Show the power card on
+    //    the device's own screen instead and start the stream once
+    //    the user boots it (or once the boot already underway lands).
+    if (sim && isBooted(meta.state)) {
+      startSession(pickFormat());
+    } else {
+      showPowerCard(sim ? meta.state : '');
+    }
 
     wireActions();
     wireToolbarScroll();
@@ -326,6 +349,14 @@
     // — the bezel renders un-rotated but the iOS framebuffer
     // shows UI from the stale orientation, which looks upside
     // down to the user.
+    //
+    // Only meaningful once the guest is up: an unbooted device has no
+    // PurpleWorkspacePort to send the GSEvent to. `resetToPortrait`
+    // runs again after a boot completes.
+    if (isBooted(meta.state)) resetToPortrait();
+  }
+
+  function resetToPortrait() {
     fetch('/simulators/' + encodeURIComponent(udid) + '/orientation?value=portrait',
         { method: 'POST' }).catch(() => { /* best-effort */ });
   }
@@ -391,7 +422,12 @@
     session = new window.StreamSession({
       udid, format, version: 'v2',
       canvas: sim.canvas,
-      onSize: (w, h) => { lastPaintedSize = { w, h }; },
+      onSize: (w, h) => {
+        lastPaintedSize = { w, h };
+        // First frame after a boot — the guest is genuinely up, so
+        // drop the power card and hand the screen back to the stream.
+        hidePowerCard();
+      },
       onFps:  (fps) => {
         const el = document.getElementById('nativeStatus');
         if (el) el.textContent = fps + ' fps';
@@ -406,6 +442,199 @@
     // portrait while the simulator is still landscape.
     if (currentOrientation !== 'portrait') applyOrientation(currentOrientation);
     mountAxInspector();
+  }
+
+  // --- Power card ----------------------------------------------------
+  // A tab opened on a device that isn't running used to load a bezel
+  // wrapped around a socket that would never carry a frame — no boot
+  // control anywhere in focus mode, so the only way out was back to
+  // the list. The card puts the boot control on the device's own
+  // screen and drives the wait, then hands the screen to the stream.
+  //
+  // Three phases:
+  //   off      — Boot button. The device is Shutdown (or shutting down).
+  //   booting  — POST sent (or the device was already Booting when the
+  //              tab opened); polling /simulators.json for "Booted".
+  //   starting — CoreSimulator says Booted; the stream is open and
+  //              we're waiting on the first composited frame.
+  // `gone` is the degenerate case: the udid isn't in the device set at
+  // all, so there is nothing to boot.
+
+  const BOOT_POLL_MS = 1000;
+  const BOOT_TIMEOUT_MS = 180000;   // cold boots on a busy Mac are slow
+  const FIRST_FRAME_TIMEOUT_MS = 15000;
+  const IDLE_POLL_MS = 4000;        // watch for a boot we didn't start
+
+  function isBooted(state) {
+    return String(state || '') === 'Booted';
+  }
+
+  function showPowerCard(state) {
+    hidePowerCard();
+
+    // Normally the card goes on the device's own glass. With no
+    // definition there's no bezel to sit inside, so it stands alone in
+    // the empty device slot and gets its own device-ish silhouette.
+    const glass = sim && sim.screenArea;
+    const host = glass || document.getElementById('nativeDeviceFrame');
+    if (!host) return;
+
+    powerCard = document.createElement('div');
+    powerCard.className = glass ? 'power-card' : 'power-card power-card--bare';
+    // The SDK's PointerInterpreter is attached to the same screenArea.
+    // Without this, clicking Boot also dispatches a tap gesture at the
+    // button's coords into a simulator that can't receive it.
+    ['pointerdown', 'pointerup', 'pointermove', 'mousedown', 'mouseup', 'click']
+        .forEach((evt) => powerCard.addEventListener(evt, (e) => e.stopPropagation()));
+    host.appendChild(powerCard);
+
+    if (!state) {
+      renderPowerCard('gone');
+    } else if (String(state) === 'Booting') {
+      // Someone else already started it — join the wait rather than
+      // POSTing a second boot.
+      renderPowerCard('booting');
+      waitForBoot();
+    } else {
+      renderPowerCard('off');
+    }
+  }
+
+  function hidePowerCard() {
+    if (!powerCard && !bootPollTimer && !firstFrameTimer) return;
+    if (bootPollTimer)   { clearTimeout(bootPollTimer);   bootPollTimer = null; }
+    if (firstFrameTimer) { clearTimeout(firstFrameTimer); firstFrameTimer = null; }
+    if (powerCard && powerCard.parentNode) powerCard.parentNode.removeChild(powerCard);
+    powerCard = null;
+    const view = document.getElementById('simNativeView');
+    if (view) view.removeAttribute('data-power');
+  }
+
+  const POWER_GLYPH =
+      '<path d="M12 3.5v7.5"/>' +
+      '<path d="M6.9 6.9a7.5 7.5 0 1 0 10.2 0"/>';
+  const SPIN_GLYPH =
+      '<circle cx="12" cy="12" r="8.6" stroke-opacity="0.22"/>' +
+      '<path d="M20.6 12A8.6 8.6 0 0 0 12 3.4"/>';
+
+  // Renders one phase into the existing card. `detail` overrides the
+  // subtitle — used to surface a boot failure verbatim instead of a
+  // generic "try again".
+  function renderPowerCard(phase, detail) {
+    if (!powerCard) return;
+    // Whatever poll belonged to the previous phase is done with.
+    if (bootPollTimer) { clearTimeout(bootPollTimer); bootPollTimer = null; }
+    powerCard.setAttribute('data-phase', phase);
+    // Presence of `data-power` on the root is what dims the toolbar;
+    // the value carries the phase for anyone inspecting the DOM.
+    const view = document.getElementById('simNativeView');
+    if (view) view.setAttribute('data-power', phase);
+
+    const copy = {
+      off:      { title: 'Not booted',  sub: deviceName || 'This simulator', btn: 'Boot' },
+      booting:  { title: 'Booting…',    sub: 'Waiting for CoreSimulator',    btn: null },
+      starting: { title: 'Starting…',   sub: 'Waiting for the first frame',  btn: null },
+      gone:     { title: 'Unavailable', sub: 'This simulator is no longer in the device set.', btn: null },
+    }[phase] || {};
+
+    const glyph = (phase === 'booting' || phase === 'starting') ? SPIN_GLYPH : POWER_GLYPH;
+    powerCard.innerHTML =
+        '<svg class="power-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+        'stroke-width="1.7" stroke-linecap="round" width="34" height="34" aria-hidden="true">' +
+        glyph + '</svg>' +
+        '<div class="power-title"></div>' +
+        '<div class="power-sub"></div>' +
+        (copy.btn ? '<button class="power-btn" type="button"></button>' : '');
+
+    powerCard.querySelector('.power-title').textContent = copy.title || '';
+    const sub = powerCard.querySelector('.power-sub');
+    sub.textContent = detail || copy.sub || '';
+    if (detail) sub.setAttribute('data-error', 'true');
+
+    const btn = powerCard.querySelector('.power-btn');
+    if (btn) {
+      btn.textContent = copy.btn;
+      btn.addEventListener('click', requestBoot);
+    }
+
+    const status = document.getElementById('nativeStatus');
+    if (status) status.textContent = phase === 'gone' ? 'unavailable' : 'not booted';
+
+    if (phase === 'off') watchForExternalBoot();
+  }
+
+  // While the Boot button is up, keep an eye on the device — it can
+  // come up from anywhere: `baguette boot`, another tab, Xcode,
+  // `simctl`. Without this the card would sit on "Not booted" over an
+  // already-running guest until the user clicked a button they no
+  // longer needed (and CoreSimulator rejects a boot in that state, so
+  // the click would report a failure that isn't one).
+  function watchForExternalBoot() {
+    bootPollTimer = setTimeout(async () => {
+      bootPollTimer = null;
+      if (!powerCard || powerCard.getAttribute('data-phase') !== 'off') return;
+      const meta = await fetchDeviceMeta(udid);
+      if (!powerCard) return;
+      if (isBooted(meta.state)) onBooted();
+      else watchForExternalBoot();
+    }, IDLE_POLL_MS);
+  }
+
+  // POST /simulators/<udid>/boot, then poll until CoreSimulator agrees.
+  // The route is synchronous on the server side (it calls
+  // `bootWithOptions:error:`), but "returned" only means the boot was
+  // accepted — the guest keeps coming up afterwards, which is what the
+  // poll is for.
+  async function requestBoot() {
+    renderPowerCard('booting');
+    try {
+      const r = await fetch('/simulators/' + encodeURIComponent(udid) + '/boot',
+          { method: 'POST' });
+      if (!r.ok) {
+        // CoreSimulator refuses a boot when the device is already
+        // booted. If that's why this failed, the user got what they
+        // wanted — go live instead of reporting an error.
+        const meta = await fetchDeviceMeta(udid);
+        if (isBooted(meta.state)) { onBooted(); return; }
+        const body = await r.json().catch(() => null);
+        renderPowerCard('off', (body && body.error) || ('boot failed (HTTP ' + r.status + ')'));
+        return;
+      }
+    } catch (e) {
+      renderPowerCard('off', 'boot request failed — is the server still running?');
+      return;
+    }
+    waitForBoot();
+  }
+
+  function waitForBoot(deadline) {
+    const until = deadline || (Date.now() + BOOT_TIMEOUT_MS);
+    bootPollTimer = setTimeout(async () => {
+      if (!powerCard) return;            // card dismissed underneath us
+      const meta = await fetchDeviceMeta(udid);
+      if (isBooted(meta.state)) {
+        onBooted();
+        return;
+      }
+      if (Date.now() >= until) {
+        renderPowerCard('off',
+            'still not booted after ' + Math.round(BOOT_TIMEOUT_MS / 60000) + ' min');
+        return;
+      }
+      waitForBoot(until);
+    }, BOOT_POLL_MS);
+  }
+
+  // CoreSimulator flipped to Booted. That's earlier than SpringBoard
+  // being on screen, so keep the card up (as "Starting…") until a
+  // frame actually lands — with a fallback, because the stream only
+  // emits when SimulatorKit composites and a device sitting on a
+  // static screen may not composite anything for a while.
+  function onBooted() {
+    renderPowerCard('starting');
+    startSession(pickFormat());
+    resetToPortrait();
+    firstFrameTimer = setTimeout(hidePowerCard, FIRST_FRAME_TIMEOUT_MS);
   }
 
   // Lazy-mounts the AXInspector once a surface + session are ready.
@@ -481,10 +710,14 @@
           name: hit.name || 'Simulator',
           runtime: hit.displayRuntime
               || formatRuntime(hit.runtime || hit.os || ''),
+          // `SimulatorState.description` — "Booted" / "Shutdown" /
+          // "Booting" / "ShuttingDown" / "Creating". Absent only if
+          // the device vanished between page load and this fetch.
+          state: hit.state || '',
         };
       }
     } catch (_) { /* fall through */ }
-    return { name: 'Simulator', runtime: '' };
+    return { name: 'Simulator', runtime: '', state: '' };
   }
 
   function formatRuntime(raw) {
@@ -741,6 +974,7 @@
 
   function wireUnload() {
     window.addEventListener('beforeunload', () => {
+      try { hidePowerCard(); } catch (_) { /* ignore */ }
       try { if (session) session.stop(); } catch (_) { /* ignore */ }
       try { if (sim) sim.detach(); } catch (_) { /* ignore */ }
       try { if (axInspector) axInspector.detach(); } catch (_) { /* ignore */ }

--- a/Tests/BaguetteTests/Orientation/PurpleEventOrientationTests.swift
+++ b/Tests/BaguetteTests/Orientation/PurpleEventOrientationTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Mockable
+import Testing
+@testable import Baguette
+
+/// A `SimDevice` stand-in that answers `lookup:error:` the way
+/// CoreSimulator does for a device that isn't booted: no port, and an
+/// `NSError` written back through the out-parameter.
+///
+/// `error:` is an ObjC `NSError **` — i.e. `__autoreleasing`. The
+/// callee hands back a **+0, autoreleased** reference: it belongs to
+/// the surrounding autorelease pool, not to the caller. Modelling that
+/// faithfully is the whole point of this fake, so `NSErrorPointer`
+/// (`AutoreleasingUnsafeMutablePointer<NSError?>?`) is the parameter
+/// type — its setter retains + autoreleases exactly as ObjC does.
+private final class UnbootedFakeDevice: NSObject {
+    let error: NSError
+    /// Extra strong references so an over-release on the caller's side
+    /// can't drive the error to zero and crash the whole test runner —
+    /// it shows up as a retain-count mismatch below instead.
+    private let pins: [NSError]
+
+    init(error: NSError) {
+        self.error = error
+        self.pins = [error, error, error]
+        super.init()
+    }
+
+    @objc(lookup:error:)
+    func lookup(_ name: NSString, error outError: NSErrorPointer) -> UInt32 {
+        outError?.pointee = error
+        return 0
+    }
+}
+
+/// Error-path coverage for `PurpleEventOrientation` — the branch a
+/// non-booted simulator takes. The happy path (a live
+/// `PurpleWorkspacePort` + `mach_msg_send`) is integration-only.
+@Suite("PurpleEventOrientation — unbooted device")
+struct PurpleEventOrientationTests {
+
+    @Test func `set reports failure when the device vends no PurpleWorkspacePort`() {
+        let host = MockDeviceHost()
+        let device = UnbootedFakeDevice(
+            error: NSError(domain: "com.apple.CoreSimulator.SimError", code: 405)
+        )
+        given(host).resolveDevice(udid: .any).willReturn(device)
+
+        let orientation = PurpleEventOrientation(udid: "unbooted", host: host)
+
+        // Drained while `device` still pins the error: the whole point of
+        // the bug below is that the pool holds a reference the adapter
+        // must not have consumed.
+        let result = autoreleasepool { orientation.set(.portrait) }
+
+        withExtendedLifetime(device) {
+            #expect(result == false)
+        }
+    }
+
+    /// The crash this suite exists for: `serve` segfaulted whenever a
+    /// browser tab opened on a non-booted simulator, because the page
+    /// POSTs `/orientation?value=portrait` on load. `lookup:error:`
+    /// wrote back an autoreleased `NSError`, the adapter released it as
+    /// if it owned it, and the process died at the next autorelease-pool
+    /// pop — inside an unrelated task, which is why the backtrace
+    /// pointed at `objc_autoreleasePoolPop` rather than at orientation.
+    ///
+    /// Asserted as retain-count parity across a pool drain: the error is
+    /// pinned by extra strong references so a double-release shows up as
+    /// a failed expectation instead of taking the test runner down with
+    /// it.
+    @Test func `set does not consume the error reference CoreSimulator wrote back`() {
+        let error = NSError(domain: "com.apple.CoreSimulator.SimError", code: 405)
+        let host = MockDeviceHost()
+        let device = UnbootedFakeDevice(error: error)
+        given(host).resolveDevice(udid: .any).willReturn(device)
+        let orientation = PurpleEventOrientation(udid: "unbooted", host: host)
+
+        let before = CFGetRetainCount(error as CFTypeRef)
+        autoreleasepool {
+            _ = orientation.set(.portrait)
+        }
+        let after = CFGetRetainCount(error as CFTypeRef)
+
+        withExtendedLifetime(device) {
+            #expect(after == before)
+        }
+    }
+}

--- a/docs/features/boot.md
+++ b/docs/features/boot.md
@@ -1,0 +1,131 @@
+# Booting a device
+
+Every baguette surface that shows a simulator can also start one. The
+CLI has `baguette boot`, the list page and the device farm have boot
+buttons, and — as of this feature — so does **focus mode**
+(`/simulators/<udid>`), which is where a deep link lands you.
+
+Focus mode used to assume a running guest. Opening a tab on a device
+that wasn't booted mounted the bezel, opened a stream WebSocket that
+would never carry a frame, and left you looking at a black rectangle
+with no explanation and no way forward except navigating back to the
+list. Now the device's own screen carries the boot control.
+
+## Entry points
+
+| Surface | Invocation |
+|---------|------------|
+| **CLI** | `baguette boot --udid <UDID>` |
+| **HTTP** | `POST /simulators/<UDID>/boot` → `{"ok":true}`, or `{"ok":false,"error":"…"}` with a 404 (unknown udid) / 500 (boot refused) |
+| **Focus mode** | Open `/simulators/<UDID>` on a shutdown device — the screen shows **Boot** |
+| **List page** | `/simulators` — boot / shutdown buttons per row |
+| **Device farm** | `/farm` — per-tile and bulk boot |
+
+All of them land on the same `Simulator.boot()`, which tries
+`bootWithOptions:error:` with `{"persist": true}` first (headless boot
+that survives the client disconnecting) and falls back to
+`bootWithError:`. See `Sources/Baguette/Infrastructure/Simulator/CoreSimulator.swift`.
+
+## Focus-mode flow
+
+`sim-native.js` already fetched `/simulators.json` on load to resolve
+the device's name and runtime; it now reads `state` from the same
+response. No new endpoint, no change to the definition payload.
+
+```
+GET /simulators/<udid>          ← deep link
+      │
+      ▼
+GET /simulators.json            ← name · runtime · state
+      │
+      ├── state == "Booted" ────▶ startSession() + reset to portrait
+      │
+      └── anything else ───────▶ power card on the device's glass
+                                    │
+                     ┌──────────────┴───────────────┐
+                     │ off       Boot button        │◀── polls every 4 s
+                     │ booting   POST /boot, poll   │    for a boot
+                     │ starting  stream open,       │    started elsewhere
+                     │           awaiting frame 1   │
+                     │ gone      no such device     │
+                     └──────────────┬───────────────┘
+                                    ▼
+                     first frame paints → card clears,
+                     toolbar re-enables
+```
+
+The card lives inside the SDK bezel's `screenArea`, so it inherits the
+screen cutout's rounded clip and looks like a powered-off phone rather
+than a modal over the page. It is black in both light and dark themes
+for the same reason.
+
+### The four phases
+
+- **off** — the device is `Shutdown` / `ShuttingDown` / `Creating`. Shows
+  the Boot button, and polls `/simulators.json` every 4 s so a boot
+  started from anywhere else (`baguette boot`, another tab, Xcode,
+  `simctl`) is picked up without a click.
+- **booting** — `POST /boot` accepted, or the device was already
+  `Booting` when the tab opened (in which case no second boot is sent).
+  Polls once a second for up to 3 minutes.
+- **starting** — CoreSimulator reports `Booted`. That's earlier than
+  SpringBoard being on screen, so the stream opens but the card stays up
+  until a frame actually paints. A 15 s fallback clears it regardless:
+  `Screen` is pure pass-through and only emits when SimulatorKit
+  composites, so a device sitting on a static screen may not produce a
+  frame promptly.
+- **gone** — `definition.json` 404s, i.e. the udid isn't in the device
+  set at all. Nothing to boot; the card says so instead of leaving the
+  tab blank.
+
+### Toolbar gating
+
+While the card is up, `#simNativeView` carries `data-power="<phase>"`,
+which dims and disables `#nativeToolScroll` and `#nativeFormatPicker`.
+Rotate, camera, status bar, location, logs, AX inspector, home,
+screenshot and app switcher all need a live guest. The back link, theme
+toggle and sidebar-view toggle stay active — those are how you leave a
+device that won't boot.
+
+The portrait reset that focus mode fires on load is gated the same way:
+an unbooted device has no `PurpleWorkspacePort` to receive the GSEvent.
+
+## Where the state string comes from
+
+`/simulators.json` projects `SimulatorState.description` verbatim:
+`"Creating"`, `"Shutdown"`, `"Booting"`, `"Booted"`, `"ShuttingDown"`
+(`Sources/Baguette/Domain/Simulator/Simulator.swift`). The browser
+compares against `"Booted"` and treats everything else as not-ready, so
+a new state added on the Swift side degrades to "show the Boot button"
+rather than to a broken page.
+
+## Adding a lifecycle control to focus mode
+
+1. The route probably exists — check `Server.registerRoutes`; `boot` and
+   `shutdown` are both already there via `Server.lifecycle`.
+2. Read whatever state you need from `fetchDeviceMeta` in
+   `sim-native.js`; extend its return value rather than adding a fetch.
+3. Render through `renderPowerCard(phase, detail)` — add a phase to the
+   `copy` table and, if it needs a spinner, to the `SPIN_GLYPH` branch.
+4. Style it in the `--- Power card ---` block of `sim-native.html`. The
+   card is a container (`container-type: inline-size`), so type sizes
+   use `cqw` and track the rendered bezel, not the viewport.
+5. Keep the frontend a dumb sender: no state machine duplicated from
+   Swift, no derived capability flags. It reads a state string and posts
+   a verb.
+
+## Limits
+
+- Boot progress is binary. CoreSimulator reports `Booted` the moment the
+  device's services are up, which is well before SpringBoard renders;
+  there's no progress fraction to show, hence "Starting…" plus a
+  first-frame wait.
+- The 3-minute boot timeout is a guess at "something is wrong", not a
+  CoreSimulator limit. A genuinely slow cold boot on a loaded Mac can
+  exceed it; the card then re-offers Boot rather than failing hard.
+- Shutdown has no focus-mode control. Closing the tab leaves the device
+  running (the boot is `persist: true` deliberately) — use the list
+  page, the farm, or `baguette shutdown`.
+- The 4 s idle poll runs only while the Boot button is showing. Once the
+  stream is live, focus mode doesn't watch for the device going away
+  underneath it; the stream simply stops delivering frames.


### PR DESCRIPTION
Opening a tab on a simulator that isn't booted killed `baguette serve` outright. Fixing that exposed the reason you'd ever open one: focus mode had no way to boot a device, so the tab was a dead end even when the server survived.

Two commits, one crash and the feature it points at.

## 1. The segfault

The focus-mode page POSTs `/orientation?value=portrait` on load, which asks CoreSimulator for the device's `PurpleWorkspacePort`. A shutdown device has none, so `lookup:error:` writes back an `NSError` — and the `@convention(c)` thunk typed that ObjC `NSError **` out-parameter as a plain `UnsafeMutablePointer<NSError?>` instead of an `AutoreleasingUnsafeMutablePointer`.

ObjC hands back a **+0, autoreleased** error: it belongs to the surrounding pool, not the caller. ARC released it on our behalf as well, and the process died at the next autorelease-pool pop — inside whatever task happened to be draining, which is why the crash reports pointed at `objc_autoreleasePoolPop` with no baguette frame anywhere in the stack:

```
objc_release
AutoreleasePoolPage::releaseUntil(objc_object**)
objc_autoreleasePoolPop
swift::runJobInEstablishedExecutorContext(swift::Job*)
```

Booted devices never hit it: the lookup succeeds and CoreSimulator writes no error at all. That's why it only ever crashed on a *shutdown* simulator, and why it looked unrelated to orientation.

The four `invoke*WithError` thunks in `CoreSimulators.swift` already use the correct pointer type — this was the one site that didn't, and there is no second instance.

**Verification.** Reproduced first: one `POST /orientation` on a shutdown sim, crash report signature identical to the report. Isolated the mechanism in a standalone program — current shape loses one retain per call, fixed shape is balanced. `PurpleEventOrientationTests` drives the adapter with a fake `SimDevice` whose `lookup:error:` writes an autoreleased error the way CoreSimulator does; before the fix it took the test runner down with SIGSEGV, after it passes. Release binary survives repeated orientation POSTs on two shutdown sims, and a booted sim still rotates.

## 2. Boot from the device's own screen

`/simulators/<udid>` used to assume a running guest — mount the bezel, open a stream that would never carry a frame, show a black rectangle. The list page and the farm both have boot buttons; focus mode, where a deep link lands you, did not.

Four phases on the device's glass:

| Phase | Behaviour |
|---|---|
| **off** | Boot button. Polls every 4s so a boot started from `baguette boot` / another tab / Xcode / `simctl` is picked up without a click — and so clicking Boot on an already-booted device goes live instead of surfacing CoreSimulator's "already booted" refusal |
| **booting** | `POST /boot` sent, or the device was already `Booting` when the tab opened (no second boot in that case). Polls once a second |
| **starting** | CoreSimulator reports `Booted`, which is earlier than SpringBoard rendering, so the card holds until a frame paints. 15s fallback, because `Screen` only emits when SimulatorKit composites |
| **gone** | `definition.json` 404s — the udid isn't in the device set. Previously an unhandled rejection and a blank tab |

Guest-dependent toolbar controls dim while the card is up; the back link and theme toggle stay live, since those are how you leave a device that won't boot. The portrait reset on load is gated the same way.

**No Swift change** — `/simulators.json` already projected `SimulatorState` and `POST /simulators/<udid>/boot` already existed. Per CLAUDE.md, `Resources/Web/` is exempt from the TDD gate; verified in-browser against a real shutdown simulator: click-to-boot goes live, an externally-started boot is picked up on its own, unknown UDIDs say so, light and dark themes both read correctly. The stream socket now opens only after boot rather than dangling.

## Notes

- 790 tests pass.
- One branch I couldn't reproduce live: the "already `Booting`" join. CoreSimulator flips to `Booted` within about a second here, so the window never opened. It shares `waitForBoot` with the verified click path — reasoned, not observed. Racing it is what surfaced the stale-card gap the 4s watch now closes.
- Orientation on a non-booted device now returns a clean 500 instead of crashing. The page's call is best-effort so nothing breaks, but a quieter status for that case would be a reasonable follow-up.

Docs: [`docs/features/boot.md`](docs/features/boot.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boot controls when opening a simulator directly, including boot progress and clear handling for unavailable devices.
  * Added a power-state overlay with booting indicators and temporarily disabled controls until the simulator is ready.
  * Added simulator boot support documentation across the CLI, web interface, deep links, and device farm.

* **Bug Fixes**
  * Fixed a crash when opening an unbooted simulator through `baguette serve`.
  * Improved handling of simulator orientation errors during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->