### PR TITLE
feat(shake): shake a booted simulator via CLI, serve route, and toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Added
+
+- **Shake gesture.** `baguette shake --udid <UDID>`, `POST
+  /simulators/<UDID>/shake` on `serve`, and a shake button in the serve
+  UI toolbar (next to Home / App switcher, mirroring the rotate button)
+  deliver a motion shake to a booted simulator — UIKit fires
+  `motionShake` on the frontmost
+  responder, the same as Simulator.app's *Device → Shake*. Backed by
+  `simctl spawn <udid> notifyutil -p com.apple.UIKit.SimulatorShake`,
+  which posts the private UIKit Darwin notification into the *guest's*
+  notify namespace (a host `notify_post` never reaches the iOS guest).
+  Chosen over the native `-[SimDevice gsEventsSendShake]` /
+  `PurpleWorkspacePort` GSEvent path because the shake body bytes aren't
+  documented like orientation's — the simctl path is documented,
+  crash-free, and unit-testable end-to-end. iOS-only by design.
+  See [`docs/features/shake.md`](docs/features/shake.md).
+
 ---
 
 ## [0.1.88] - 2026-08-01

--- a/Sources/Baguette/App/Commands/ShakeCommand.swift
+++ b/Sources/Baguette/App/Commands/ShakeCommand.swift
@@ -1,0 +1,39 @@
+import ArgumentParser
+import Foundation
+
+/// `baguette shake --udid <UDID>`
+///
+/// Delivers a motion shake to the booted simulator — the same signal as
+/// Simulator.app's "Device → Shake". Backed by `simctl spawn <udid>
+/// notifyutil -p com.apple.UIKit.SimulatorShake`, which posts the Darwin
+/// notification UIKit's shake detection observes into the guest's notify
+/// namespace. The value-domain projection lives in
+/// `Domain/Shake/MotionShake.swift`; the spawn is in
+/// `Infrastructure/Shake/SimctlShake.swift`.
+struct ShakeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "shake",
+        abstract: "Shake the booted simulator (fires UIKit motionShake)"
+    )
+
+    @OptionGroup var options: DeviceOption
+
+    func run() async throws {
+        let simulators = CoreSimulators(deviceSetPath: options.deviceSet)
+        guard let simulator = simulators.find(udid: options.udid) else {
+            log("Device \(options.udid) not found")
+            throw ExitCode.failure
+        }
+        guard simulator.canAcceptInput else {
+            log("Device \(simulator.name) is not booted")
+            throw ExitCode.failure
+        }
+        do {
+            try await simulator.shake().shake()
+        } catch {
+            log("shake failed: \(error)")
+            throw ExitCode.failure
+        }
+        log("Shook \(simulator.name)")
+    }
+}

--- a/Sources/Baguette/App/RootCommand.swift
+++ b/Sources/Baguette/App/RootCommand.swift
@@ -30,6 +30,7 @@ struct Baguette: AsyncParsableCommand {
             LogsCommand.self,
             ServeCommand.self,
             OrientationCommand.self,
+            ShakeCommand.self,
             StatusBarCommand.self,
             LocationCommand.self,
             InstallCommand.self,

--- a/Sources/Baguette/Domain/Shake/MotionShake.swift
+++ b/Sources/Baguette/Domain/Shake/MotionShake.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// The UIKit motion-shake signal delivered to a booted simulator.
+///
+/// Knows the private Darwin notification name UIKit's shake detection
+/// listens for and the `xcrun simctl spawn` argv that posts it into a
+/// booted simulator's *guest* notify namespace. A `notify_post` from
+/// the host would land in the host's notifyd, which the iOS guest never
+/// observes — so the notification is posted by `notifyutil` spawned
+/// *inside* the simulator runtime via `simctl spawn <udid>`, where its
+/// `notify_post` reaches the guest's notifyd and UIKit's frontmost
+/// responder chain fires `motionBegan(_:with:)` / `motionEnded(_:with:)`
+/// with `UIEventSubtypeMotionShake`. This is the same signal
+/// Simulator.app's "Device → Shake" menu ultimately synthesises.
+struct MotionShake: Equatable, Sendable {
+    /// Darwin notification UIKit's shake detection observes. Widely
+    /// used from inside a running app (`notify_post` in UI tests); we
+    /// post it from a guest-spawned `notifyutil` instead so no code has
+    /// to run inside the target app.
+    static let notificationName = "com.apple.UIKit.SimulatorShake"
+
+    /// `xcrun simctl` arguments that post the shake notification inside
+    /// the guest. `notifyutil -p <name>` fires a one-shot Darwin
+    /// notification; running it under `simctl spawn <udid>` lands it in
+    /// the simulator's notify namespace rather than the host Mac's.
+    func simctlArguments(udid: String) -> [String] {
+        ["simctl", "spawn", udid, "notifyutil", "-p", Self.notificationName]
+    }
+}
+
+/// Failure mode surfaced by the shake dispatch — the guest `simctl
+/// spawn` exited non-zero (host gone, device not booted, notifyutil
+/// missing from the runtime).
+enum ShakeError: Error, Equatable {
+    case simctlFailed(status: Int32)
+}

--- a/Sources/Baguette/Domain/Shake/Shake.swift
+++ b/Sources/Baguette/Domain/Shake/Shake.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Mockable
+
+/// A booted simulator's motion-shake surface. Delivering a shake posts
+/// the `com.apple.UIKit.SimulatorShake` Darwin notification into the
+/// guest's notify namespace, so UIKit's frontmost responder chain fires
+/// `motionBegan(_:with:)` / `motionEnded(_:with:)` with
+/// `UIEventSubtypeMotionShake` — the same signal Simulator.app's
+/// "Device → Shake" menu synthesises.
+///
+/// Async because the underlying `simctl spawn` is a subprocess round
+/// trip; throwing because the spawn can fail (host gone, device not
+/// booted, `notifyutil` absent from the runtime). Prefer this handle
+/// over reaching for `MotionShake` directly so callers get the same
+/// ergonomics as `orientation()` / `location()`.
+@Mockable
+protocol Shake: Sendable {
+    /// Deliver a single shake to the booted simulator. Throws
+    /// `ShakeError.simctlFailed` when the guest spawn exits non-zero.
+    func shake() async throws
+}

--- a/Sources/Baguette/Domain/Simulator/Simulator.swift
+++ b/Sources/Baguette/Domain/Simulator/Simulator.swift
@@ -88,6 +88,12 @@ protocol Simulator: Sendable {
     /// video). Each call returns a fresh handle; the underlying `simctl
     /// addmedia` invocation is stateless.
     func photos() -> any PhotoLibrary
+
+    /// Deliver a motion shake to the booted simulator — the same signal
+    /// as Simulator.app's "Device → Shake". Each call returns a fresh
+    /// handle; the underlying `simctl spawn notifyutil` invocation is
+    /// stateless.
+    func shake() -> any Shake
 }
 
 /// `Simulator.State` lifted to a top-level enum so the protocol can

--- a/Sources/Baguette/Infrastructure/Server/Server.swift
+++ b/Sources/Baguette/Infrastructure/Server/Server.swift
@@ -149,6 +149,22 @@ struct Server: Sendable {
             }
         }
 
+        // Shake — `POST` fires a UIKit motionShake via
+        // `simulator.shake().shake()`, backed by `simctl spawn
+        // notifyutil`. Pure dispatch lives in `Server.applyShake` for
+        // unit testing.
+        router.post("/simulators/:udid/shake") { [simulators] r, _ in
+            if let rejected = rejectUntrustedBrowser(r) { return rejected }
+            switch await Self.applyShake(udid: Self.udidParam(r), simulators: simulators) {
+            case .ok:
+                return jsonOK
+            case .unknownDevice:
+                return errorJSON("unknown udid: \(Self.udidParam(r))", status: .notFound)
+            case .dispatchFailed:
+                return errorJSON("shake failed (simctl error)", status: .internalServerError)
+            }
+        }
+
         // Status bar — `POST` sets overrides from a JSON body,
         // `DELETE` clears them. Backed by `simctl status_bar`; pure
         // parse + dispatch lives in `Server.applyStatusBar` /
@@ -688,6 +704,32 @@ struct Server: Sendable {
             return .unknownDevice
         }
         return sim.orientation().set(orientation) ? .ok : .dispatchFailed
+    }
+
+    /// Outcome of `applyShake` — one case per HTTP-status branch the
+    /// shake route maps to.
+    enum ShakeOutcome: Equatable {
+        case ok
+        case unknownDevice
+        case dispatchFailed
+    }
+
+    /// Pure dispatch for `POST /simulators/:udid/shake`. Split from the
+    /// route closure so unit tests can drive every branch
+    /// (`MockSimulators` + `MockShake`) without booting Hummingbird.
+    static func applyShake(
+        udid: String,
+        simulators: any Simulators
+    ) async -> ShakeOutcome {
+        guard !udid.isEmpty, let sim = simulators.find(udid: udid) else {
+            return .unknownDevice
+        }
+        do {
+            try await sim.shake().shake()
+            return .ok
+        } catch {
+            return .dispatchFailed
+        }
     }
 
     /// Outcome of the status-bar routes — one case per HTTP-status

--- a/Sources/Baguette/Infrastructure/Shake/SimctlShake.swift
+++ b/Sources/Baguette/Infrastructure/Shake/SimctlShake.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// `Shake` backed by `xcrun simctl spawn <udid> notifyutil -p
+/// com.apple.UIKit.SimulatorShake`.
+///
+/// The orchestration here is pure: argv assembly (delegated to
+/// `MotionShake.simctlArguments(udid:)`) + the `Subprocess` exit
+/// handshake. The `Foundation.Process` plumbing lives in
+/// `HostSubprocess` (already vendored for `LogStream` / `SimctlLocation`),
+/// so this file is unit-covered end-to-end via `MockSubprocess` — only
+/// the real spawn is integration-only.
+final class SimctlShake: Shake, @unchecked Sendable {
+    private let udid: String
+    private let signal: MotionShake
+    private let subprocess: any Subprocess
+    private let xcrun: URL
+
+    init(
+        udid: String,
+        signal: MotionShake = MotionShake(),
+        subprocess: any Subprocess = HostSubprocess(),
+        xcrun: URL = URL(fileURLWithPath: "/usr/bin/xcrun")
+    ) {
+        self.udid = udid
+        self.signal = signal
+        self.subprocess = subprocess
+        self.xcrun = xcrun
+    }
+
+    func shake() async throws {
+        try await spawn(signal.simctlArguments(udid: udid))
+    }
+
+    private func spawn(_ arguments: [String]) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            do {
+                try subprocess.run(
+                    executable: xcrun,
+                    arguments: arguments,
+                    onBytes: { _ in },
+                    onExit: { code in
+                        if code == 0 {
+                            continuation.resume()
+                        } else {
+                            continuation.resume(throwing: ShakeError.simctlFailed(status: code))
+                        }
+                    }
+                )
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}

--- a/Sources/Baguette/Infrastructure/Simulator/CoreSimulator.swift
+++ b/Sources/Baguette/Infrastructure/Simulator/CoreSimulator.swift
@@ -112,6 +112,10 @@ final class CoreSimulator: Simulator, @unchecked Sendable {
         SimctlLocation(udid: udid)
     }
 
+    func shake() -> any Shake {
+        SimctlShake(udid: udid)
+    }
+
     func pasteboard() -> any Pasteboard {
         SimctlPasteboard(udid: udid)
     }

--- a/Sources/Baguette/Resources/Web/sim-native.html
+++ b/Sources/Baguette/Resources/Web/sim-native.html
@@ -1530,6 +1530,23 @@
             <path d="M8 7V5.2A2.2 2.2 0 0 1 10.2 3H19a2 2 0 0 1 2 2v8.8A2.2 2.2 0 0 1 18.8 16H17"/>
           </svg>
         </button>
+        <!-- Shake — fires a UIKit motionShake on the frontmost app
+             (shake-to-undo, shake-to-report). Momentary, like Home /
+             App switcher. POSTs to `/simulators/<udid>/shake`; the
+             server delegates to `simulator.shake().shake()`, backed by
+             `simctl spawn notifyutil`. -->
+        <button class="ico-btn" title="Shake device"
+                aria-label="Shake device"
+                onclick="window.__nativeShake && window.__nativeShake()">
+          <!-- Phone glyph flanked by motion arcs — reads as a device
+               shaking side to side. -->
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"
+               stroke-linecap="round" stroke-linejoin="round" width="17" height="17">
+            <rect x="9" y="3" width="6" height="18" rx="1.6"/>
+            <path d="M5 8.5c-1.2 2-1.2 5 0 7"/>
+            <path d="M19 8.5c1.2 2 1.2 5 0 7"/>
+          </svg>
+        </button>
       </div>
       </div><!-- /.tb-scroll -->
 

--- a/Sources/Baguette/Resources/Web/sim-native.js
+++ b/Sources/Baguette/Resources/Web/sim-native.js
@@ -951,6 +951,17 @@
           + '/orientation?value=' + encodeURIComponent(value);
       fetch(url, { method: 'POST' }).catch(() => { /* best-effort */ });
     };
+
+    // Shake — fires a UIKit motionShake on the frontmost app
+    // (shake-to-undo etc). POSTs to `/simulators/<udid>/shake`; the
+    // server delegates to `simulator.shake().shake()`, backed by
+    // `simctl spawn notifyutil`. Unlike rotate there's no visual state
+    // to mirror — the motion event lives entirely in the guest — so
+    // this is a pure fire-and-forget POST.
+    window.__nativeShake = () => {
+      const url = '/simulators/' + encodeURIComponent(udid) + '/shake';
+      fetch(url, { method: 'POST' }).catch(() => { /* best-effort */ });
+    };
   }
 
   // Surface a selected AX node in the floating `#nativeAxHost`

--- a/Tests/BaguetteTests/App/Commands/CommandParsingTests.swift
+++ b/Tests/BaguetteTests/App/Commands/CommandParsingTests.swift
@@ -20,7 +20,7 @@ struct CommandParsingTests {
             "tap", "double-tap", "swipe", "pinch", "pan", "press",
             "key", "type", "paste", "clipboard",
             "chrome", "screenshot", "render-3d", "describe-ui", "logs", "serve",
-            "orientation", "status-bar", "location", "install", "add-media",
+            "orientation", "shake", "status-bar", "location", "install", "add-media",
             "diag-digitizer-trackpad", "lifetime",
         ])
     }
@@ -151,6 +151,20 @@ struct CommandParsingTests {
     @Test func `orientation rejects argv without --udid`() {
         #expect(throws: (any Error).self) {
             try OrientationCommand.parse(["portrait"])
+        }
+    }
+
+    // MARK: - shake
+
+    @Test func `shake parses --udid`() throws {
+        let cmd = try ShakeCommand.parse(["--udid", "U"])
+        #expect(cmd.options.udid == "U")
+        #expect(ShakeCommand.configuration.commandName == "shake")
+    }
+
+    @Test func `shake rejects argv without --udid`() {
+        #expect(throws: (any Error).self) {
+            try ShakeCommand.parse([])
         }
     }
 

--- a/Tests/BaguetteTests/Server/BezelRoutesTests.swift
+++ b/Tests/BaguetteTests/Server/BezelRoutesTests.swift
@@ -79,6 +79,40 @@ struct BezelRoutesTests {
         #expect(Server.applyOrientation(udid: "U", value: "portrait", simulators: host) == .dispatchFailed)
     }
 
+    @Test func `applyShake dispatches through the simulator's shake surface`() async {
+        let host = MockSimulators()
+        let sim = MockSimulator()
+        let shake = MockShake()
+        given(host).find(udid: .value("U")).willReturn(sim)
+        given(sim).shake().willReturn(shake)
+        given(shake).shake().willReturn()
+
+        #expect(await Server.applyShake(udid: "U", simulators: host) == .ok)
+        verify(shake).shake().called(1)
+    }
+
+    @Test func `applyShake reports unknownDevice when the simulator can't be found`() async {
+        let host = MockSimulators()
+        given(host).find(udid: .value("ghost")).willReturn(nil)
+        #expect(await Server.applyShake(udid: "ghost", simulators: host) == .unknownDevice)
+    }
+
+    @Test func `applyShake reports unknownDevice when the udid is empty`() async {
+        let host = MockSimulators()
+        #expect(await Server.applyShake(udid: "", simulators: host) == .unknownDevice)
+    }
+
+    @Test func `applyShake reports dispatchFailed when the shake surface throws`() async {
+        let host = MockSimulators()
+        let sim = MockSimulator()
+        let shake = MockShake()
+        given(host).find(udid: .value("U")).willReturn(sim)
+        given(sim).shake().willReturn(shake)
+        given(shake).shake().willThrow(ShakeError.simctlFailed(status: 1))
+
+        #expect(await Server.applyShake(udid: "U", simulators: host) == .dispatchFailed)
+    }
+
     @Test func `bezelImage returns nil for an unknown udid`() {
         let chromes = MockChromes()
         let sims = MockSimulators()

--- a/Tests/BaguetteTests/Shake/MotionShakeTests.swift
+++ b/Tests/BaguetteTests/Shake/MotionShakeTests.swift
@@ -1,0 +1,22 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// Domain coverage for `MotionShake` — the value that owns the UIKit
+/// shake notification name and the `simctl spawn notifyutil` argv that
+/// posts it into a booted simulator's guest notify namespace.
+@Suite("MotionShake")
+struct MotionShakeTests {
+
+    @Test func `posts the UIKit shake notification via simctl spawn notifyutil into the guest namespace`() {
+        let shake = MotionShake()
+        #expect(shake.simctlArguments(udid: "ABC-123") == [
+            "simctl", "spawn", "ABC-123", "notifyutil", "-p",
+            "com.apple.UIKit.SimulatorShake",
+        ])
+    }
+
+    @Test func `carries the private UIKit Darwin notification name`() {
+        #expect(MotionShake.notificationName == "com.apple.UIKit.SimulatorShake")
+    }
+}

--- a/Tests/BaguetteTests/Shake/SimctlShakeTests.swift
+++ b/Tests/BaguetteTests/Shake/SimctlShakeTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+import Mockable
+@testable import Baguette
+
+/// Orchestration coverage for `SimctlShake` — argv assembly (delegated
+/// to `MotionShake`) + the `Subprocess` exit handshake. The irreducible
+/// `xcrun` spawn lives in `HostSubprocess` (integration-only), so every
+/// branch here is driven through `MockSubprocess`.
+@Suite("SimctlShake")
+struct SimctlShakeTests {
+
+    final class Captures: @unchecked Sendable {
+        var executable: URL?
+        var arguments: [String]?
+        var ran = false
+    }
+
+    private func makeShake(exitCode: Int32 = 0) -> (SimctlShake, Captures) {
+        let sub = MockSubprocess()
+        let captures = Captures()
+        given(sub).run(
+            executable: .any, arguments: .any, onBytes: .any, onExit: .any
+        ).willProduce { exe, args, _, onExit in
+            captures.ran = true
+            captures.executable = exe
+            captures.arguments = args
+            onExit(exitCode)
+        }
+        given(sub).terminate().willReturn()
+        return (SimctlShake(udid: "U", subprocess: sub), captures)
+    }
+
+    @Test func `shake spawns xcrun simctl spawn notifyutil posting the UIKit shake notification`() async throws {
+        let (shake, captures) = makeShake()
+        try await shake.shake()
+
+        #expect(captures.executable == URL(fileURLWithPath: "/usr/bin/xcrun"))
+        #expect(captures.arguments == [
+            "simctl", "spawn", "U", "notifyutil", "-p",
+            "com.apple.UIKit.SimulatorShake",
+        ])
+    }
+
+    @Test func `a non-zero simctl exit propagates as a shake failure`() async {
+        let (shake, _) = makeShake(exitCode: 3)
+        var caught: ShakeError?
+        do {
+            try await shake.shake()
+        } catch {
+            caught = error as? ShakeError
+        }
+        #expect(caught == .simctlFailed(status: 3))
+    }
+}

--- a/docs/features/shake.md
+++ b/docs/features/shake.md
@@ -1,0 +1,115 @@
+# Shake gesture
+
+Deliver a motion shake to a booted simulator — the same signal as
+Simulator.app's **Device → Shake** menu. iOS surfaces it to the
+frontmost app's responder chain as `motionBegan(_:with:)` /
+`motionEnded(_:with:)` with `UIEventSubtypeMotionShake` (the standard
+"shake to undo" / shake-to-report trigger). Three entry points share one
+dispatch:
+
+- `baguette shake --udid <UDID>` — CLI.
+- `POST /simulators/<UDID>/shake` on `baguette serve` — HTTP route.
+- The **serve UI toolbar** — a shake button next to Home / App switcher
+  (mirrors the rotate button; see [Browser](#browser) below).
+
+There is **no** gesture-WebSocket / `baguette input` stdin verb: shake
+is a device action (like `orientation`, `status-bar`, `location`), not a
+pointer/HID gesture, so it doesn't ride the `GestureRegistry` →
+`IndigoHIDInput` pipeline.
+
+## Platform scope
+
+baguette only drives **iOS** simulators. watchOS / tvOS have no shake
+concept, and CarPlay is a display surface, not a motion target — so
+shake is iOS-only by design. It fails cleanly (device-not-booted /
+unknown-udid) rather than silently no-op'ing elsewhere.
+
+## Dispatch — `simctl spawn notifyutil`
+
+`Simulator.shake().shake()` runs:
+
+```
+xcrun simctl spawn <udid> notifyutil -p com.apple.UIKit.SimulatorShake
+```
+
+`com.apple.UIKit.SimulatorShake` is the private Darwin notification
+UIKit's shake detection observes. A `notify_post` from the **host** Mac
+lands in the host's `notifyd`, which the iOS guest never sees — so the
+notification is posted by `notifyutil` spawned *inside* the simulator
+runtime via `simctl spawn <udid>`, where its `notify_post` reaches the
+**guest's** `notifyd` and UIKit fires the motion event on the frontmost
+responder.
+
+This mirrors the widely-used in-app UI-test trick
+(`notify_post("com.apple.UIKit.SimulatorShake")`), but posts from a
+guest-spawned helper so no code has to run inside the target app.
+
+### Why not the GSEvent / PurpleWorkspacePort path?
+
+Simulator.app itself synthesises shake via `-[SimDevice
+gsEventsSendShake]` — a `kGSEventMotionBegin` (1020) GSEvent over
+`PurpleWorkspacePort`, the same transport baguette's `orientation` uses.
+That path is more "native", but unlike the orientation type-50 layout
+(documented and unit-tested in `OrientationEvent`), the shake body bytes
+(motion subtype / shake-state) aren't documented — reverse-engineering
+them risks a `backboardd` crash on a wrong byte. The `simctl spawn`
+notification path is documented, carries zero mach byte-layout risk, and
+is unit-testable end-to-end. If a future need demands the GSEvent path
+(e.g. a runtime without `notifyutil`), add a `PurpleEventShake`
+alongside `PurpleEventOrientation` and swap it in `CoreSimulator.shake()`.
+
+## Layering
+
+| Layer | File | Responsibility |
+|-------|------|----------------|
+| Domain value | `Domain/Shake/MotionShake.swift` | Owns the notification name + `simctlArguments(udid:)`; `ShakeError` |
+| Domain abstraction | `Domain/Shake/Shake.swift` | `@Mockable protocol Shake { func shake() async throws }` |
+| Infrastructure | `Infrastructure/Shake/SimctlShake.swift` | argv assembly + `Subprocess` exit handshake |
+| Factory | `Infrastructure/Simulator/CoreSimulator.swift` | `func shake() -> any Shake` |
+| CLI | `App/Commands/ShakeCommand.swift` | `baguette shake --udid` |
+| Serve route | `Infrastructure/Server/Server.swift` | `POST /…/shake` + pure `applyShake` |
+
+The `Foundation.Process` plumbing is the already-vendored
+`HostSubprocess` (shared with `LogStream` / `SimctlLocation`), so
+`SimctlShake` is unit-covered end-to-end via `MockSubprocess`; only the
+real spawn is integration-only.
+
+## Wire
+
+CLI (no options beyond the target):
+
+```bash
+baguette shake --udid <UDID>
+```
+
+HTTP:
+
+```
+POST /simulators/<UDID>/shake        → {"ok":true}
+                                       404 unknown udid
+                                       500 shake failed (simctl error)
+```
+
+## Browser
+
+The `serve` native UI exposes shake as a momentary toolbar button
+(`sim-native.html`) next to Home / App switcher, wired to
+`window.__nativeShake` in `sim-native.js`. Exactly like the rotate
+button, it's a **dumb sender**: a fire-and-forget
+`POST /simulators/<udid>/shake`, no HID codes or domain logic on the
+client. Unlike rotate there's no visual state to mirror — the motion
+event lives entirely inside the guest — so the handler doesn't touch the
+bezel. The button sits inside `#nativeToolScroll`, so it's automatically
+dimmed/disabled until the guest is live (same gating as every other
+toolbar control).
+
+## Known limits
+
+- **Single shake per call.** No intensity or repeat count — one
+  `motionShake` per invocation. Loop client-side if you need a burst.
+- **Depends on `notifyutil` in the runtime.** If a future iOS runtime
+  drops the host `notifyutil` from the guest-spawn path, the spawn exits
+  non-zero and the call reports `simctlFailed`; switch to the GSEvent
+  path noted above.
+- **Frontmost-responder only.** iOS delivers `motionShake` to the first
+  responder chain; a backgrounded app won't see it.

--- a/skills/baguette/references/cli.md
+++ b/skills/baguette/references/cli.md
@@ -295,6 +295,17 @@ packed into a stored zip in-page and posted as `<Name>.app.zip`. See
 directory directly but not a `.zip`; generic docs (`.pdf`, `.json`, …)
 have no home on a simulator and are refused.
 
+## Shake — `shake`
+
+```bash
+baguette shake --udid <UDID>   # UIKit motionShake on the frontmost app → simctl spawn notifyutil -p com.apple.UIKit.SimulatorShake
+```
+
+Device action (not a gesture): the frontmost responder gets
+`motionBegan/Ended` with `UIEventSubtypeMotionShake`. iOS-only. Also on
+`serve` as `POST /simulators/<UDID>/shake`. See
+[`docs/features/shake.md`](../../../docs/features/shake.md).
+
 ## Simulated GPS location — `location`
 
 ```bash

--- a/skills/baguette/references/wire-protocol.md
+++ b/skills/baguette/references/wire-protocol.md
@@ -296,6 +296,18 @@ tree, or skip the image and act on the labels and frames directly.
 
 These do not exist for `baguette input` (no stream there).
 
+## Shake HTTP route
+
+Device action, not a gesture verb — fires a UIKit `motionShake` on the
+booted simulator's frontmost app:
+
+```http
+POST /simulators/<UDID>/shake
+```
+
+Response: `{"ok":true}`; `404` unknown udid; `500 shake failed (simctl
+error)`. iOS-only. See [`docs/features/shake.md`](../../../docs/features/shake.md).
+
 ## 3D render HTTP routes
 
 3D rendering is HTTP, not a WebSocket gesture verb:


### PR DESCRIPTION
## Summary

Adds a **shake** action for booted iOS simulators — the same signal as
Simulator.app's **Device → Shake** (UIKit fires `motionShake` on the
frontmost responder: shake-to-undo, shake-to-report, etc.). Three entry
points share one dispatch:

- `baguette shake --udid <UDID>` — CLI
- `POST /simulators/<UDID>/shake` — `baguette serve` HTTP route
- A shake button in the serve native toolbar (next to Home / App
  switcher, mirroring the rotate button)

## Mechanism

Backed by `xcrun simctl spawn <udid> notifyutil -p
com.apple.UIKit.SimulatorShake`, which posts the private UIKit Darwin
notification into the **guest's** notify namespace (a host `notify_post`
never reaches the iOS guest, so it's spawned inside the runtime).

Chosen over the native `-[SimDevice gsEventsSendShake]` /
`PurpleWorkspacePort` GSEvent path: unlike orientation's documented
type-50 layout, the shake GSEvent body bytes aren't documented —
reverse-engineering them risks a `backboardd` crash. The notification
path is documented, crash-free, and unit-testable end-to-end. If a
runtime ever lacks `notifyutil`, a `PurpleEventShake` can slot in beside
`PurpleEventOrientation`.

## Architecture

Modeled as a device action (like `orientation` / `status-bar` /
`location`), **not** a pointer/HID gesture — it does not ride the
`GestureRegistry` → `IndigoHIDInput` pipeline.

| Layer | Change |
|-------|--------|
| Domain | `MotionShake` value (notification name + argv), `Shake` `@Mockable` abstraction, `ShakeError` |
| Infra | `SimctlShake` (argv + `Subprocess` exit handshake), `CoreSimulator.shake()` |
| App | `ShakeCommand` (`baguette shake`) |
| Serve | `POST /simulators/:udid/shake` + pure `Server.applyShake` |
| Web | toolbar button → `window.__nativeShake` (dumb `POST` sender) |

## Testing

- TDD throughout (red → green): `MotionShakeTests`, `SimctlShakeTests`
  (driven via `MockSubprocess`), `applyShake` route branches, CLI parse
  tests. **1006 tests pass.**
- `SimctlShake` is unit-covered end-to-end; only the real `simctl` spawn
  is integration-only.
- Manual smoke: no booted sim was available in this environment, so the
  live end-to-end shake was **not** verified — CLI wiring + guard paths
  were confirmed (`baguette shake --help`, unknown-udid exits 1).

## Scope

iOS-only by design (watchOS/tvOS have no shake; CarPlay is a display
surface) — fails cleanly elsewhere rather than silently no-op'ing.

See `docs/features/shake.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an iOS Simulator shake action through the CLI, HTTP API, and serve UI.
  - Added a toolbar button to trigger a shake for the active simulator.
  - Added validation for simulator availability and boot status, with clear failure responses.

- **Documentation**
  - Documented shake usage, supported entry points, API responses, and iOS-only limitations.

- **Tests**
  - Added coverage for command parsing, API behavior, simulator targeting, successful shakes, and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->