### PR TITLE
fix(web): style the plugins rail from the focus-mode design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Changed
+
+- **The plugins rail follows the focus-mode design system.** The rail, its
+  flyout, the panel and the bakery modal were styled by a stylesheet
+  `sim-plugins.js` injected into `document.head` — and a stylesheet written
+  beside its module can't see the `--nv-*` theme tokens, which are defined on
+  `#simNativeView`. Every colour in it therefore carried a guessed fallback,
+  and the guesses were light-theme values: light-slate shadows with no dark
+  variant, a white `var(--panel)` text field inside a dark glass modal, and an
+  accent pulled from `sim.html`'s light-only `--accent` rather than
+  `--nv-accent`. It also invented its own geometry — 34×34 rail buttons at
+  radius 9 against the toolbar's 30×28 at radius 8, a `600 10px/0.06em` accent
+  heading against the app's `700 9.5px/0.10em` faint one, a fourth primary
+  button, and four 2px accent seams no other surface has.
+
+  All of it now lives in `sim-native.html` under `#simNativeView`, beside the
+  panels it sits next to, with no fallbacks — the same arrangement the logs,
+  status-bar, location and a11y panels already use. The companion-screens rail
+  moved with it and the two now share every rule they had duplicated. The rails
+  being separate is the trust signal (see `docs/features/plugins.md`); the
+  plugin rail keeps its accent emblem to say which is which, and drops the
+  second colour system that was layered on top.
+
+### Added
+
+- `--nv-danger`, `--nv-warn` and `--nv-scrim` theme tokens, in both light and
+  dark. A panel reporting an error previously picked its own red, and the one
+  it picked was a light-theme `#b91c1c` on a near-black page. Plugin row
+  severity is now a `data-severity` attribute the stylesheet colours, rather
+  than an inline hex the module carries.
+
 ---
 
 ## [0.1.91] - 2026-08-14

--- a/Sources/Baguette/Resources/Web/sim-native.html
+++ b/Sources/Baguette/Resources/Web/sim-native.html
@@ -53,6 +53,13 @@
     --nv-fmt-btn-text:   rgba(245, 245, 247, 0.65);
     --nv-accent:         #2563eb;
     --nv-accent-text:    #fff;
+    /* Status colours and the modal scrim. Both themes get a value for
+       the same reason the rest of this block exists: a panel reporting
+       an error picked its own red before these were here, and the one
+       it picked was a light-theme red on a near-black page. */
+    --nv-danger:         #f87171;
+    --nv-warn:           #fbbf24;
+    --nv-scrim:          rgba(0, 0, 0, 0.55);
 
     position: fixed; inset: 0;
     display: flex; align-items: center; justify-content: center;
@@ -83,6 +90,9 @@
       --nv-fmt-track-bg:   rgba(15, 23, 42, 0.06);
       --nv-fmt-track-border: rgba(15, 23, 42, 0.06);
       --nv-fmt-btn-text:   rgba(29, 29, 31, 0.65);
+      --nv-danger:         #b91c1c;
+      --nv-warn:           #b45309;
+      --nv-scrim:          rgba(15, 23, 42, 0.32);
     }
     #simNativeView:not([data-theme="dark"]) .carplay-frame,
     #simNativeView:not([data-theme="dark"]) .watch-frame {
@@ -105,6 +115,9 @@
     --nv-fmt-track-bg:   rgba(15, 23, 42, 0.06);
     --nv-fmt-track-border: rgba(15, 23, 42, 0.06);
     --nv-fmt-btn-text:   rgba(29, 29, 31, 0.65);
+    --nv-danger:         #b91c1c;
+    --nv-warn:           #b45309;
+    --nv-scrim:          rgba(15, 23, 42, 0.32);
   }
   #simNativeView[data-theme="light"] .carplay-frame,
   #simNativeView[data-theme="light"] .watch-frame {
@@ -768,20 +781,11 @@
     pointer-events: none;
   }
   #simNativeView .right-rails > * { pointer-events: auto; }
-  /* The rails position themselves when they stand alone (the plugin
-     rail is also used outside focus mode); inside the stack the flex
-     column places them.
-
-     `order` rather than DOM order: both rails are appended by their own
+  /* `order` rather than DOM order: both rails are appended by their own
      async fetch, so whichever server answer lands first would otherwise
      decide which rail is on top — and the plugins rail beat the screens
      rail on a warm cache but not a cold one. baguette's own controls go
      above the ones you installed, every time. */
-  #simNativeView .right-rails > .plugin-rail,
-  #simNativeView .right-rails > .screens-rail {
-    position: static;
-    transform: none;
-  }
   #simNativeView .right-rails > .screens-rail { order: 1; }
   #simNativeView .right-rails > .plugin-rail  { order: 2; }
 
@@ -1572,6 +1576,360 @@
   #simNativeView .ax-host .btn-primary {
     background: var(--nv-text); color: var(--nv-bar-bg);
     border-color: transparent;
+  }
+
+  /* --- Right-edge rails: companion screens + plugins -----------------
+     Both rails and everything they open. This lives here, with the rest
+     of the focus chrome, rather than in sim-screens.js / sim-plugins.js
+     — those used to inject a stylesheet each, and a stylesheet written
+     next to its module can't see the token block, so both had to guess
+     at a fallback for every colour. The guesses were light-theme values,
+     so the rails rendered light-on-dark wherever a token didn't reach,
+     and the two rails drifted from each other and from the toolbar.
+
+     The two share every shape below. What tells them apart is one
+     thing: the plugin rail's emblem is drawn in the accent, baguette's
+     own rail's in the muted text colour. The rails being separate is
+     the trust signal (see docs/features/plugins.md); it doesn't need a
+     second colour system on top. */
+  #simNativeView .screens-rail,
+  #simNativeView .plugin-rail {
+    display: flex; flex-direction: column; align-items: center; gap: 6px;
+    padding: 8px 6px;
+    background: var(--nv-bar-bg);
+    border: 1px solid var(--nv-bar-border);
+    border-radius: 14px;
+    box-shadow: var(--nv-bar-shadow), var(--nv-bar-inset);
+    backdrop-filter: blur(18px) saturate(1.5);
+    -webkit-backdrop-filter: blur(18px) saturate(1.5);
+    color: var(--nv-text);
+  }
+  /* Emblem cap — names the strip. */
+  #simNativeView .screens-rail-cap,
+  #simNativeView .plugin-rail-cap {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 30px; height: 24px;
+    color: var(--nv-text-muted);
+  }
+  #simNativeView .plugin-rail-cap { color: var(--nv-accent); }
+  #simNativeView .screens-rail-divider,
+  #simNativeView .plugin-rail-divider {
+    width: 20px; height: 1px; margin: 1px 0 3px;
+    background: var(--nv-divider);
+  }
+
+  /* Rail buttons are the toolbar's `.ico-btn` in a column — same box,
+     same radius, same hover / active / selected treatment. */
+  #simNativeView .screens-rail-btn,
+  #simNativeView .plugin-rail-btn {
+    position: relative;
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 30px; height: 28px; padding: 0;
+    background: transparent; border: 0; border-radius: 8px;
+    color: var(--nv-text); cursor: pointer;
+    transition: background 0.12s ease, opacity 0.12s ease;
+  }
+  #simNativeView .screens-rail-btn:hover,
+  #simNativeView .plugin-rail-btn:hover { background: var(--nv-btn-hover); }
+  #simNativeView .screens-rail-btn:active,
+  #simNativeView .plugin-rail-btn:active { background: var(--nv-btn-active); }
+  #simNativeView .screens-rail-btn.active,
+  #simNativeView .plugin-rail-btn.active {
+    background: var(--nv-accent); color: var(--nv-accent-text);
+  }
+  #simNativeView .screens-rail-btn:focus-visible,
+  #simNativeView .plugin-rail-btn:focus-visible {
+    outline: 2px solid var(--nv-accent); outline-offset: 2px;
+  }
+  #simNativeView .screens-rail-btn svg,
+  #simNativeView .plugin-rail-btn svg { display: block; }
+  /* A slot whose flyout is open, but which isn't the open panel. */
+  #simNativeView .plugin-rail-btn.expanded { background: var(--nv-btn-hover); }
+  /* Dimmed, not hidden: the button is how you find out the screen could
+     exist, and how you reach the instructions for attaching one. */
+  #simNativeView .screens-rail-btn.unavailable { opacity: 0.38; }
+  #simNativeView .screens-rail-btn.unavailable:hover { opacity: 0.7; }
+  #simNativeView .screens-rail-refresh { color: var(--nv-text-muted); }
+  #simNativeView .plugin-rail-add { color: var(--nv-accent); }
+  /* A caret on plugins that hold more than one tool: says "there is
+     more here, and it opens leftward" before you hover to find out. */
+  #simNativeView .plugin-rail-group::after {
+    content: ''; position: absolute; left: 2px; top: 50%;
+    margin-top: -3px; border: 3px solid transparent;
+    border-right-color: currentColor; opacity: 0.4;
+    transition: opacity 0.12s ease;
+  }
+  #simNativeView .plugin-rail-group:hover::after,
+  #simNativeView .plugin-rail-group.expanded::after { opacity: 0.75; }
+
+  /* The flyout listing one plugin's tools, and the companion-screens
+     card. Both are `position: fixed` and placed by their module against
+     the button that opened them, so only the surface is described here.
+     Same glass, radius and motion as the floating panels above. */
+  #simNativeView .plugin-flyout,
+  #simNativeView .screens-card {
+    position: fixed; z-index: 50;
+    background: var(--nv-bar-bg);
+    border: 1px solid var(--nv-bar-border);
+    border-radius: 12px;
+    box-shadow: var(--nv-bar-shadow), var(--nv-bar-inset);
+    backdrop-filter: blur(18px) saturate(1.5);
+    -webkit-backdrop-filter: blur(18px) saturate(1.5);
+    color: var(--nv-text);
+    animation: nv-rail-pop-in 0.16s ease;
+  }
+  #simNativeView .plugin-flyout {
+    min-width: 172px; max-width: 260px;
+    padding: 5px; display: flex; flex-direction: column; gap: 1px;
+  }
+  #simNativeView .screens-card { width: 268px; }
+  @keyframes nv-rail-pop-in {
+    from { opacity: 0; transform: translateX(4px); }
+    to   { opacity: 1; transform: translateX(0); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    #simNativeView .plugin-flyout,
+    #simNativeView .screens-card { animation: none; }
+  }
+  /* Micro-heading, same as the status-bar card's section titles. */
+  #simNativeView .plugin-flyout-head {
+    padding: 6px 8px 7px; margin-bottom: 3px;
+    color: var(--nv-text-faint);
+    font: 700 9.5px/1 -apple-system, sans-serif;
+    letter-spacing: 0.10em; text-transform: uppercase;
+    border-bottom: 1px solid var(--nv-divider);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  #simNativeView .plugin-flyout-item {
+    display: flex; align-items: center; gap: 8px; width: 100%;
+    padding: 6px 8px; border: 0; border-radius: 8px; cursor: pointer;
+    background: transparent; text-align: left;
+    font: 500 12px/1.2 -apple-system, sans-serif;
+    color: var(--nv-text);
+    transition: background 0.12s ease;
+  }
+  #simNativeView .plugin-flyout-item:hover { background: var(--nv-btn-hover); }
+  #simNativeView .plugin-flyout-item.active {
+    background: var(--nv-accent); color: var(--nv-accent-text);
+  }
+  #simNativeView .plugin-flyout-item:focus-visible {
+    outline: 2px solid var(--nv-accent); outline-offset: -2px;
+  }
+  #simNativeView .plugin-flyout-glyph {
+    display: inline-flex; flex: 0 0 auto; color: var(--nv-text-muted);
+  }
+  #simNativeView .plugin-flyout-item:hover .plugin-flyout-glyph,
+  #simNativeView .plugin-flyout-item.active .plugin-flyout-glyph { color: inherit; }
+  #simNativeView .plugin-flyout-label {
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+
+  /* The open plugin panel. Anchored like the other floating panels
+     (`top: 84px`, the same height budget) but inset from the right far
+     enough to clear the rails it opens from, rather than the 24px the
+     panels that have no rail beside them use. */
+  #simNativeView .plugin-host {
+    position: fixed;
+    top: 84px;
+    right: 76px;
+    z-index: 40;
+    width: 340px;
+    max-height: calc(100dvh - 120px);
+  }
+  #simNativeView .plugin-card {
+    display: flex; flex-direction: column;
+    max-height: calc(100dvh - 120px);
+    background: var(--nv-bar-bg);
+    border: 1px solid var(--nv-bar-border);
+    border-radius: 14px;
+    box-shadow: var(--nv-bar-shadow), var(--nv-bar-inset);
+    backdrop-filter: blur(18px) saturate(1.5);
+    -webkit-backdrop-filter: blur(18px) saturate(1.5);
+    color: var(--nv-text);
+    overflow: hidden;
+  }
+  #simNativeView .plugin-head,
+  #simNativeView .screens-card-head {
+    display: flex; align-items: center; gap: 8px;
+    padding: 11px 12px 9px 14px;
+    border-bottom: 1px solid var(--nv-divider);
+  }
+  #simNativeView .plugin-title,
+  #simNativeView .screens-card-title {
+    font: 600 13px/1.2 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+    letter-spacing: 0.01em;
+  }
+  /* Which plugin the panel came from. Quiet chip, not a second accent:
+     the panel is already inside the plugin system by the time you read
+     it. */
+  #simNativeView .plugin-tag {
+    border: 1px solid var(--nv-bar-border);
+    background: var(--nv-fmt-track-bg);
+    color: var(--nv-text-muted);
+    font: 600 9.5px/1 -apple-system, sans-serif;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    padding: 4px 7px; border-radius: 999px;
+  }
+  #simNativeView .plugin-close,
+  #simNativeView .screens-card-close {
+    margin-left: auto;
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 24px; height: 22px; padding: 0;
+    background: transparent; border: 0; border-radius: 8px;
+    color: var(--nv-text-muted); cursor: pointer;
+    font: 500 12px/1 -apple-system, sans-serif;
+    transition: background 0.12s ease, color 0.12s ease;
+  }
+  #simNativeView .plugin-close:hover,
+  #simNativeView .screens-card-close:hover {
+    background: var(--nv-btn-hover); color: var(--nv-text);
+  }
+  #simNativeView .plugin-body { overflow-y: auto; }
+  #simNativeView .plugin-status {
+    padding: 12px 14px;
+    font: 400 12px/1.4 -apple-system, sans-serif;
+    color: var(--nv-text-muted);
+  }
+  #simNativeView .plugin-error { color: var(--nv-danger); }
+  #simNativeView .plugin-rows { list-style: none; margin: 0; padding: 4px 0; }
+  #simNativeView .plugin-row {
+    display: flex; gap: 8px; align-items: flex-start;
+    padding: 8px 14px;
+    font: 400 12px/1.35 -apple-system, sans-serif;
+    color: var(--nv-text);
+  }
+  #simNativeView .plugin-row-clickable { cursor: pointer; }
+  #simNativeView .plugin-row-clickable:hover { background: var(--nv-btn-hover); }
+  #simNativeView .plugin-row-active { background: var(--nv-btn-active); }
+  /* Severity is an attribute rather than an inline colour, so the three
+     reds and ambers this panel can show are the page's, not a palette
+     the module carries. */
+  #simNativeView .plugin-dot {
+    width: 7px; height: 7px; border-radius: 50%; margin-top: 4px;
+    flex: 0 0 auto; background: var(--nv-text-muted);
+  }
+  #simNativeView .plugin-dot[data-severity="warn"]  { background: var(--nv-warn); }
+  #simNativeView .plugin-dot[data-severity="error"] { background: var(--nv-danger); }
+  #simNativeView .plugin-row-text {
+    display: flex; flex-direction: column; gap: 2px; min-width: 0;
+  }
+  #simNativeView .plugin-row-sub {
+    color: var(--nv-text-muted); font-size: 11px; overflow-wrap: anywhere;
+  }
+  /* The box drawn over the live screen for a `highlight` row. */
+  #simNativeView .plugin-highlight {
+    position: absolute; z-index: 30; pointer-events: none;
+    border: 2px solid var(--nv-accent);
+    background: color-mix(in srgb, var(--nv-accent) 16%, transparent);
+    border-radius: 6px;
+  }
+
+  /* Companion-screens card body — the "how to attach one" instructions. */
+  #simNativeView .screens-card-body { padding: 11px 14px 13px; }
+  #simNativeView .screens-card-status {
+    margin: 0 0 8px;
+    font: 600 11px/1.35 -apple-system, sans-serif;
+    color: var(--nv-text-muted);
+  }
+  #simNativeView .screens-card-note {
+    margin: 0 0 10px;
+    font: 400 11.5px/1.45 -apple-system, sans-serif;
+    color: var(--nv-text-muted);
+  }
+  #simNativeView .screens-steps {
+    margin: 0 0 11px; padding-left: 17px;
+    display: flex; flex-direction: column; gap: 6px;
+    font: 400 11.5px/1.45 -apple-system, sans-serif;
+    color: var(--nv-text);
+  }
+  #simNativeView .screens-steps li { overflow-wrap: anywhere; }
+
+  /* The bakery-preview modal, opened from the rail's "+". */
+  #simNativeView .plugin-modal-overlay {
+    position: fixed; inset: 0; z-index: 60;
+    display: flex; align-items: center; justify-content: center;
+    background: var(--nv-scrim);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+  }
+  #simNativeView .plugin-modal {
+    width: min(440px, 92vw);
+    background: var(--nv-bar-bg);
+    border: 1px solid var(--nv-bar-border);
+    border-radius: 14px;
+    box-shadow: var(--nv-bar-shadow), var(--nv-bar-inset);
+    backdrop-filter: blur(18px) saturate(1.5);
+    -webkit-backdrop-filter: blur(18px) saturate(1.5);
+    color: var(--nv-text);
+    overflow: hidden;
+  }
+  #simNativeView .plugin-modal-body {
+    padding: 14px; display: flex; flex-direction: column; gap: 10px;
+  }
+  #simNativeView .plugin-field-label {
+    font: 500 11px/1.3 -apple-system, sans-serif;
+    color: var(--nv-text-muted);
+  }
+  #simNativeView .plugin-field-row { display: flex; gap: 8px; }
+  #simNativeView .plugin-input {
+    flex: 1; appearance: none; -webkit-appearance: none;
+    padding: 6px 8px; border-radius: 8px;
+    background: var(--nv-fmt-track-bg);
+    border: 1px solid var(--nv-bar-border);
+    color: var(--nv-text);
+    font: 400 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+    min-width: 0; box-sizing: border-box;
+  }
+  #simNativeView .plugin-input:focus {
+    outline: none; border-color: var(--nv-accent);
+  }
+  #simNativeView .plugin-btn,
+  #simNativeView .screens-card-btn {
+    appearance: none; padding: 8px 12px;
+    border: 0; border-radius: 8px; cursor: pointer;
+    font: 600 12px/1 -apple-system, sans-serif;
+    color: var(--nv-accent-text); background: var(--nv-accent);
+  }
+  #simNativeView .screens-card-btn { width: 100%; }
+  #simNativeView .plugin-btn:disabled,
+  #simNativeView .screens-card-btn:disabled { opacity: 0.45; cursor: default; }
+  #simNativeView .plugin-warn {
+    font: 400 12px/1.45 -apple-system, sans-serif;
+    color: var(--nv-text);
+    background: color-mix(in srgb, var(--nv-warn) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--nv-warn) 30%, transparent);
+    border-radius: 8px; padding: 10px;
+  }
+  #simNativeView .plugin-commit {
+    font: 500 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--nv-text-muted);
+  }
+  #simNativeView .plugin-offers {
+    list-style: none; margin: 4px 0 0; padding: 0;
+    display: flex; flex-direction: column; gap: 6px;
+  }
+  #simNativeView .plugin-offer {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 10px; padding: 8px 10px; border-radius: 8px;
+    background: var(--nv-fmt-track-bg);
+    font: 500 12px/1.2 -apple-system, sans-serif;
+    color: var(--nv-text);
+  }
+  #simNativeView .plugin-inline-error {
+    font-size: 11px; margin-left: 8px; color: var(--nv-danger);
+  }
+  /* The install command. Selectable and monospaced — it exists to be
+     read and run, so it must look like something you'd paste. */
+  #simNativeView .plugin-cmd {
+    flex: 1 1 auto; min-width: 0; overflow-x: auto; white-space: nowrap;
+    user-select: all; -webkit-user-select: all;
+    font: 500 11px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--nv-text-muted);
+  }
+
+  @media (max-width: 560px) {
+    #simNativeView .plugin-host { right: 12px; left: 12px; width: auto; }
+    #simNativeView .screens-card { width: auto; left: 12px; right: 12px; }
   }
 
   /* Preview ribbon — only when opened via file:// */

--- a/Sources/Baguette/Resources/Web/sim-plugins.js
+++ b/Sources/Baguette/Resources/Web/sim-plugins.js
@@ -54,7 +54,10 @@
 
   ICONS.puzzle = PUZZLE;
 
-  const SEVERITY_COLOR = { error: '#b91c1c', warn: '#b45309', info: '#64748b' };
+  // The severities the stylesheet draws a dot for. Anything else — a
+  // level from a newer manifest, or a typo — falls back to `info`
+  // rather than reaching the page as an unrecognised attribute value.
+  const SEVERITIES = ['info', 'warn', 'error'];
 
   function escapeHTML(s) {
     return String(s == null ? '' : s)
@@ -148,7 +151,6 @@
     }
 
     render() {
-      PluginPanels.injectCSS();
       this.buildRail();
       for (const group of this.visibleGroups()) this.addGroup(group);
       // The "+ Add" entry point always shows, so a fresh user with no
@@ -478,10 +480,10 @@
       }
       const action = new window.Baguette._PluginRowAction(rowAction);
       const items = rows.map((row, index) => {
-        const color = SEVERITY_COLOR[row.severity] || SEVERITY_COLOR.info;
+        const severity = SEVERITIES.includes(row.severity) ? row.severity : 'info';
         const clickable = action.actionable(row) ? ' plugin-row-clickable' : '';
         return '<li class="plugin-row' + clickable + '" data-index="' + index + '">'
-             + '<span class="plugin-dot" style="background:' + color + '"></span>'
+             + '<span class="plugin-dot" data-severity="' + severity + '"></span>'
              + '<span class="plugin-row-text">'
              +   '<span class="plugin-row-title">' + escapeHTML(row.title) + '</span>'
              +   (row.subtitle
@@ -605,171 +607,11 @@
 
   }
 
-  // Host-owned styling. Injected here rather than added to
-  // sim-native.html so the module stays self-contained; no plugin
-  // contributes CSS. The rail gets an accent seam so it reads as a
-  // distinct system, not another toolbar.
-  const CSS = `
-  .plugin-rail { position: fixed; right: 16px; top: 50%; transform: translateY(-50%);
-                 display: flex; flex-direction: column; align-items: center; gap: 6px;
-                 padding: 8px 6px; z-index: 45;
-                 background: var(--nv-bar-bg, rgba(255,255,255,0.92));
-                 border: 1px solid var(--nv-bar-border, rgba(15,23,42,0.10));
-                 border-left: 2px solid var(--accent, #2563eb);
-                 border-radius: 14px;
-                 box-shadow: var(--nv-bar-shadow, 0 8px 30px rgba(15,23,42,0.12));
-                 backdrop-filter: blur(18px) saturate(1.5);
-                 -webkit-backdrop-filter: blur(18px) saturate(1.5);
-                 color: var(--nv-text, #1d1d1f); }
-  .plugin-rail-cap { display: inline-flex; align-items: center; justify-content: center;
-                     width: 30px; height: 24px; color: var(--accent, #2563eb); opacity: 0.85; }
-  .plugin-rail-divider { width: 20px; height: 1px; margin: 1px 0 3px;
-                         background: var(--nv-divider, rgba(15,23,42,0.14)); }
-  .plugin-rail-btn { position: relative; width: 34px; height: 34px; padding: 0; border: 0;
-                     cursor: pointer;
-                     display: inline-flex; align-items: center; justify-content: center;
-                     background: transparent; border-radius: 9px; color: var(--nv-text, #1d1d1f);
-                     transition: background 0.12s ease, transform 0.12s ease; }
-  .plugin-rail-btn:hover  { background: var(--nv-btn-hover, rgba(15,23,42,0.06)); }
-  .plugin-rail-btn:active { transform: scale(0.94); }
-  .plugin-rail-btn.active { background: color-mix(in srgb, var(--accent, #2563eb) 16%, transparent);
-                            color: var(--accent, #2563eb); }
-  .plugin-rail-btn.expanded { background: var(--nv-btn-hover, rgba(15,23,42,0.06)); }
-  /* A caret on plugins that hold more than one tool: says "there is
-     more here, and it opens leftward" before you hover to find out. */
-  .plugin-rail-group::after { content: ''; position: absolute; left: 3px; top: 50%;
-                              margin-top: -3px; border: 3px solid transparent;
-                              border-right-color: currentColor; opacity: 0.4;
-                              transition: opacity 0.12s ease; }
-  .plugin-rail-group:hover::after, .plugin-rail-group.expanded::after { opacity: 0.75; }
-
-  .plugin-flyout { position: fixed; z-index: 50; min-width: 172px; max-width: 260px;
-                   padding: 5px; display: flex; flex-direction: column; gap: 1px;
-                   background: var(--nv-bar-bg, rgba(255,255,255,0.96));
-                   border: 1px solid var(--nv-bar-border, rgba(15,23,42,0.10));
-                   border-right: 2px solid var(--accent, #2563eb);
-                   border-radius: 12px;
-                   box-shadow: 0 10px 34px rgba(15,23,42,0.20);
-                   backdrop-filter: blur(18px) saturate(1.5);
-                   -webkit-backdrop-filter: blur(18px) saturate(1.5);
-                   animation: plugin-flyout-in 0.12s ease-out; }
-  @keyframes plugin-flyout-in { from { opacity: 0; transform: translateX(6px); }
-                                to   { opacity: 1; transform: translateX(0); } }
-  @media (prefers-reduced-motion: reduce) { .plugin-flyout { animation: none; } }
-  .plugin-flyout-head { padding: 5px 8px 6px; font: 600 10px/1 -apple-system, sans-serif;
-                        letter-spacing: 0.06em; text-transform: uppercase;
-                        color: var(--accent, #2563eb);
-                        border-bottom: 1px solid var(--nv-divider, rgba(15,23,42,0.10));
-                        margin-bottom: 3px; overflow: hidden; text-overflow: ellipsis;
-                        white-space: nowrap; }
-  .plugin-flyout-item { display: flex; align-items: center; gap: 9px; width: 100%;
-                        padding: 7px 9px; border: 0; border-radius: 8px; cursor: pointer;
-                        background: transparent; text-align: left;
-                        font: 500 12px/1.2 -apple-system, sans-serif;
-                        color: var(--nv-text, #1d1d1f);
-                        transition: background 0.1s ease; }
-  .plugin-flyout-item:hover { background: var(--nv-btn-hover, rgba(15,23,42,0.06)); }
-  .plugin-flyout-item.active { background: color-mix(in srgb, var(--accent, #2563eb) 14%, transparent);
-                               color: var(--accent, #2563eb); }
-  .plugin-flyout-glyph { display: inline-flex; flex: 0 0 auto;
-                         color: var(--nv-text-muted, rgba(29,29,31,0.65)); }
-  .plugin-flyout-item:hover .plugin-flyout-glyph,
-  .plugin-flyout-item.active .plugin-flyout-glyph { color: inherit; }
-  .plugin-flyout-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-
-  .plugin-host { position: fixed; right: 72px; top: 50%; transform: translateY(-50%);
-                 width: 340px; max-height: 66vh; z-index: 44; }
-  .plugin-card { background: var(--nv-bar-bg, rgba(255,255,255,0.94));
-                 border: 1px solid var(--nv-bar-border, rgba(15,23,42,0.10));
-                 border-top: 2px solid var(--accent, #2563eb);
-                 border-radius: 14px; box-shadow: 0 10px 34px rgba(15,23,42,0.20);
-                 backdrop-filter: blur(18px) saturate(1.5);
-                 -webkit-backdrop-filter: blur(18px) saturate(1.5);
-                 overflow: hidden; display: flex; flex-direction: column; max-height: 66vh; }
-  .plugin-head { display: flex; align-items: center; gap: 8px; padding: 10px 12px;
-                 border-bottom: 1px solid var(--nv-divider, rgba(15,23,42,0.10)); }
-  .plugin-title { font: 600 12px/1 -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif;
-                  color: var(--nv-text, #1d1d1f); letter-spacing: 0.02em; }
-  .plugin-tag { font: 600 10px/1 -apple-system, sans-serif; letter-spacing: 0.04em;
-                text-transform: lowercase; color: var(--accent, #2563eb);
-                background: color-mix(in srgb, var(--accent, #2563eb) 12%, transparent);
-                padding: 3px 6px; border-radius: 999px; }
-  .plugin-close { margin-left: auto; border: 0; background: transparent; cursor: pointer;
-                  font-size: 12px; color: var(--nv-text-muted, rgba(29,29,31,0.65)); padding: 2px 4px; }
-  .plugin-body { overflow-y: auto; }
-  .plugin-status { padding: 14px 12px; font: 400 12px/1.4 -apple-system, sans-serif;
-                   color: var(--nv-text-muted, rgba(29,29,31,0.65)); }
-  .plugin-error { color: #b91c1c; }
-  .plugin-rows { list-style: none; margin: 0; padding: 4px 0; }
-  .plugin-row { display: flex; gap: 8px; align-items: flex-start; padding: 8px 12px;
-                font: 400 12px/1.35 -apple-system, sans-serif; color: var(--nv-text, #1d1d1f); }
-  .plugin-row-clickable { cursor: pointer; }
-  .plugin-row-clickable:hover { background: var(--nv-btn-hover, rgba(15,23,42,0.06)); }
-  .plugin-row-active { background: var(--nv-btn-active, rgba(15,23,42,0.12)); }
-  .plugin-dot { width: 7px; height: 7px; border-radius: 50%; margin-top: 4px; flex: 0 0 auto; }
-  .plugin-row-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-  .plugin-row-sub { color: var(--nv-text-muted, rgba(29,29,31,0.65)); font-size: 11px;
-                    overflow-wrap: anywhere; }
-  .plugin-highlight { position: absolute; border: 2px solid var(--accent, #2563eb);
-                      background: rgba(37,99,235,0.16); border-radius: 3px;
-                      pointer-events: none; z-index: 30; }
-
-  .plugin-rail-add { color: var(--accent, #2563eb); }
-
-  .plugin-modal-overlay { position: fixed; inset: 0; z-index: 60;
-                          display: flex; align-items: center; justify-content: center;
-                          background: rgba(15,23,42,0.32); backdrop-filter: blur(2px); }
-  .plugin-modal { width: min(440px, 92vw);
-                  background: var(--nv-bar-bg, rgba(255,255,255,0.98));
-                  border: 1px solid var(--nv-bar-border, rgba(15,23,42,0.12));
-                  border-top: 2px solid var(--accent, #2563eb);
-                  border-radius: 14px; box-shadow: 0 20px 60px rgba(15,23,42,0.30);
-                  overflow: hidden; }
-  .plugin-modal-body { padding: 14px; display: flex; flex-direction: column; gap: 10px; }
-  .plugin-field-label { font: 500 11px/1.3 -apple-system, sans-serif;
-                        color: var(--nv-text-muted, rgba(29,29,31,0.65)); }
-  .plugin-field-row { display: flex; gap: 8px; }
-  .plugin-input { flex: 1; padding: 8px 10px; border-radius: 8px;
-                  border: 1px solid var(--nv-bar-border, rgba(15,23,42,0.16));
-                  background: var(--panel, #fff); color: var(--nv-text, #1d1d1f);
-                  font: 400 13px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; }
-  .plugin-btn { padding: 8px 12px; border: 0; border-radius: 8px; cursor: pointer;
-                font: 600 12px/1 -apple-system, sans-serif; color: #fff;
-                background: var(--accent, #2563eb); }
-  .plugin-btn:disabled { opacity: 0.6; cursor: default; }
-  .plugin-warn { font: 400 12px/1.45 -apple-system, sans-serif; color: var(--nv-text, #1d1d1f);
-                 background: color-mix(in srgb, #b45309 10%, transparent);
-                 border: 1px solid color-mix(in srgb, #b45309 26%, transparent);
-                 border-radius: 8px; padding: 10px; }
-  .plugin-commit { font: 500 11px/1 ui-monospace, Menlo, monospace;
-                   color: var(--nv-text-muted, rgba(29,29,31,0.65)); }
-  .plugin-offers { list-style: none; margin: 4px 0 0; padding: 0;
-                   display: flex; flex-direction: column; gap: 6px; }
-  .plugin-offer { display: flex; align-items: center; justify-content: space-between;
-                  gap: 10px; padding: 8px 10px; border-radius: 8px;
-                  background: var(--nv-btn-hover, rgba(15,23,42,0.05));
-                  font: 500 13px/1.2 -apple-system, sans-serif; color: var(--nv-text, #1d1d1f); }
-  .plugin-inline-error { font-size: 11px; margin-left: 8px; }
-  /* The install command. Selectable and monospaced — it exists to be
-     read and run, so it must look like something you'd paste. */
-  .plugin-cmd { flex: 1 1 auto; min-width: 0; overflow-x: auto; white-space: nowrap;
-                user-select: all; -webkit-user-select: all;
-                font: 500 11px/1.6 ui-monospace, Menlo, monospace;
-                color: var(--nv-text-muted, rgba(29,29,31,0.75)); }
-
-  @media (max-width: 560px) {
-    .plugin-host { right: 12px; left: 12px; width: auto; }
-  }
-  `;
-
-  function injectCSS() {
-    if (document.getElementById('plugin-panel-css')) return;
-    const style = document.createElement('style');
-    style.id = 'plugin-panel-css';
-    style.textContent = CSS;
-    document.head.appendChild(style);
-  }
-
+  // No CSS here. The rail, its flyout and the panel are styled by the
+  // focus-mode stylesheet in sim-native.html, under `#simNativeView`,
+  // where the --nv-* theme tokens are defined — same arrangement as the
+  // logs, status-bar, location and a11y panels. A stylesheet written
+  // beside this module can't see those tokens, so every colour in it had
+  // to carry a guessed fallback, and the guesses were light-theme values.
   root.PluginPanels = PluginPanels;
-  root.PluginPanels.injectCSS = injectCSS;
 })(window);

--- a/Sources/Baguette/Resources/Web/sim-screens.js
+++ b/Sources/Baguette/Resources/Web/sim-screens.js
@@ -159,7 +159,6 @@
     }
 
     render() {
-      ScreensRail.injectCSS();
       if (this.rail) this.rail.remove();
       this.buttons.clear();
 
@@ -505,91 +504,8 @@
     }
   }
 
-  // Host-owned styling, injected here so the module stays self-contained
-  // — same arrangement as the plugin rail it sits above. The two rails
-  // share a shape on purpose but not an accent: this one is baguette's
-  // own, so it takes the page's text colour rather than the plugin
-  // system's accent seam.
-  const CSS = `
-  .screens-rail { display: flex; flex-direction: column; align-items: center; gap: 6px;
-                  padding: 8px 6px; z-index: 45;
-                  background: var(--nv-bar-bg, rgba(255,255,255,0.92));
-                  border: 1px solid var(--nv-bar-border, rgba(15,23,42,0.10));
-                  border-radius: 14px;
-                  box-shadow: var(--nv-bar-shadow, 0 8px 30px rgba(15,23,42,0.12));
-                  backdrop-filter: blur(18px) saturate(1.5);
-                  -webkit-backdrop-filter: blur(18px) saturate(1.5);
-                  color: var(--nv-text, #1d1d1f); }
-  .screens-rail-cap { display: inline-flex; align-items: center; justify-content: center;
-                      width: 30px; height: 24px; color: var(--nv-text-muted, rgba(29,29,31,0.65));
-                      opacity: 0.9; }
-  .screens-rail-divider { width: 20px; height: 1px; margin: 1px 0 3px;
-                          background: var(--nv-divider, rgba(15,23,42,0.14)); }
-  .screens-rail-btn { position: relative; width: 34px; height: 34px; padding: 0; border: 0;
-                      cursor: pointer;
-                      display: inline-flex; align-items: center; justify-content: center;
-                      background: transparent; border-radius: 9px;
-                      color: var(--nv-text, #1d1d1f);
-                      transition: background 0.12s ease, transform 0.12s ease, opacity 0.12s ease; }
-  .screens-rail-btn:hover  { background: var(--nv-btn-hover, rgba(15,23,42,0.06)); }
-  .screens-rail-btn:active { transform: scale(0.94); }
-  .screens-rail-btn.active { background: var(--nv-accent, #2563eb);
-                             color: var(--nv-accent-text, #fff); }
-  /* Dimmed, not hidden: the button is how you find out the screen could
-     exist, and how you reach the instructions for attaching one. */
-  .screens-rail-btn.unavailable { opacity: 0.38; }
-  .screens-rail-btn.unavailable:hover { opacity: 0.7; }
-  .screens-rail-refresh { color: var(--nv-text-muted, rgba(29,29,31,0.65)); }
-
-  .screens-card { position: fixed; z-index: 50; width: 268px;
-                  background: var(--nv-bar-bg, rgba(255,255,255,0.96));
-                  border: 1px solid var(--nv-bar-border, rgba(15,23,42,0.10));
-                  border-radius: 13px;
-                  box-shadow: 0 10px 34px rgba(15,23,42,0.20);
-                  backdrop-filter: blur(18px) saturate(1.5);
-                  -webkit-backdrop-filter: blur(18px) saturate(1.5);
-                  color: var(--nv-text, #1d1d1f);
-                  animation: screens-card-in 0.12s ease-out; }
-  @keyframes screens-card-in { from { opacity: 0; transform: translateX(6px); }
-                               to   { opacity: 1; transform: translateX(0); } }
-  @media (prefers-reduced-motion: reduce) { .screens-card { animation: none; } }
-  .screens-card-head { display: flex; align-items: center; gap: 8px; padding: 10px 12px;
-                       border-bottom: 1px solid var(--nv-divider, rgba(15,23,42,0.10)); }
-  .screens-card-title { font: 600 12px/1 -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif;
-                        letter-spacing: 0.02em; }
-  .screens-card-close { margin-left: auto; border: 0; background: transparent; cursor: pointer;
-                        font-size: 12px; padding: 2px 4px;
-                        color: var(--nv-text-muted, rgba(29,29,31,0.65)); }
-  .screens-card-body { padding: 11px 12px 13px; }
-  .screens-card-status { margin: 0 0 8px;
-                         font: 600 11px/1.35 -apple-system, sans-serif;
-                         color: var(--nv-text-muted, rgba(29,29,31,0.65)); }
-  .screens-card-note { margin: 0 0 10px;
-                       font: 400 11.5px/1.45 -apple-system, sans-serif;
-                       color: var(--nv-text-muted, rgba(29,29,31,0.65)); }
-  .screens-steps { margin: 0 0 11px; padding-left: 17px;
-                   display: flex; flex-direction: column; gap: 6px;
-                   font: 400 11.5px/1.45 -apple-system, sans-serif;
-                   color: var(--nv-text, #1d1d1f); }
-  .screens-steps li { overflow-wrap: anywhere; }
-  .screens-card-btn { width: 100%; padding: 8px 12px; border: 0; border-radius: 8px;
-                      cursor: pointer; font: 600 12px/1 -apple-system, sans-serif;
-                      color: var(--nv-accent-text, #fff); background: var(--nv-accent, #2563eb); }
-  .screens-card-btn:disabled { opacity: 0.6; cursor: default; }
-
-  @media (max-width: 560px) {
-    .screens-card { width: auto; left: 12px; right: 12px; }
-  }
-  `;
-
-  function injectCSS() {
-    if (document.getElementById('screens-rail-css')) return;
-    const style = document.createElement('style');
-    style.id = 'screens-rail-css';
-    style.textContent = CSS;
-    document.head.appendChild(style);
-  }
-
+  // No CSS here — the rail and its card are styled by the focus-mode
+  // stylesheet in sim-native.html, beside the plugin rail it shares a
+  // shape with. See the note there.
   root.ScreensRail = ScreensRail;
-  root.ScreensRail.injectCSS = injectCSS;
 })(window);

--- a/Tests/Web/sim-native-style.test.js
+++ b/Tests/Web/sim-native-style.test.js
@@ -115,3 +115,43 @@ test('the size budget defines every variable the device and panes size from', ()
     assert.ok(defined.has(name), `${name} is not defined anywhere`);
   }
 });
+
+// The two checks below are about *where* focus-mode styling lives, not
+// whether it parses. A panel that ships its own stylesheet is styling
+// itself against a token set it can't see, so it drifts — different
+// radii, a shadow that never learned about dark mode, an accent pulled
+// from whatever `--accent` happens to mean on the page it landed on.
+// The rest of the focus chrome (logs, status bar, location, the a11y
+// inspector) contributes zero CSS and is styled here; these keep it that
+// way.
+
+/** Panel modules that render into `#simNativeView` and must not carry CSS. */
+const PANEL_MODULES = ['sim-plugins.js', 'sim-screens.js'];
+
+test('panel modules inject no stylesheet of their own', () => {
+  for (const name of PANEL_MODULES) {
+    const src = fs.readFileSync(path.join(path.dirname(TEMPLATE), name), 'utf8');
+    assert.ok(
+      !/createElement\(\s*['"]style['"]\s*\)/.test(src),
+      `${name} builds a <style> element — focus-mode CSS belongs in ` +
+      'sim-native.html under #simNativeView, where the --nv-* tokens are'
+    );
+  }
+});
+
+test('the focus-mode stylesheet reads no token from outside the --nv-* set', () => {
+  const css = styleBlocks(fs.readFileSync(TEMPLATE, 'utf8'));
+  // `--bg` / `--text` are the standalone-preview :root in <head>, which
+  // only applies under file://; `--swatch` is written per-element from
+  // sim-3d.js. Everything else must come from the theme block, because
+  // only those names are redefined for light and dark.
+  const allowed = new Set(['--bg', '--text', '--swatch']);
+  const foreign = [...new Set(
+    [...css.matchAll(/var\(\s*(--[\w-]+)/g)].map((m) => m[1])
+  )].filter((name) => !name.startsWith('--nv-') && !allowed.has(name));
+  assert.deepEqual(
+    foreign, [],
+    'these resolve against sim.html\'s light-only :root, so they never ' +
+    'change for dark mode — use the --nv-* equivalent'
+  );
+});


### PR DESCRIPTION
The plugins rail didn't follow the rest of the web app's design language. This moves it onto the same system the other focus-mode panels already use.

## The cause

Every other panel in focus mode — logs, status bar, location, the a11y inspector — ships **zero CSS**. It emits class names and `sim-native.html` styles them under `#simNativeView`, where the `--nv-*` theme tokens are defined.

`sim-plugins.js` instead built a stylesheet in a template literal and injected it into `document.head` with globally-scoped selectors. A stylesheet written beside its module can't see those tokens, so every colour in it had to carry a fallback — and the fallbacks were light-theme values.

## What that cost

- **`var(--accent, #2563eb)` at 15 sites.** `--accent` is a `sim.html` token, light-only, never overridden for dark. It resolved by accident. `--nv-accent-text` was never used at all; the primary button hardcoded `color: #fff`.
- **Hardcoded light-slate shadows** on the flyout, card and modal (`rgba(15,23,42,0.20/0.30)`), with no dark variant. `--nv-bar-inset` was never applied.
- **A white text field in a dark modal** — `background: var(--panel, #fff)`, another light-only `sim.html` token.
- **Its own geometry**: 34×34 rail buttons at radius 9 against the toolbar's `.ico-btn` 30×28 at radius 8; press feedback as `scale(0.94)` where the app uses `0.96` or a background change; a `600 10px/0.06em` accent micro-heading against the app's `700 9.5px/0.10em` faint one; radius 3 and 13 which exist nowhere else; a fourth primary button; `right: 72px; top: 50%; max-height: 66vh` where every panel is `top: 84px` on the `dvh` budget.
- **Raw status colours** — `#b91c1c` (near-unreadable on the `#1a1a1f` page), `#b45309` (appears nowhere else in the repo), a hand-expanded `rgba(37,99,235,0.16)`.
- **Four 2px accent seams** on rail, flyout, card and modal, where every host surface is `1px solid var(--nv-bar-border)`.
- No `:focus-visible` anywhere, despite `focus` being bound to open the flyout.

## What changed

All of it now lives in `sim-native.html` under `#simNativeView`, **with no fallbacks**. The companion-screens rail moved with it — it shared most of the same structural problems — and the two rails now share every rule they had duplicated instead of drifting apart.

On the accent seams: the rails being *separate* is the trust signal ([`docs/features/plugins.md`](https://github.com/tddworks/baguette/blob/main/docs/features/plugins.md#the-rail)), not the border. The plugin rail keeps an accent emblem to say which rail is which and drops the second colour system layered on top. `sim-screens.js` had already declined to copy those seams when it was written.

Three tokens the plugin CSS needed and couldn't find, in both themes: `--nv-danger`, `--nv-warn`, `--nv-scrim`. Row severity is now a `data-severity` attribute the stylesheet colours, rather than an inline hex the module carries.

## Tests

Two guards added to `Tests/Web/sim-native-style.test.js`:

- **panel modules inject no stylesheet of their own** — red before this change (`sim-plugins.js builds a <style> element`)
- **the focus-mode stylesheet reads no token from outside the `--nv-*` set** — catches a `var(--accent)` / `var(--panel)` creeping back in

`node --test 'Tests/Web/**/*.test.js'` — 119 pass. `swift test --filter PluginRoute` — 25 pass.

## Verified

Rendered against a booted iPhone 17 Pro Max in both themes: rails, flyout, and the a11y panel with its severity dots. The warn dots now swap amber↔`#b45309` with the theme instead of staying put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned focus mode with consistent styling across plugin and companion-screen panels.
  * Added light and dark theme colors for warnings, errors, and modal overlays.
  * Added responsive layouts and visual severity indicators for plugin statuses.

* **Bug Fixes**
  * Improved handling of unknown plugin severity values by displaying them as informational.
  * Removed inconsistent fallback colors and duplicated panel styling.

* **Tests**
  * Added coverage to verify consistent theme usage and prevent conflicting panel styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->