### PR TITLE
feat(lifetime): stop Simulator.app shutting booted devices down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For releases prior to this changelog, see the
 
 ### Added
 
+- **`baguette lifetime` — stop Simulator.app shutting devices down.** A device
+  booted headlessly dies the moment someone closes its window in Simulator.app,
+  which is easy to hit without meaning to: toolchains like Expo open
+  Simulator.app on your behalf, so a device baguette is driving ends up with a
+  window you can close. Simulator.app has had the fix all along — two
+  preferences it groups under "Simulator lifetime" — but they default to
+  shutdown and are buried. `baguette lifetime` reports the current policy,
+  `--detach` opts into leaving devices booted, and `--shutdown` restores
+  Apple's default. `serve` and `boot` now print a one-line warning when the
+  policy will lose devices, naming the command that fixes it. Nothing is
+  written unless you ask: the keys live in Xcode's preferences domain, the
+  change is machine-wide and outlives baguette, so it stays an explicit
+  opt-in rather than something first boot does behind your back.
+
 - **Boot a device from its own tab.** Opening `/simulators/<udid>` on a
   simulator that isn't running used to mount a bezel around a stream that
   would never carry a frame — a black rectangle with no explanation and no

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ baguette <command> [options]
                                              --json emits {"running":[…],"available":[…]})
   boot     --udid <UDID>                     Boot headlessly
   shutdown --udid <UDID>                     Shutdown
+  lifetime [--detach | --shutdown]           Show/set whether Simulator.app
+                                             leaves devices booted when a
+                                             window closes (machine-wide)
   orientation --udid <UDID>                  Rotate the booted simulator
               <portrait|landscape-left|       (GSEvent over PurpleWorkspacePort —
                landscape-right|portrait-      no NSView, host stays headless)

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ baguette <command> [options]
   shutdown --udid <UDID>                     Shutdown
   lifetime [--detach | --shutdown]           Show/set whether Simulator.app
                                              leaves devices booted when a
-                                             window closes (machine-wide)
+                                             window closes or the app quits
+                                             (machine-wide)
   orientation --udid <UDID>                  Rotate the booted simulator
               <portrait|landscape-left|       (GSEvent over PurpleWorkspacePort —
                landscape-right|portrait-      no NSView, host stays headless)

--- a/Sources/Baguette/App/Commands/BootCommand.swift
+++ b/Sources/Baguette/App/Commands/BootCommand.swift
@@ -18,6 +18,9 @@ struct BootCommand: ParsableCommand {
         do {
             try simulator.boot()
             log("Booted \(simulator.name)")
+            if let advisory = SimulatorAppPreferences.lifetime().advisory {
+                log(advisory)
+            }
         } catch {
             log("Boot failed: \(error)")
             Foundation.exit(1)

--- a/Sources/Baguette/App/Commands/BootCommand.swift
+++ b/Sources/Baguette/App/Commands/BootCommand.swift
@@ -19,7 +19,7 @@ struct BootCommand: ParsableCommand {
             try simulator.boot()
             log("Booted \(simulator.name)")
             if let advisory = SimulatorAppPreferences.lifetime().advisory {
-                log(advisory)
+                warn(advisory)
             }
         } catch {
             log("Boot failed: \(error)")

--- a/Sources/Baguette/App/Commands/LifetimeCommand.swift
+++ b/Sources/Baguette/App/Commands/LifetimeCommand.swift
@@ -69,7 +69,7 @@ struct LifetimeCommand: ParsableCommand {
             }
             log(Self.headline(desired))
             if restartSimulatorApp {
-                log("""
+                warn("""
                     Simulator.app is running and may overwrite this when it \
                     quits — quit and reopen it to be sure the change sticks.
                     """)
@@ -83,7 +83,11 @@ struct LifetimeCommand: ParsableCommand {
         print("  quitting the app   \(Self.effect(lifetime.detachOnAppQuit))")
         print("")
         if let advisory = lifetime.advisory {
-            print(advisory)
+            // The report is the command's product, so it goes to stdout
+            // — but the advisory is the same problem `serve` warns
+            // about, and it would read oddly as the only uncoloured
+            // warning in the tool.
+            print(TerminalStyle.warning(advisory, colored: terminalColorized(STDOUT_FILENO)))
         } else {
             print("Booted devices survive Simulator.app.")
         }

--- a/Sources/Baguette/App/Commands/LifetimeCommand.swift
+++ b/Sources/Baguette/App/Commands/LifetimeCommand.swift
@@ -1,0 +1,101 @@
+import ArgumentParser
+import Foundation
+
+/// `baguette lifetime` — show or change whether Simulator.app leaves
+/// devices booted when their window closes or the app quits.
+///
+/// This is deliberately an explicit command rather than something
+/// `boot` / `serve` apply on your behalf. The keys live in Xcode's
+/// preferences domain, not baguette's: the change is machine-wide,
+/// persists after baguette is uninstalled, and is invisible unless
+/// somebody typed it. `serve` and `boot` only *warn* — see
+/// `SimulatorLifetime.advisory`.
+struct LifetimeCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "lifetime",
+        abstract: "Show or change whether Simulator.app leaves devices booted",
+        discussion: """
+            Simulator.app shuts a device down when you close its window \
+            or quit the app. That kills devices baguette is driving — \
+            including ones another toolchain booted for you.
+
+            Run with no flags to see the current policy. This setting is \
+            Simulator.app's own, so it applies to every simulator on the \
+            machine, not just one device.
+            """
+    )
+
+    @Flag(name: .long, help: "Leave devices booted when a window closes or Simulator.app quits.")
+    var detach = false
+
+    @Flag(name: .long, help: "Restore Apple's default: closing a window or quitting shuts the device down.")
+    var shutdown = false
+
+    func validate() throws {
+        if detach && shutdown {
+            throw ValidationError("Pass only one of --detach or --shutdown.")
+        }
+    }
+
+    /// nil when the command was invoked with no flags, i.e. read-only.
+    private var desired: SimulatorLifetime? {
+        if detach { return .detached }
+        if shutdown { return .appleDefault }
+        return nil
+    }
+
+    func run() {
+        let current = SimulatorAppPreferences.lifetime()
+
+        guard let desired else {
+            report(current)
+            return
+        }
+
+        let change = current.change(
+            to: desired,
+            simulatorAppRunning: SimulatorAppPreferences.simulatorAppIsRunning
+        )
+
+        switch change {
+        case .unchanged:
+            log("Already set — \(Self.headline(desired))")
+        case .applied(let restartSimulatorApp):
+            do {
+                try SimulatorAppPreferences.write(desired)
+            } catch {
+                log("Could not change the lifetime policy: \(error)")
+                Foundation.exit(1)
+            }
+            log(Self.headline(desired))
+            if restartSimulatorApp {
+                log("""
+                    Simulator.app is running and may overwrite this when it \
+                    quits — quit and reopen it to be sure the change sticks.
+                    """)
+            }
+        }
+    }
+
+    private func report(_ lifetime: SimulatorLifetime) {
+        print("Simulator lifetime (\(SimulatorAppPreferences.domain))")
+        print("  closing a window   \(Self.effect(lifetime.detachOnWindowClose))")
+        print("  quitting the app   \(Self.effect(lifetime.detachOnAppQuit))")
+        print("")
+        if let advisory = lifetime.advisory {
+            print(advisory)
+        } else {
+            print("Booted devices survive Simulator.app.")
+        }
+    }
+
+    private static func effect(_ detaches: Bool) -> String {
+        detaches ? "leaves the device booted" : "shuts the device down"
+    }
+
+    private static func headline(_ lifetime: SimulatorLifetime) -> String {
+        lifetime.survivesSimulatorApp
+            ? "Simulator.app will leave booted devices running."
+            : "Simulator.app will shut devices down on window close and quit."
+    }
+}

--- a/Sources/Baguette/App/Commands/ServeCommand.swift
+++ b/Sources/Baguette/App/Commands/ServeCommand.swift
@@ -25,6 +25,14 @@ struct ServeCommand: AsyncParsableCommand {
     var allowedHosts: [String] = []
 
     func run() async throws {
+        // A device driven over `serve` is lost the moment Simulator.app
+        // closes its window, which is easy to trigger by accident when
+        // another toolchain opened Simulator.app for you. Warn, don't
+        // rewrite Xcode's preferences behind the user's back.
+        if let advisory = SimulatorAppPreferences.lifetime().advisory {
+            log(advisory)
+        }
+
         let server = Server(
             simulators: CoreSimulators(deviceSetPath: deviceSet),
             chromes: LiveChromes(

--- a/Sources/Baguette/App/Commands/ServeCommand.swift
+++ b/Sources/Baguette/App/Commands/ServeCommand.swift
@@ -30,7 +30,7 @@ struct ServeCommand: AsyncParsableCommand {
         // another toolchain opened Simulator.app for you. Warn, don't
         // rewrite Xcode's preferences behind the user's back.
         if let advisory = SimulatorAppPreferences.lifetime().advisory {
-            log(advisory)
+            warn(advisory)
         }
 
         let server = Server(

--- a/Sources/Baguette/App/Logger.swift
+++ b/Sources/Baguette/App/Logger.swift
@@ -5,3 +5,21 @@ import Foundation
 func log(_ message: String) {
     fputs("[baguette] \(message)\n", stderr)
 }
+
+/// Like `log`, but marked as a warning — tinted yellow when stderr is a
+/// terminal, plain (and still marked) when it's redirected.
+func warn(_ message: String) {
+    let styled = TerminalStyle.warning(message, colored: terminalColorized(STDERR_FILENO))
+    fputs("[baguette] \(styled)\n", stderr)
+}
+
+/// Whether the given file descriptor should carry ANSI colour.
+///
+/// The `isatty` probe and the environment read are the only impure
+/// parts; the decision itself lives in `TerminalStyle` and is covered.
+func terminalColorized(_ fileDescriptor: Int32) -> Bool {
+    TerminalStyle.shouldColorize(
+        isTTY: isatty(fileDescriptor) == 1,
+        environment: ProcessInfo.processInfo.environment
+    )
+}

--- a/Sources/Baguette/App/RootCommand.swift
+++ b/Sources/Baguette/App/RootCommand.swift
@@ -10,6 +10,7 @@ struct Baguette: AsyncParsableCommand {
             ListCommand.self,
             BootCommand.self,
             ShutdownCommand.self,
+            LifetimeCommand.self,
             InputCommand.self,
             StreamCommand.self,
             TapCommand.self,

--- a/Sources/Baguette/App/TerminalStyle.swift
+++ b/Sources/Baguette/App/TerminalStyle.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// How a message looks on the way to stderr.
+///
+/// Pure string composition plus a pure colour decision — the `isatty`
+/// probe and the environment lookup stay at the call site in `Logger`,
+/// so everything here is unit-covered.
+enum TerminalStyle {
+    private static let escape = "\u{001B}"
+    /// SGR 33 — plain yellow. Legible on both light and dark terminal
+    /// themes, unlike bright yellow, which washes out on white.
+    private static let yellow = "\(escape)[33m"
+    private static let reset = "\(escape)[0m"
+
+    /// Render a warning.
+    ///
+    /// The `warning:` marker is applied whether or not colour is on:
+    /// colour is the only cue a human gets on a terminal, but a piped
+    /// or redirected log has none, so the marker has to survive.
+    static func warning(_ message: String, colored: Bool) -> String {
+        let marked = "warning: \(message)"
+        guard colored else { return marked }
+        // The reset closes the sequence even when the message wraps
+        // across lines; leaving it open would tint later output.
+        return "\(yellow)\(marked)\(reset)"
+    }
+
+    /// Whether to emit colour at all.
+    ///
+    /// Redirected output stays clean — a log file full of escape
+    /// sequences is worse than no colour. `NO_COLOR` (https://no-color.org)
+    /// and `TERM=dumb` are both honoured as opt-outs.
+    static func shouldColorize(isTTY: Bool, environment: [String: String]) -> Bool {
+        // The convention is explicit that presence alone isn't enough:
+        // the value has to be non-empty.
+        if let noColor = environment["NO_COLOR"], !noColor.isEmpty { return false }
+        if environment["TERM"] == "dumb" { return false }
+        return isTTY
+    }
+}

--- a/Sources/Baguette/Domain/Simulator/SimulatorLifetime.swift
+++ b/Sources/Baguette/Domain/Simulator/SimulatorLifetime.swift
@@ -103,14 +103,25 @@ struct SimulatorLifetime: Equatable, Sendable {
     /// A one-line warning for commands that hold a device open (`serve`,
     /// `boot`), or nil when the policy already keeps devices alive.
     ///
-    /// This names the command that fixes it — an advisory that only
+    /// Only the routes that will actually shut a device down are named.
+    /// The two keys are independent checkboxes in Simulator → Settings,
+    /// so a half-detached policy is reachable, and claiming a route
+    /// shuts devices down when it doesn't would misdescribe what
+    /// Simulator.app is going to do — the one thing this message exists
+    /// to get right.
+    ///
+    /// It also names the command that fixes it: an advisory that only
     /// describes the problem is noise.
     var advisory: String? {
         guard !survivesSimulatorApp else { return nil }
+        // The guard leaves at least one route live, so this is never
+        // empty.
+        var routes: [String] = []
+        if !detachOnWindowClose { routes.append("their window is closed") }
+        if !detachOnAppQuit { routes.append("Simulator.app quits") }
         return """
-            Simulator.app will shut this device down when its window is \
-            closed or the app quits — run `baguette lifetime --detach` to \
-            leave booted devices running.
+            Booted devices will be shut down when \(routes.joined(separator: " or ")) \
+            — run `baguette lifetime --detach` to leave them running.
             """
     }
 

--- a/Sources/Baguette/Domain/Simulator/SimulatorLifetime.swift
+++ b/Sources/Baguette/Domain/Simulator/SimulatorLifetime.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// Simulator.app's device lifetime policy — whether closing a
+/// simulator's window, or quitting the app, leaves the device booted
+/// or shuts it down.
+///
+/// Apple exposes exactly two preferences for this, grouped under
+/// "Simulator lifetime" in `Simulator.app/Contents/Resources/
+/// Settings.bundle/Root.plist`:
+///
+///   DetachOnWindowClose — "When closing a simulator's window leave it running"
+///   DetachOnAppQuit     — "When quitting leave simulators running"
+///
+/// Both ship as `false`. That default is why a device baguette booted
+/// headlessly dies the moment anything opens it in Simulator.app and
+/// the window is later closed — a common way to lose a device is a
+/// toolchain (Expo, `xcrun simctl` wrappers, Xcode itself) opening
+/// Simulator.app on your behalf.
+///
+/// Per CLAUDE.md's one-shot-fetch split, everything downstream of the
+/// fetched plist lives here as a pure factory; the irreducible
+/// `CFPreferences` read/write pair is the only Infrastructure code.
+struct SimulatorLifetime: Equatable, Sendable {
+    /// Closing a simulator's window detaches from the device instead
+    /// of shutting it down.
+    var detachOnWindowClose: Bool
+    /// Quitting Simulator.app leaves booted devices running.
+    var detachOnAppQuit: Bool
+
+    /// Simulator.app's own preference key for the window-close route.
+    /// These spellings are the contract with Apple — a typo writes a
+    /// key nothing reads.
+    static let windowCloseKey = "DetachOnWindowClose"
+    /// Simulator.app's own preference key for the app-quit route.
+    static let appQuitKey = "DetachOnAppQuit"
+
+    /// What Simulator.app does out of the box: both routes shut the
+    /// device down.
+    static let appleDefault = SimulatorLifetime(
+        detachOnWindowClose: false,
+        detachOnAppQuit: false
+    )
+
+    /// Both routes detach, so a booted device outlives Simulator.app.
+    static let detached = SimulatorLifetime(
+        detachOnWindowClose: true,
+        detachOnAppQuit: true
+    )
+
+    /// A device only outlives Simulator.app when *both* routes detach —
+    /// closing the window and quitting the app are independent ways to
+    /// lose a booted simulator, so opting out of one still loses it by
+    /// the other.
+    var survivesSimulatorApp: Bool { detachOnWindowClose && detachOnAppQuit }
+
+    /// Read the policy out of Simulator.app's preferences.
+    ///
+    /// An absent key means shutdown, not "unset" — a machine that has
+    /// never touched these preferences has no entry at all, and
+    /// reporting that as anything other than shutdown would misdescribe
+    /// what Simulator.app is about to do.
+    static func from(plist: [String: Any]) -> SimulatorLifetime {
+        SimulatorLifetime(
+            detachOnWindowClose: flag(plist[windowCloseKey]),
+            detachOnAppQuit: flag(plist[appQuitKey])
+        )
+    }
+
+    /// The keys to write back. Both are always present: reverting must
+    /// write `false` rather than remove the keys, so a user who opted
+    /// in can see the revert land in `defaults read`.
+    var plistPatch: [String: Bool] {
+        [
+            Self.windowCloseKey: detachOnWindowClose,
+            Self.appQuitKey: detachOnAppQuit,
+        ]
+    }
+
+    /// What moving the policy to `desired` amounts to.
+    enum Change: Equatable, Sendable {
+        /// The machine is already at the requested policy — nothing
+        /// was written.
+        case unchanged
+        /// The caller should write the requested policy.
+        /// `restartSimulatorApp` is true when Simulator.app was running,
+        /// so the write may not stick without a restart.
+        case applied(restartSimulatorApp: Bool)
+    }
+
+    /// Decide what asking for `desired` should do.
+    ///
+    /// A running Simulator.app doesn't block the write, but it does
+    /// mean the change isn't reliably live: the app can hold a cached
+    /// copy of these keys and flush it back over the write when it
+    /// quits. Callers surface that as "restart Simulator.app" rather
+    /// than refusing — a device is often booted through Simulator.app
+    /// in the first place, so refusing would block the common case.
+    func change(to desired: SimulatorLifetime, simulatorAppRunning: Bool) -> Change {
+        guard self != desired else { return .unchanged }
+        return .applied(restartSimulatorApp: simulatorAppRunning)
+    }
+
+    /// A one-line warning for commands that hold a device open (`serve`,
+    /// `boot`), or nil when the policy already keeps devices alive.
+    ///
+    /// This names the command that fixes it — an advisory that only
+    /// describes the problem is noise.
+    var advisory: String? {
+        guard !survivesSimulatorApp else { return nil }
+        return """
+            Simulator.app will shut this device down when its window is \
+            closed or the app quits — run `baguette lifetime --detach` to \
+            leave booted devices running.
+            """
+    }
+
+    /// Parse one preference value the way `-[NSUserDefaults boolForKey:]`
+    /// would.
+    ///
+    /// `defaults write … -bool YES` stores a CFBoolean that arrives as
+    /// `NSNumber`, but `defaults write … YES` (no `-bool`) stores the
+    /// *string* `"YES"` — and NSUserDefaults still reads that as true.
+    /// Matching those semantics keeps the reported policy equal to the
+    /// one Simulator.app will act on. Anything else is unreadable, and
+    /// unreadable falls back to shutdown rather than claiming safety.
+    private static func flag(_ value: Any?) -> Bool {
+        switch value {
+        case let bool as Bool: return bool
+        case let number as NSNumber: return number.boolValue
+        case let string as String: return (string as NSString).boolValue
+        default: return false
+        }
+    }
+}

--- a/Sources/Baguette/Infrastructure/Simulator/SimulatorAppPreferences.swift
+++ b/Sources/Baguette/Infrastructure/Simulator/SimulatorAppPreferences.swift
@@ -1,0 +1,82 @@
+import AppKit
+import Foundation
+
+/// Simulator.app's own preferences domain.
+///
+/// This is the integration-only half of the `SimulatorLifetime` split
+/// described in CLAUDE.md: the three irreducible calls are the
+/// `CFPreferences` read, the `CFPreferences` write, and the
+/// `NSRunningApplication` lookup. Everything that decides *what those
+/// values mean* lives in `SimulatorLifetime` and is unit-covered.
+///
+/// The preferences domain and the bundle identifier are the same string
+/// — Simulator.app stores its settings under its own bundle id.
+enum SimulatorAppPreferences {
+    /// Simulator.app's bundle identifier, which doubles as its
+    /// CFPreferences domain.
+    static let domain = "com.apple.iphonesimulator"
+
+    private static var domainID: CFString { domain as CFString }
+
+    /// Read the current device lifetime policy.
+    ///
+    /// Keys that are absent stay absent in the plist handed to
+    /// `SimulatorLifetime.from` — the value type is what decides that
+    /// absence means shutdown.
+    static func lifetime() -> SimulatorLifetime {
+        var plist: [String: Any] = [:]
+        for key in [SimulatorLifetime.windowCloseKey, SimulatorLifetime.appQuitKey] {
+            let value = CFPreferencesCopyValue(
+                key as CFString,
+                domainID,
+                kCFPreferencesCurrentUser,
+                kCFPreferencesAnyHost
+            )
+            if let value { plist[key] = value }
+        }
+        return SimulatorLifetime.from(plist: plist)
+    }
+
+    /// Write the policy into Simulator.app's domain.
+    ///
+    /// Writes go to the current user, any host — the same location
+    /// `defaults write com.apple.iphonesimulator …` targets.
+    static func write(_ lifetime: SimulatorLifetime) throws {
+        for (key, value) in lifetime.plistPatch {
+            CFPreferencesSetValue(
+                key as CFString,
+                (value ? kCFBooleanTrue : kCFBooleanFalse),
+                domainID,
+                kCFPreferencesCurrentUser,
+                kCFPreferencesAnyHost
+            )
+        }
+        guard CFPreferencesSynchronize(
+            domainID,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesAnyHost
+        ) else {
+            throw SimulatorAppPreferencesError.synchronizeFailed
+        }
+    }
+
+    /// Whether Simulator.app is running right now — it may hold a
+    /// cached copy of these keys, so a write while it is up isn't
+    /// reliably live.
+    static var simulatorAppIsRunning: Bool {
+        !NSRunningApplication
+            .runningApplications(withBundleIdentifier: domain)
+            .isEmpty
+    }
+}
+
+enum SimulatorAppPreferencesError: Error, CustomStringConvertible {
+    case synchronizeFailed
+
+    var description: String {
+        switch self {
+        case .synchronizeFailed:
+            return "could not write to the \(SimulatorAppPreferences.domain) preferences domain"
+        }
+    }
+}

--- a/Tests/BaguetteTests/App/Commands/CommandParsingTests.swift
+++ b/Tests/BaguetteTests/App/Commands/CommandParsingTests.swift
@@ -21,7 +21,7 @@ struct CommandParsingTests {
             "key", "type", "paste", "clipboard",
             "chrome", "screenshot", "describe-ui", "logs", "serve",
             "orientation", "status-bar", "location", "install", "add-media",
-            "diag-digitizer-trackpad",
+            "diag-digitizer-trackpad", "lifetime",
         ])
     }
 
@@ -71,6 +71,43 @@ struct CommandParsingTests {
         #expect(cmd.options.udid == "XYZ")
         #expect(cmd.options.deviceSet == "/var/sims")
         #expect(ShutdownCommand.configuration.commandName == "shutdown")
+    }
+
+    // MARK: - lifetime
+
+    @Test func `lifetime with no flags is read-only`() throws {
+        let cmd = try LifetimeCommand.parse([])
+        #expect(cmd.detach == false)
+        #expect(cmd.shutdown == false)
+        #expect(LifetimeCommand.configuration.commandName == "lifetime")
+    }
+
+    @Test func `lifetime parses --detach`() throws {
+        let cmd = try LifetimeCommand.parse(["--detach"])
+        #expect(cmd.detach == true)
+        #expect(cmd.shutdown == false)
+    }
+
+    @Test func `lifetime parses --shutdown`() throws {
+        let cmd = try LifetimeCommand.parse(["--shutdown"])
+        #expect(cmd.shutdown == true)
+        #expect(cmd.detach == false)
+    }
+
+    @Test func `lifetime rejects both directions at once`() {
+        // --detach and --shutdown are opposite ends of one policy;
+        // accepting both would silently pick one.
+        #expect(throws: (any Error).self) {
+            try LifetimeCommand.parse(["--detach", "--shutdown"])
+        }
+    }
+
+    @Test func `lifetime takes no udid because the policy is machine-wide`() {
+        // These are Simulator.app's preferences, not a device's, so a
+        // per-device flag would be a lie.
+        #expect(throws: (any Error).self) {
+            try LifetimeCommand.parse(["--udid", "ABC"])
+        }
     }
 
     // MARK: - input

--- a/Tests/BaguetteTests/App/LoggerTests.swift
+++ b/Tests/BaguetteTests/App/LoggerTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import Baguette
 
 @Suite("Logger")
@@ -10,5 +11,19 @@ struct LoggerTests {
     @Test func `log prints without throwing`() {
         log("test message")
         log("")
+    }
+
+    // Same deal as `log` — the styling decision is covered in
+    // TerminalStyleTests; this just exercises the write path.
+    @Test func `warn prints without throwing`() {
+        warn("test warning")
+        warn("")
+    }
+
+    @Test func `colour is resolved per file descriptor`() {
+        // Under `swift test` stderr is not a terminal, so this also
+        // pins that redirected output stays uncoloured.
+        _ = terminalColorized(STDERR_FILENO)
+        _ = terminalColorized(STDOUT_FILENO)
     }
 }

--- a/Tests/BaguetteTests/App/LoggerTests.swift
+++ b/Tests/BaguetteTests/App/LoggerTests.swift
@@ -20,10 +20,11 @@ struct LoggerTests {
         warn("")
     }
 
-    @Test func `colour is resolved per file descriptor`() {
-        // Under `swift test` stderr is not a terminal, so this also
-        // pins that redirected output stays uncoloured.
-        _ = terminalColorized(STDERR_FILENO)
-        _ = terminalColorized(STDOUT_FILENO)
+    @Test func `a descriptor that isn't a terminal gets no colour`() {
+        // -1 is never a tty, so this is deterministic. Asserting on
+        // STDERR_FILENO would not be: `swift test` inherits the parent's
+        // stderr, which is a terminal when run interactively and a pipe
+        // in CI, so the expected value would flip with the environment.
+        #expect(terminalColorized(-1) == false)
     }
 }

--- a/Tests/BaguetteTests/App/TerminalStyleTests.swift
+++ b/Tests/BaguetteTests/App/TerminalStyleTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// `TerminalStyle` decides how a message appears on the way to stderr.
+/// Pure string composition + a pure colour decision, so the `isatty`
+/// call and the environment lookup stay at the call site in `Logger`.
+@Suite("TerminalStyle")
+struct TerminalStyleTests {
+
+    private static let esc = "\u{001B}"
+
+    // MARK: - Rendering
+
+    @Test func `a coloured warning wraps the message in yellow and resets`() {
+        let rendered = TerminalStyle.warning("device will be lost", colored: true)
+        #expect(rendered.hasPrefix("\(Self.esc)[33m"))
+        #expect(rendered.hasSuffix("\(Self.esc)[0m"))
+        #expect(rendered.contains("device will be lost"))
+    }
+
+    @Test func `a plain warning carries no escape bytes at all`() {
+        // Redirected output has to stay clean — a log file full of
+        // escape sequences is worse than no colour.
+        let rendered = TerminalStyle.warning("device will be lost", colored: false)
+        #expect(!rendered.contains(Self.esc))
+    }
+
+    @Test func `a warning is marked as one even without colour`() {
+        // Colour is the only cue a human gets on a terminal, but a
+        // piped log has none — so the marker has to survive.
+        let plain = TerminalStyle.warning("device will be lost", colored: false)
+        #expect(plain.contains("warning:"))
+
+        let coloured = TerminalStyle.warning("device will be lost", colored: true)
+        #expect(coloured.contains("warning:"))
+    }
+
+    @Test func `the reset closes a multi-line warning`() {
+        // The advisory wraps across lines; leaving the sequence open
+        // would tint everything printed after it.
+        let rendered = TerminalStyle.warning("first line\nsecond line", colored: true)
+        #expect(rendered.hasSuffix("\(Self.esc)[0m"))
+        #expect(rendered.contains("second line"))
+    }
+
+    // MARK: - Deciding whether to colour
+
+    @Test func `a terminal gets colour`() {
+        #expect(TerminalStyle.shouldColorize(isTTY: true, environment: [:]) == true)
+    }
+
+    @Test func `redirected output gets no colour`() {
+        #expect(TerminalStyle.shouldColorize(isTTY: false, environment: [:]) == false)
+    }
+
+    @Test func `NO_COLOR turns colour off on a terminal`() {
+        // https://no-color.org — any non-empty value opts out.
+        #expect(TerminalStyle.shouldColorize(
+            isTTY: true, environment: ["NO_COLOR": "1"]
+        ) == false)
+    }
+
+    @Test func `an empty NO_COLOR is ignored`() {
+        // The convention is explicit that presence alone isn't enough;
+        // the value must be non-empty.
+        #expect(TerminalStyle.shouldColorize(
+            isTTY: true, environment: ["NO_COLOR": ""]
+        ) == true)
+    }
+
+    @Test func `a dumb terminal gets no colour`() {
+        #expect(TerminalStyle.shouldColorize(
+            isTTY: true, environment: ["TERM": "dumb"]
+        ) == false)
+    }
+
+    @Test func `an ordinary TERM keeps colour`() {
+        #expect(TerminalStyle.shouldColorize(
+            isTTY: true, environment: ["TERM": "xterm-256color"]
+        ) == true)
+    }
+}

--- a/Tests/BaguetteTests/Simulator/SimulatorLifetimeTests.swift
+++ b/Tests/BaguetteTests/Simulator/SimulatorLifetimeTests.swift
@@ -1,0 +1,194 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// `SimulatorLifetime` is the value-typed reading of Simulator.app's
+/// device lifetime policy — the two preferences Apple groups under
+/// "Simulator lifetime" in `Simulator.app/Contents/Resources/
+/// Settings.bundle/Root.plist`:
+///
+///   DetachOnWindowClose — "When closing a simulator's window leave it running"
+///   DetachOnAppQuit     — "When quitting leave simulators running"
+///
+/// Both default to `false`, which is why a device booted headlessly by
+/// baguette dies the moment someone closes its window in Simulator.app.
+///
+/// This is CLAUDE.md's one-shot-fetch split: the irreducible call is a
+/// pair of `CFPreferences` reads/writes in Infrastructure, and
+/// everything downstream of the fetched plist lives here as a pure
+/// factory — so no `@Mockable` collaborator is needed.
+@Suite("SimulatorLifetime")
+struct SimulatorLifetimeTests {
+
+    // MARK: - Reading
+
+    @Test func `an absent preference reads as Apple's shutdown default`() {
+        // A machine that has never touched these keys has no entry at
+        // all — not `false`. Absence must read as shutdown, because
+        // that is what Simulator.app actually does.
+        let lifetime = SimulatorLifetime.from(plist: [:])
+        #expect(lifetime == .appleDefault)
+        #expect(lifetime.detachOnWindowClose == false)
+        #expect(lifetime.detachOnAppQuit == false)
+    }
+
+    @Test func `both keys set reads as fully detached`() {
+        let lifetime = SimulatorLifetime.from(plist: [
+            "DetachOnWindowClose": NSNumber(value: true),
+            "DetachOnAppQuit": NSNumber(value: true),
+        ])
+        #expect(lifetime == .detached)
+    }
+
+    @Test func `defaults-write booleans arrive as NSNumber and parse either way`() {
+        // `defaults write … -bool YES` stores a CFBoolean, which bridges
+        // to NSNumber on the way back out of CFPreferences.
+        let on = SimulatorLifetime.from(plist: ["DetachOnWindowClose": NSNumber(value: true)])
+        #expect(on.detachOnWindowClose == true)
+
+        let off = SimulatorLifetime.from(plist: ["DetachOnWindowClose": NSNumber(value: false)])
+        #expect(off.detachOnWindowClose == false)
+    }
+
+    @Test func `a string written without -bool parses the way NSUserDefaults would`() {
+        // `defaults write … DetachOnAppQuit YES` (no -bool) stores the
+        // *string* "YES". `-[NSUserDefaults boolForKey:]` still reads
+        // that as true, so reporting it as false would misdescribe what
+        // Simulator.app is going to do.
+        for truthy in ["YES", "true", "1"] {
+            #expect(SimulatorLifetime.from(plist: ["DetachOnAppQuit": truthy]).detachOnAppQuit == true,
+                    "expected \(truthy) to read as true")
+        }
+        for falsy in ["NO", "false", "0"] {
+            #expect(SimulatorLifetime.from(plist: ["DetachOnAppQuit": falsy]).detachOnAppQuit == false,
+                    "expected \(falsy) to read as false")
+        }
+    }
+
+    @Test func `a value of an unreadable type falls back to shutdown`() {
+        // Garbage in the domain shouldn't be reported as "you're safe".
+        let lifetime = SimulatorLifetime.from(plist: ["DetachOnWindowClose": ["nested": 1]])
+        #expect(lifetime.detachOnWindowClose == false)
+    }
+
+    @Test func `each key is read independently`() {
+        let lifetime = SimulatorLifetime.from(plist: ["DetachOnWindowClose": NSNumber(value: true)])
+        #expect(lifetime.detachOnWindowClose == true)
+        #expect(lifetime.detachOnAppQuit == false)
+    }
+
+    // MARK: - Surviving Simulator.app
+
+    @Test func `a device survives Simulator app only when both routes detach`() {
+        #expect(SimulatorLifetime.detached.survivesSimulatorApp == true)
+        #expect(SimulatorLifetime.appleDefault.survivesSimulatorApp == false)
+
+        // Detaching on one route alone still loses the device by the
+        // other — closing the window and quitting the app are separate
+        // ways to lose a booted simulator.
+        let closeOnly = SimulatorLifetime(detachOnWindowClose: true, detachOnAppQuit: false)
+        #expect(closeOnly.survivesSimulatorApp == false)
+
+        let quitOnly = SimulatorLifetime(detachOnWindowClose: false, detachOnAppQuit: true)
+        #expect(quitOnly.survivesSimulatorApp == false)
+    }
+
+    // MARK: - Writing
+
+    @Test func `the patch carries both keys under Simulator app's own names`() {
+        // These spellings are the contract with Simulator.app; a typo
+        // here writes a key nothing reads.
+        let patch = SimulatorLifetime.detached.plistPatch
+        #expect(patch["DetachOnWindowClose"] == true)
+        #expect(patch["DetachOnAppQuit"] == true)
+        #expect(patch.count == 2)
+    }
+
+    @Test func `the patch writes both keys explicitly when reverting`() {
+        // Reverting must write `false`, not remove the keys — a user who
+        // opted in should see the revert land in `defaults read`.
+        let patch = SimulatorLifetime.appleDefault.plistPatch
+        #expect(patch["DetachOnWindowClose"] == false)
+        #expect(patch["DetachOnAppQuit"] == false)
+    }
+
+    @Test func `a patch round-trips back through the reader`() {
+        for lifetime in [SimulatorLifetime.detached,
+                         .appleDefault,
+                         SimulatorLifetime(detachOnWindowClose: true, detachOnAppQuit: false)] {
+            let round = SimulatorLifetime.from(plist: lifetime.plistPatch)
+            #expect(round == lifetime)
+        }
+    }
+
+    // MARK: - Changing the policy
+
+    @Test func `asking for the policy already in place writes nothing`() {
+        let change = SimulatorLifetime.detached.change(
+            to: .detached,
+            simulatorAppRunning: false
+        )
+        #expect(change == .unchanged)
+    }
+
+    @Test func `asking for a different policy applies it`() {
+        let change = SimulatorLifetime.appleDefault.change(
+            to: .detached,
+            simulatorAppRunning: false
+        )
+        #expect(change == .applied(restartSimulatorApp: false))
+    }
+
+    @Test func `applying while Simulator app runs asks for a restart`() {
+        // A running Simulator.app may hold a cached copy of these keys
+        // and flush it back over the write when it quits, so the user
+        // has to be told the change isn't reliably live yet.
+        let change = SimulatorLifetime.appleDefault.change(
+            to: .detached,
+            simulatorAppRunning: true
+        )
+        #expect(change == .applied(restartSimulatorApp: true))
+    }
+
+    @Test func `a no-op change never asks for a restart`() {
+        // Nothing was written, so there is nothing for a running
+        // Simulator.app to clobber.
+        let change = SimulatorLifetime.detached.change(
+            to: .detached,
+            simulatorAppRunning: true
+        )
+        #expect(change == .unchanged)
+    }
+
+    @Test func `reverting to Apple's default is an ordinary change`() {
+        let change = SimulatorLifetime.detached.change(
+            to: .appleDefault,
+            simulatorAppRunning: false
+        )
+        #expect(change == .applied(restartSimulatorApp: false))
+    }
+
+    @Test func `a partial policy still counts as a change toward detached`() {
+        let partial = SimulatorLifetime(detachOnWindowClose: true, detachOnAppQuit: false)
+        let change = partial.change(to: .detached, simulatorAppRunning: false)
+        #expect(change == .applied(restartSimulatorApp: false))
+    }
+
+    // MARK: - Advising the user
+
+    @Test func `a policy that loses devices advises the fix by name`() throws {
+        // `serve` prints this at startup; it has to name the command
+        // that fixes it, or it is just noise.
+        let advisory = try #require(SimulatorLifetime.appleDefault.advisory)
+        #expect(advisory.contains("baguette lifetime --detach"))
+    }
+
+    @Test func `a partial policy still advises because the device can be lost`() {
+        let partial = SimulatorLifetime(detachOnWindowClose: true, detachOnAppQuit: false)
+        #expect(partial.advisory != nil)
+    }
+
+    @Test func `a policy that survives Simulator app says nothing`() {
+        #expect(SimulatorLifetime.detached.advisory == nil)
+    }
+}

--- a/Tests/BaguetteTests/Simulator/SimulatorLifetimeTests.swift
+++ b/Tests/BaguetteTests/Simulator/SimulatorLifetimeTests.swift
@@ -183,9 +183,38 @@ struct SimulatorLifetimeTests {
         #expect(advisory.contains("baguette lifetime --detach"))
     }
 
-    @Test func `a partial policy still advises because the device can be lost`() {
+    @Test func `Apple's default names both routes because both shut down`() throws {
+        let advisory = try #require(SimulatorLifetime.appleDefault.advisory)
+        #expect(advisory.contains("window"))
+        #expect(advisory.contains("quits"))
+    }
+
+    @Test func `detaching on window close leaves only the quit route named`() throws {
+        // Closing the window no longer shuts this device down, so saying
+        // it does would misdescribe what Simulator.app will actually do.
+        // Reachable from Simulator → Settings, where the two keys are
+        // independent checkboxes.
         let partial = SimulatorLifetime(detachOnWindowClose: true, detachOnAppQuit: false)
-        #expect(partial.advisory != nil)
+        let advisory = try #require(partial.advisory)
+        #expect(advisory.contains("quits"))
+        #expect(!advisory.contains("window"))
+    }
+
+    @Test func `detaching on quit leaves only the window route named`() throws {
+        let partial = SimulatorLifetime(detachOnWindowClose: false, detachOnAppQuit: true)
+        let advisory = try #require(partial.advisory)
+        #expect(advisory.contains("window"))
+        #expect(!advisory.contains("quits"))
+    }
+
+    @Test func `every advising policy still names the fix`() throws {
+        // Whichever routes are live, the advisory has to stay actionable.
+        for lifetime in [SimulatorLifetime.appleDefault,
+                         SimulatorLifetime(detachOnWindowClose: true, detachOnAppQuit: false),
+                         SimulatorLifetime(detachOnWindowClose: false, detachOnAppQuit: true)] {
+            let advisory = try #require(lifetime.advisory)
+            #expect(advisory.contains("baguette lifetime --detach"))
+        }
     }
 
     @Test func `a policy that survives Simulator app says nothing`() {

--- a/skills/baguette/references/cli.md
+++ b/skills/baguette/references/cli.md
@@ -32,6 +32,45 @@ Headless boot — the CoreSimulator framework spins the device up without
 opening Simulator.app. `boot` is idempotent: an already-booted device
 returns `{"ok":true}`.
 
+## Surviving Simulator.app — `lifetime`
+
+```bash
+baguette lifetime              # report the current policy
+baguette lifetime --detach     # leave devices booted on window close / quit
+baguette lifetime --shutdown   # restore Apple's default
+```
+
+Simulator.app shuts a device down when you close its window or quit the
+app, which kills devices baguette is driving. That bites even in a
+headless workflow, because other toolchains (Expo's `i`, `xcrun simctl`
+wrappers, Xcode) open Simulator.app for you — so a device you booted
+headlessly acquires a window somebody can close.
+
+The policy is two preferences in Simulator.app's own domain
+(`com.apple.iphonesimulator`), which Apple groups under "Simulator
+lifetime" and ships as `false`:
+
+| Key | Simulator.app's wording |
+|---|---|
+| `DetachOnWindowClose` | "When closing a simulator's window leave it running" |
+| `DetachOnAppQuit` | "When quitting leave simulators running" |
+
+Both must detach for a device to survive — closing the window and
+quitting the app are independent ways to lose it. The same toggles live
+in Simulator → Settings… if you'd rather flip them by hand.
+
+Two things worth knowing:
+
+- **It's machine-wide.** These are Simulator.app's settings, not a
+  device's, so there's no `--udid`. The change persists after baguette is
+  uninstalled — which is why nothing applies it automatically. `serve`
+  and `boot` only warn.
+- **Quit Simulator.app first if you can.** A running Simulator.app may
+  hold a cached copy of these keys and flush it back over the write when
+  it quits. `lifetime` writes anyway (refusing would block the common
+  case, since the device is often booted through Simulator.app) but tells
+  you to restart it.
+
 ## Screen geometry — `chrome layout`
 
 ```bash


### PR DESCRIPTION
Simulator.app shuts a device down when its window closes or the app quits, killing devices baguette is driving. Easy to hit by accident — Expo's `i` and friends open Simulator.app for you, so a headlessly-booted device ends up with a window someone can close.

Apple already has the fix: two preferences under "Simulator lifetime", both shipping as `false`, both required (window-close and app-quit are independent ways to lose a device).

- `baguette lifetime` reports the policy, `--detach` opts in, `--shutdown` reverts.
- `serve` / `boot` print a yellow warning when the policy will lose devices.
- Nothing is written unless asked — the keys are Xcode's, machine-wide, and outlive baguette.

`SimulatorLifetime` and `TerminalStyle` are pure value types; only the `CFPreferences` / `NSRunningApplication` / `isatty` calls sit in the impure layer. 826 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added the `baguette lifetime` command to view or set Simulator.app device shutdown behavior.
  * Introduced `--detach` and `--shutdown` flags (with mutual exclusivity validation).
  * Updated `boot` and `serve` to emit a single warning when the chosen policy could cause device shutdown.
  * Improved warning output with terminal-aware ANSI coloring.

* **Documentation**
  * Documented the new command, options, and machine-wide behavior in the README and CLI reference.

* **Tests**
  * Added/updated coverage for command parsing, logging/warning rendering, terminal color rules, and lifetime policy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->