### PR TITLE
feat: add deep links and scheme completion for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ For releases prior to this changelog, see the
   an app's own scheme before its reverse-DNS and `exp+` aliases). Unlike
   `simctl openurl` / `idb open` / Maestro, `openurl` warns that `https://` lands
   in **Safari** rather than your app — the simulator doesn't resolve associated
-  domains, so dispatch succeeds and nothing opens. Schemes need two reads:
+  domains, so dispatch succeeds and your app never comes up. Schemes need two
+  reads:
   `simctl listapps` gives the roster and each app's `Path` but not
   `CFBundleURLTypes`, so those come from `<Path>/Info.plist`. Over HTTP as
   `POST /simulators/:udid/openurl` and `GET /simulators/:udid/schemes.json`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Added
+
+- **Deep links — `baguette openurl <url>` and `baguette schemes`.** Opens a link
+  on a booted simulator, and lists the URL schemes its apps registered (ranked:
+  an app's own scheme before its reverse-DNS and `exp+` aliases). Unlike
+  `simctl openurl` / `idb open` / Maestro, `openurl` warns that `https://` lands
+  in **Safari** rather than your app — the simulator doesn't resolve associated
+  domains, so dispatch succeeds and nothing opens. Schemes need two reads:
+  `simctl listapps` gives the roster and each app's `Path` but not
+  `CFBundleURLTypes`, so those come from `<Path>/Info.plist`. Over HTTP as
+  `POST /simulators/:udid/openurl` and `GET /simulators/:udid/schemes.json`,
+  reachable by a plugin holding the new `open-url` capability — which is apart
+  from `apps`, since this only launches software that is already installed.
+  See [`docs/features/deep-links.md`](docs/features/deep-links.md).
+
+- **A deep-link panel, as an installable official plugin.** Not in the toolbar —
+  baguette ships the toolbar, this is a thing you choose:
+
+  ```bash
+  baguette bakery add tddworks/baguette
+  baguette plugin install deeplink
+  ```
+
+  This makes baguette's own repo a bakery. Only `a11y` still ships inside the
+  binary; everything else maintained alongside baguette is official *and*
+  installed on purpose.
+
+- **Plugin panels can be operated, not just read.** A panel was a report: the
+  host ran a command and drew the rows. It can now carry a text field
+  (`body.prompt`) and tickable rows (`body.control` — switches, checkboxes,
+  radios, grouped so one panel can ask several questions). Both invoke the
+  panel's own `source` command with `args`, which is the path `rowAction: "run"`
+  already took, so this adds widgets rather than an execution model — still no
+  plugin code in the page.
+
+  The field completes as you type (`Tab` / `→` to accept), remembers the last 25
+  submissions on `↑` / `↓`, filters the rows already on screen, and takes a row's
+  text on click via `rowAction: "fill"` — so a list of suggestions behaves like a
+  URL bar instead of a launcher. History is browser-side: a plugin sees what you
+  submit, never what you typed before.
+
+  Ticks are local and batched — no subprocess per tick, and rows the device
+  hasn't confirmed are drawn pending until the submit returns. Every answer
+  rebuilds them from what the plugin reported, so a refused setting snaps back.
+  `a11y`'s display panel uses this (`1.2.0`) and no longer writes `"● Light"` /
+  `"○ Dark"` into row titles. All of it is additive — `apiVersion` stays 1.
+
 ### Changed
 
 - **The plugins rail follows the focus-mode design system.** The rail, its

--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ baguette <command> [options]
                                              Stream os_log output. Levels are
                                              the three the iOS-runtime accepts.
 
+  # Deep links. `https://` dispatches fine and then opens SAFARI rather
+  # than your app — the simulator doesn't resolve associated domains — so
+  # openurl warns before doing it. See docs/features/deep-links.md.
+  openurl --udid <UDID> <url>                Open a deep link, e.g.
+                                             'myapp://profile/42'
+  schemes --udid <UDID> [--json]             URL schemes the device's apps
+                                             registered, ranked: an app's own
+                                             scheme before its aliases
+
   # Long-lived gesture pipe
   input --udid <UDID>                        Read newline-delimited JSON
                                              gestures from stdin
@@ -348,6 +357,8 @@ rejected.
 | `POST` | `/simulators/:udid/interface`              | set any subset; answers with the resulting state |
 | `GET`  | `/simulators/:udid/describe-ui.json`       | accessibility tree over HTTP (`?x=&y=` hit-tests a point) |
 | `POST` | `/simulators/:udid/input`                  | one gesture envelope — same JSON `baguette input` takes |
+| `POST` | `/simulators/:udid/openurl?url=…`          | open a deep link; answers where it went (`app` / `browser` + warning) |
+| `GET`  | `/simulators/:udid/schemes.json?q=`        | URL schemes the device's apps registered, ranked |
 | `GET`  | `/plugins.json`                            | installed plugin manifests   |
 | `POST` | `/plugins/:id/commands/:cmd?udid=`         | run one plugin contribution, answer its rows |
 | `GET`  | `/bakeries.json`                           | trusted bakeries + pinned commits |
@@ -434,11 +445,17 @@ ever loaded into baguette's process or into the served page: it declares
 a panel, baguette draws it with host markup.
 
 ```bash
-baguette bakery add tddworks/baguette-plugins   # trust a source, once
-baguette plugin install a11y                    # or: plugin install owner/repo/a11y
-baguette plugin show a11y                       # what it may do, before you install
+baguette bakery add tddworks/baguette           # trust a source, once
+baguette plugin install deeplink                # or: plugin install owner/repo/deeplink
+baguette plugin show deeplink                   # what it may do, before you install
 baguette serve --plugin-dir ./my-plugins        # local authoring, nothing installed
 ```
+
+baguette's own repo is the **official bakery**. Only `a11y` ships inside
+the binary, so a fresh install has something in the rail; everything
+else it maintains — starting with
+[`deeplink`](docs/features/deep-links.md) — is official and still
+something you choose to install.
 
 Two properties define the security model:
 
@@ -657,8 +674,14 @@ feature lives in one place across both layers.
 │   │   │                             content size) + InterfaceAppearance /
 │   │   │                             InterfaceContrast / ContentSize /
 │   │   │                             ContentSizeChange / InterfaceUpdate
+│   │   ├── Apps/                     AppBundle / AppArchive (install) +
+│   │   │                             DeepLink / InstalledApp / SchemeSuggestion
+│   │   │                             (open a link; rank what's openable) +
+│   │   │                             @Mockable Apps aggregate
 │   │   ├── Plugin/                   PluginManifest / Plugin / Plugins aggregate +
-│   │   │                             Contribution / PanelBody / PluginResult +
+│   │   │                             Contribution / PanelBody / ListBody /
+│   │   │                             PanelPrompt / PanelControl /
+│   │   │                             PluginResult +
 │   │   │                             PluginCapability / PluginGrants /
 │   │   │                             PluginRoute + PluginAccess (what a plugin
 │   │   │                             may reach, decided in one place)
@@ -722,6 +745,8 @@ feature lives in one place across both layers.
 │       ├── sim-ax-inspector.js       Accessibility-tree overlay
 │       ├── sim-plugins.js            Plugins rail + panels (host-drawn)
 │       ├── plugin-row-action.js      what clicking a plugin row means
+│       ├── plugin-prompt.js          what a plugin panel's text field means
+│       ├── plugin-control.js         what ticking a plugin row means
 │       ├── recorder.js               In-browser MP4 recorder
 │       ├── frame-decoder.js          MJPEG / AVCC strategy
 │       ├── stream-session.js         WebSocket + paint loop

--- a/README.md
+++ b/README.md
@@ -717,6 +717,8 @@ feature lives in one place across both layers.
 │   │   ├── Orientation/              PurpleWorkspacePortOrientation (GSEvent)
 │   │   ├── Logs/                     SimDeviceLogStream + HostSubprocess
 │   │   ├── Interface/                SimctlInterface (`simctl ui`)
+│   │   ├── Apps/                     SimctlApps (`simctl install` / `openurl` /
+│   │   │                             `listapps` + the Info.plist scheme read)
 │   │   ├── Plugin/                   FileSystemPlugins + PluginRoot (bundled /
 │   │   │                             installed / --plugin-dir lookup)
 │   │   ├── Bakery/                   FileSystemBakeries + GitCheckout (shallow,

--- a/Sources/Baguette/App/Commands/DeepLinkCommands.swift
+++ b/Sources/Baguette/App/Commands/DeepLinkCommands.swift
@@ -1,0 +1,117 @@
+import ArgumentParser
+import Foundation
+
+/// `baguette openurl --udid <UDID> <url>`
+///
+/// Opens a deep link on a booted simulator — the CLI half of the console
+/// surface, and the thing `baguette serve`'s URL bar drives.
+///
+/// The one behaviour that distinguishes this from `xcrun simctl openurl`
+/// is the warning: an `https://` universal link dispatches fine and then
+/// opens **Safari** rather than the app, because the simulator doesn't
+/// resolve associated domains the way a device does. Every existing tool
+/// does this silently, leaving the developer to guess whether their
+/// entitlement, their apple-app-site-association file, or the simulator
+/// is at fault. `DeepLink.routing` names the case, so we say it out loud
+/// before dispatching.
+struct OpenURLCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "openurl",
+        abstract: "Open a deep link on the booted simulator"
+    )
+
+    @OptionGroup var options: DeviceOption
+
+    @Argument(help: "The URL to open, e.g. myapp://profile/42")
+    var url: String
+
+    func run() async throws {
+        let simulators = CoreSimulators(deviceSetPath: options.deviceSet)
+        guard let simulator = simulators.find(udid: options.udid) else {
+            log("Device \(options.udid) not found")
+            throw ExitCode.failure
+        }
+        guard let link = DeepLink.from(url) else {
+            log("Not a URL (expected a scheme, e.g. myapp://path): \(url)")
+            throw ExitCode.failure
+        }
+
+        if link.routing == .browser {
+            log("""
+                Warning: \(link.scheme):// lands in Safari on the simulator, not your app. \
+                If an app claims the domain, iOS then shows an "Open in …?" dialog that \
+                needs a tap, so this never completes unattended. For an automated check, \
+                use the app's custom scheme — `baguette schemes` lists them.
+                """)
+        }
+
+        do {
+            try await simulator.apps().open(link)
+        } catch {
+            log("openurl failed: \(error)")
+            throw ExitCode.failure
+        }
+        log("Opened \(link.url.absoluteString) on \(simulator.name)")
+    }
+}
+
+/// `baguette schemes --udid <UDID>`
+///
+/// Lists the URL schemes the device's installed apps answer to — the
+/// inventory behind console completion, and useful on its own when you
+/// know an app handles *something* but not what it's called.
+///
+/// Schemes are ranked the same way the console ranks them: an app's own
+/// readable scheme first, aliases after.
+struct SchemesCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "schemes",
+        abstract: "List URL schemes the booted simulator's apps answer to"
+    )
+
+    @OptionGroup var options: DeviceOption
+
+    @Flag(name: .long, help: "Emit JSON instead of a table")
+    var json = false
+
+    func run() async throws {
+        let simulators = CoreSimulators(deviceSetPath: options.deviceSet)
+        guard let simulator = simulators.find(udid: options.udid) else {
+            log("Device \(options.udid) not found")
+            throw ExitCode.failure
+        }
+
+        let installed: [InstalledApp]
+        do {
+            installed = try await simulator.apps().installed()
+        } catch {
+            log("listing apps failed: \(error)")
+            throw ExitCode.failure
+        }
+
+        let suggestions = SchemeSuggestion.matching("", in: installed)
+        guard !suggestions.isEmpty else {
+            log("No app on \(simulator.name) registers a URL scheme")
+            return
+        }
+
+        if json {
+            let rows = suggestions.map {
+                ["scheme": $0.scheme, "url": $0.completion,
+                 "app": $0.appName, "bundleId": $0.bundleIdentifier]
+            }
+            let data = try JSONSerialization.data(
+                withJSONObject: rows, options: [.prettyPrinted, .sortedKeys]
+            )
+            print(String(decoding: data, as: UTF8.self))
+        } else {
+            let width = suggestions.map(\.completion.count).max() ?? 0
+            for suggestion in suggestions {
+                let padded = suggestion.completion.padding(
+                    toLength: width, withPad: " ", startingAt: 0
+                )
+                print("\(padded)  \(suggestion.appName)")
+            }
+        }
+    }
+}

--- a/Sources/Baguette/App/RootCommand.swift
+++ b/Sources/Baguette/App/RootCommand.swift
@@ -36,6 +36,8 @@ struct Baguette: AsyncParsableCommand {
             LocationCommand.self,
             InstallCommand.self,
             AddMediaCommand.self,
+            OpenURLCommand.self,
+            SchemesCommand.self,
             PluginsCommand.self,
             BakeryCommand.self,
             DiagDigitizerTrackpadCommand.self,

--- a/Sources/Baguette/Domain/Apps/Apps.swift
+++ b/Sources/Baguette/Domain/Apps/Apps.swift
@@ -26,6 +26,17 @@ protocol Apps: Sendable {
     /// installable is inside, and `.installFailed` when simctl rejects
     /// the located app.
     func install(archive: AppArchive) async throws
+
+    /// Open a deep link on the device — the app that registered the
+    /// scheme comes to the foreground. Throws `AppsError.openFailed`
+    /// when simctl exits non-zero.
+    func open(_ link: DeepLink) async throws
+
+    /// Every app on the device, each carrying the URL schemes it
+    /// answers to. Throws `AppsError.listFailed` when simctl exits
+    /// non-zero; an app whose bundle can't be read still lists, with no
+    /// schemes, rather than dropping out of the roster.
+    func installed() async throws -> [InstalledApp]
 }
 
 /// Failure modes surfaced when installing an app. Maps to a CLI exit
@@ -36,11 +47,17 @@ enum AppsError: Error, Equatable, CustomStringConvertible {
     case extractFailed(status: Int32)
     case archiveTooLarge(bytes: Int64, limit: Int64)
     case noAppInArchive
+    case openFailed(status: Int32)
+    case listFailed(status: Int32)
 
     var description: String {
         switch self {
         case .installFailed(let status):
             return "xcrun simctl install exited \(status)"
+        case .openFailed(let status):
+            return "xcrun simctl openurl exited \(status)"
+        case .listFailed(let status):
+            return "xcrun simctl listapps exited \(status)"
         case .extractFailed(let status):
             return "ditto -x -k exited \(status) (corrupt zip?)"
         case .archiveTooLarge(let bytes, let limit):

--- a/Sources/Baguette/Domain/Apps/DeepLink.swift
+++ b/Sources/Baguette/Domain/Apps/DeepLink.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// A URL a developer wants to open on a device — what they mean when
+/// they type `myapp://profile/42` into the console and expect their app
+/// to come to the foreground.
+///
+/// The value carries a **routing verdict** alongside the URL, because on
+/// the simulator the two kinds of link behave differently: a custom
+/// scheme reaches the app that registered it, while an `https` universal
+/// link is handed to Safari instead. That fallback is silent in every
+/// existing tool — `simctl openurl`, `idb open`, Maestro's `openLink` —
+/// so a developer testing a universal link watches Safari open and has
+/// no idea whether their app, their entitlement, or their
+/// apple-app-site-association file is at fault. Naming the verdict here
+/// lets the console say so up front.
+public struct DeepLink: Equatable, Sendable {
+
+    /// Where the simulator will actually send this link.
+    public enum Routing: Equatable, Sendable {
+        /// A custom scheme — dispatched to the app that registered it.
+        case app
+        /// A web scheme — the simulator opens Safari rather than
+        /// resolving the associated domain to an installed app.
+        case browser
+    }
+
+    public let url: URL
+
+    /// The scheme, lower-cased. Schemes are case-insensitive, so this is
+    /// the form to match installed apps' registered schemes against.
+    public let scheme: String
+
+    private init(url: URL, scheme: String) {
+        self.url = url
+        self.scheme = scheme
+    }
+
+    /// Schemes the simulator hands to Safari instead of an app.
+    static let browserSchemes: Set<String> = ["http", "https"]
+
+    public var routing: Routing {
+        Self.browserSchemes.contains(scheme) ? .browser : .app
+    }
+
+    /// Read console input as a deep link, or `nil` when it isn't one.
+    /// Trims first — console input is very often pasted, arriving with
+    /// a trailing newline or leading spaces.
+    public static func from(_ text: String) -> DeepLink? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              !scheme.isEmpty
+        else { return nil }
+        return DeepLink(url: url, scheme: scheme)
+    }
+
+    /// The argv tail handed to `xcrun simctl openurl <udid> <url>`.
+    public func openArguments(udid: String) -> [String] {
+        ["simctl", "openurl", udid, url.absoluteString]
+    }
+}

--- a/Sources/Baguette/Domain/Apps/InstalledApp.swift
+++ b/Sources/Baguette/Domain/Apps/InstalledApp.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// An app present on a device, and the URL schemes it answers to — the
+/// inventory behind console completion. Typing `myap` can only suggest
+/// `myapp://` once something has read the device's schemes.
+///
+/// Assembling one takes two reads, because neither source has the whole
+/// picture:
+///
+/// 1. `xcrun simctl listapps <udid>` gives the authoritative roster —
+///    which apps are installed, what they're called, and crucially each
+///    one's real `Path` on disk. What it does *not* give is
+///    `CFBundleURLTypes`: the command reports a curated subset of
+///    metadata, and URL types aren't in it (verified against Xcode 26).
+/// 2. `<Path>/Info.plist` gives the schemes, from the same key the app
+///    declared them under.
+///
+/// Taking the path from step one is what makes step two safe. Reading
+/// `Info.plist` means touching CoreSimulator's container layout, whose
+/// `…/Containers/Bundle/Application/<uuid>/` shape is undocumented and
+/// whose UUID changes on every reinstall — but we never have to *guess*
+/// it, because simctl just told us. Both parses are pure and live here;
+/// `SimctlApps` runs the child, reads the file, and composes them.
+public struct InstalledApp: Equatable, Sendable {
+    public let bundleIdentifier: String
+
+    /// Display name, for showing next to a suggested scheme. Falls back
+    /// through `CFBundleName` to the bundle identifier so this is never
+    /// empty.
+    public let name: String
+
+    /// The app bundle on disk, as reported by `listapps`. `nil` when
+    /// simctl reports an app without a path — nothing to read schemes
+    /// from, so it simply contributes no completions.
+    public let bundlePath: URL?
+
+    /// Registered schemes, lower-cased and de-duplicated, in declaration
+    /// order. Apps routinely register several — a readable one, a
+    /// reverse-DNS one, and often a tool-injected dev-client one — so
+    /// this is a list, and ranking is the caller's problem.
+    public let schemes: [String]
+
+    public init(
+        bundleIdentifier: String,
+        name: String,
+        bundlePath: URL? = nil,
+        schemes: [String] = []
+    ) {
+        self.bundleIdentifier = bundleIdentifier
+        self.name = name
+        self.bundlePath = bundlePath
+        self.schemes = schemes
+    }
+
+    /// The same app, with schemes read from its bundle attached.
+    public func withSchemes(_ schemes: [String]) -> InstalledApp {
+        InstalledApp(
+            bundleIdentifier: bundleIdentifier,
+            name: name,
+            bundlePath: bundlePath,
+            schemes: schemes
+        )
+    }
+
+    /// Step one: read `simctl listapps` output into a roster, ordered by
+    /// bundle identifier so the console's suggestion list is stable
+    /// between invocations. Every app comes back with no schemes — they
+    /// aren't in this output. Unreadable output yields no apps rather
+    /// than throwing: a device with nothing installed and a device that
+    /// answered with garbage are the same to the caller, no completions.
+    public static func all(fromListApps data: Data) -> [InstalledApp] {
+        guard !data.isEmpty,
+              let plist = try? PropertyListSerialization.propertyList(
+                  from: data, options: [], format: nil
+              ),
+              let root = plist as? [String: Any]
+        else { return [] }
+
+        return root.keys.sorted().compactMap { identifier in
+            guard let entry = root[identifier] as? [String: Any] else { return nil }
+            return InstalledApp(
+                bundleIdentifier: identifier,
+                name: entry["CFBundleDisplayName"] as? String
+                    ?? entry["CFBundleName"] as? String
+                    ?? identifier,
+                bundlePath: (entry["Path"] as? String).map { URL(fileURLWithPath: $0) }
+            )
+        }
+    }
+
+    /// Step two: the schemes an app declares, read from its
+    /// `Info.plist`. An app declares one entry per URL type and each
+    /// entry carries its own scheme list, so an app's schemes are the
+    /// union across entries.
+    public static func schemes(inInfoPlist data: Data) -> [String] {
+        guard !data.isEmpty,
+              let plist = try? PropertyListSerialization.propertyList(
+                  from: data, options: [], format: nil
+              ),
+              let root = plist as? [String: Any],
+              let types = root["CFBundleURLTypes"] as? [[String: Any]]
+        else { return [] }
+
+        var seen: Set<String> = []
+        return types
+            .flatMap { $0["CFBundleURLSchemes"] as? [String] ?? [] }
+            .map { $0.lowercased() }
+            .filter { seen.insert($0).inserted }
+    }
+}

--- a/Sources/Baguette/Domain/Apps/InstalledApp.swift
+++ b/Sources/Baguette/Domain/Apps/InstalledApp.swift
@@ -49,7 +49,19 @@ public struct InstalledApp: Equatable, Sendable {
         self.bundleIdentifier = bundleIdentifier
         self.name = name
         self.bundlePath = bundlePath
-        self.schemes = schemes
+        // Normalised here rather than only where plists are parsed,
+        // because the invariant is load-bearing: `SchemeSuggestion`
+        // lower-cases the needle and compares it against the stored
+        // scheme, so an upper-cased one matches nothing at all. Anything
+        // that documents an invariant and leaves its initialiser free to
+        // break it is documenting a hope.
+        self.schemes = Self.normalised(schemes)
+    }
+
+    /// Lower-cased, de-duplicated, in declaration order.
+    static func normalised(_ schemes: [String]) -> [String] {
+        var seen: Set<String> = []
+        return schemes.map { $0.lowercased() }.filter { seen.insert($0).inserted }
     }
 
     /// The same app, with schemes read from its bundle attached.
@@ -101,10 +113,6 @@ public struct InstalledApp: Equatable, Sendable {
               let types = root["CFBundleURLTypes"] as? [[String: Any]]
         else { return [] }
 
-        var seen: Set<String> = []
-        return types
-            .flatMap { $0["CFBundleURLSchemes"] as? [String] ?? [] }
-            .map { $0.lowercased() }
-            .filter { seen.insert($0).inserted }
+        return normalised(types.flatMap { $0["CFBundleURLSchemes"] as? [String] ?? [] })
     }
 }

--- a/Sources/Baguette/Domain/Apps/SchemeSuggestion.swift
+++ b/Sources/Baguette/Domain/Apps/SchemeSuggestion.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// One completion offered by the console's URL bar: a scheme an
+/// installed app answers to, plus the app it belongs to so the
+/// suggestion row can say whose scheme it is.
+///
+/// Ranking is the whole job. A single app commonly registers a readable
+/// scheme, a reverse-DNS alias, and a tool-injected dev-client scheme —
+/// three entries for one app, of which only the first is what a
+/// developer means to type. Unranked, the useful suggestion sits
+/// wherever dictionary iteration puts it. So matches are ordered:
+/// schemes *starting* with what was typed before ones merely containing
+/// it, then an app's own scheme before its aliases, then alphabetically
+/// so the list never reshuffles between keystrokes.
+public struct SchemeSuggestion: Equatable, Sendable {
+    public let scheme: String
+    public let appName: String
+    public let bundleIdentifier: String
+
+    /// What the bar completes to — the scheme plus `://`, ready for a
+    /// path to be typed after it.
+    public var completion: String { "\(scheme)://" }
+
+    /// How much of an alias a scheme looks like. An app's own scheme is
+    /// a plain word; a reverse-DNS alias carries dots; a dev-client
+    /// scheme injected by tooling carries a `+`.
+    private enum Style: Int {
+        case own = 0, reverseDNS = 1, injected = 2
+
+        init(_ scheme: String) {
+            if scheme.contains("+") { self = .injected }
+            else if scheme.contains(".") { self = .reverseDNS }
+            else { self = .own }
+        }
+    }
+
+    /// Suggestions for what's been typed so far. An empty query offers
+    /// everything — that's the "what can I even open here?" case, and
+    /// showing the full ranked inventory answers it.
+    public static func matching(_ query: String, in apps: [InstalledApp]) -> [SchemeSuggestion] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        return apps
+            .flatMap { app in
+                app.schemes.map {
+                    SchemeSuggestion(
+                        scheme: $0, appName: app.name, bundleIdentifier: app.bundleIdentifier
+                    )
+                }
+            }
+            .filter { needle.isEmpty || $0.scheme.contains(needle) }
+            .sorted { a, b in
+                let (aKey, bKey) = (a.rank(for: needle), b.rank(for: needle))
+                return aKey < bKey
+            }
+    }
+
+    /// Sort key: prefix matches first, then an app's own scheme over its
+    /// aliases, then alphabetical for a stable list.
+    private func rank(for needle: String) -> SortKey {
+        SortKey(
+            prefix: scheme.hasPrefix(needle) ? 0 : 1,
+            style: Style(scheme).rawValue,
+            scheme: scheme
+        )
+    }
+
+    private struct SortKey: Comparable {
+        let prefix: Int
+        let style: Int
+        let scheme: String
+
+        static func < (lhs: SortKey, rhs: SortKey) -> Bool {
+            (lhs.prefix, lhs.style, lhs.scheme) < (rhs.prefix, rhs.style, rhs.scheme)
+        }
+    }
+}

--- a/Sources/Baguette/Domain/Plugin/PanelBody.swift
+++ b/Sources/Baguette/Domain/Plugin/PanelBody.swift
@@ -76,14 +76,48 @@ struct PluginPanel: Equatable, Sendable {
 enum PanelBody: Equatable, Sendable {
     /// Rows come from running the plugin's `source` command and
     /// reading the `rows` array off its JSON answer.
-    case list(source: String, rowAction: RowAction?)
+    case list(ListBody)
 
     static func parsing(dict: [String: Any], declaredCommands: Set<String>) throws -> PanelBody {
         let kind = dict["kind"] as? String ?? ""
         guard kind == "list" else {
             throw PluginManifestError.unknownPanelBody(kind: kind)
         }
+        return .list(try ListBody.parsing(dict: dict, declaredCommands: declaredCommands))
+    }
+}
 
+/// Everything a `kind: "list"` body declares.
+///
+/// A struct rather than the enum case's associated values, because every
+/// optional field added here would otherwise be a source break at every
+/// construction site — Swift can't default an associated value. `prompt`
+/// cost four unrelated test edits to add that way; `control` cost none.
+/// The panel contract grows by *addition*, so the shape it grows into
+/// has to make addition free.
+struct ListBody: Equatable, Sendable {
+    /// The command whose `rows` fill the panel.
+    let source: String
+    /// What clicking a row does. `nil` leaves rows inert.
+    let rowAction: RowAction?
+    /// A text field above the rows. `nil` for a read-only report.
+    let prompt: PanelPrompt?
+    /// Tickable controls on the rows. `nil` for a plain list.
+    let control: PanelControl?
+
+    init(
+        source: String,
+        rowAction: RowAction? = nil,
+        prompt: PanelPrompt? = nil,
+        control: PanelControl? = nil
+    ) {
+        self.source = source
+        self.rowAction = rowAction
+        self.prompt = prompt
+        self.control = control
+    }
+
+    static func parsing(dict: [String: Any], declaredCommands: Set<String>) throws -> ListBody {
         let source = dict["source"] as? String ?? ""
         guard declaredCommands.contains(source) else {
             throw PluginManifestError.unknownCommandSource(id: source)
@@ -97,7 +131,161 @@ enum PanelBody: Equatable, Sendable {
             rowAction = parsed
         }
 
-        return .list(source: source, rowAction: rowAction)
+        return ListBody(
+            source: source,
+            rowAction: rowAction,
+            prompt: try (dict["prompt"] as? [String: Any]).map(PanelPrompt.parsing(dict:)),
+            control: try (dict["control"] as? [String: Any]).map(PanelControl.parsing(dict:))
+        )
+    }
+}
+
+/// Tickable controls on a panel's rows, and what submitting them means.
+///
+/// Before this, a plugin wanting a settings list wrote its state into
+/// the row *title* — `display.py` shipped `"● Light"` / `"○ Dark"` —
+/// which is a plugin drawing a control glyph inside a string, in a page
+/// whose whole premise is that the host owns every pixel. Escaping made
+/// it safe, not right: the host couldn't style it, a screen reader read
+/// a bullet, and "which one is on" was unreadable to anything but a
+/// human eye.
+///
+/// So state moves onto the row (`ResultRow.state`) and the *drawing*
+/// moves here. The plugin says what's on; baguette says what on looks
+/// like.
+///
+/// Ticking is **local** — it costs no subprocess. The panel accumulates
+/// ticks and sends them together when the submit button is pressed,
+/// which is the trade this makes deliberately: one child process per
+/// *batch* instead of one per tick, at the price of rows briefly showing
+/// state the device hasn't confirmed. The host marks those rows pending
+/// rather than letting them look settled, because a control that lies
+/// about the device is worse than one that's slow.
+struct PanelControl: Equatable, Sendable {
+    /// Which glyph family the host draws. Purely cosmetic: grouping is
+    /// the plugin's business, since it re-renders the whole panel from
+    /// its own answer after every submit.
+    let kind: RowControl
+    /// The key the ticked rows' `value`s are submitted under, i.e. the
+    /// command sees `{"args": {"<arg>": ["camera", "mic"]}}`.
+    ///
+    /// **Always an array**, including for `radio`, which yields one
+    /// element. One shape means a plugin has one branch to write rather
+    /// than a scalar case it discovers by reading the docs twice.
+    let arg: String
+    /// The submit button's label.
+    let submit: String
+
+    init(kind: RowControl, arg: String, submit: String = "Apply") {
+        self.kind = kind
+        self.arg = arg
+        self.submit = submit
+    }
+
+    static func parsing(dict: [String: Any]) throws -> PanelControl {
+        let rawKind = dict["kind"] as? String ?? ""
+        guard let kind = RowControl(rawValue: rawKind) else {
+            throw PluginManifestError.unknownRowControl(name: rawKind)
+        }
+        guard let arg = dict["arg"] as? String, !arg.isEmpty else {
+            throw PluginManifestError.missingControlArg
+        }
+        return PanelControl(kind: kind, arg: arg, submit: dict["submit"] as? String ?? "Apply")
+    }
+}
+
+/// The control families baguette draws. A closed set for the same
+/// reason `PluginIcon` is one: the name reaches a protected page.
+///
+/// Unlike an icon, an unknown one **throws** rather than degrading —
+/// a checkbox silently drawn as a switch would misrepresent whether
+/// ticking two rows at once is allowed, and that's a lie about
+/// behaviour rather than a substituted picture.
+enum RowControl: String, Equatable, Sendable, CaseIterable {
+    /// Independent on/off. Several may be on at once.
+    case `switch`
+    /// Many-of-many, in a set that belongs together.
+    case checkbox
+    /// One-of-many; the host clears the others when one is ticked.
+    case radio
+}
+
+/// A text field above a panel's rows, and what submitting it means.
+///
+/// Every panel before this one was a report: the host ran a command and
+/// drew what came back. Some tools need the opposite direction — a deep
+/// link is interesting precisely because nobody has typed it yet — and a
+/// list of rows has nowhere to put a value that doesn't exist.
+///
+/// Submitting invokes the panel's **own** `source` command with the
+/// typed text under `arg`, which is exactly the path `rowAction: "run"`
+/// already takes. So this adds a widget, not an execution model: still
+/// one command per panel, still an HTTP call to the same endpoint the
+/// panel opens with, still no plugin code in the page.
+///
+/// The field is optional and additive on purpose. A baguette that
+/// predates it ignores the key and renders the plain list, which for a
+/// well-written plugin is a working panel with one affordance missing —
+/// so `apiVersion` doesn't move.
+struct PanelPrompt: Equatable, Sendable {
+    /// The key the typed text is submitted under, i.e. the command sees
+    /// `{"args": {"<arg>": "<typed>"}}`. Required: a field that
+    /// submitted into nowhere would look like a working control and do
+    /// nothing, so a manifest without it is refused rather than drawn.
+    let arg: String
+    /// Greyed hint inside the empty field. `nil` leaves it blank.
+    let placeholder: String?
+    /// The submit button's label.
+    let submit: String
+    /// Whether typing also filters the rows already on screen.
+    ///
+    /// A command is a subprocess with a bounded budget, so re-running it
+    /// per keystroke is the wrong shape — but the rows it *already*
+    /// returned are right there, and narrowing them locally gives back
+    /// the feel of completion for the price of a string comparison.
+    let filter: Bool
+    /// Whether the field finishes the word for you: the rest of the best
+    /// candidate drawn greyed after the caret, accepted with `Tab` or
+    /// `→`. A list you have to point at is slower than a bar that
+    /// completes.
+    let complete: Bool
+    /// Whether submissions are remembered for `↑` / `↓`.
+    ///
+    /// Kept by the browser, per panel. It's a convenience for the person
+    /// typing, not state the plugin owns — so it doesn't ride the wire,
+    /// and a plugin never sees what you typed before.
+    let history: Bool
+
+    init(
+        arg: String,
+        placeholder: String? = nil,
+        submit: String = "Run",
+        filter: Bool = false,
+        complete: Bool = false,
+        history: Bool = false
+    ) {
+        self.arg = arg
+        self.placeholder = placeholder
+        self.submit = submit
+        self.filter = filter
+        self.complete = complete
+        self.history = history
+    }
+
+    static func parsing(dict: [String: Any]) throws -> PanelPrompt {
+        guard let arg = dict["arg"] as? String, !arg.isEmpty else {
+            throw PluginManifestError.missingPromptArg
+        }
+        return PanelPrompt(
+            arg: arg,
+            placeholder: dict["placeholder"] as? String,
+            // A label is chrome, not meaning — default rather than
+            // demand one, the way `title` already falls back to `id`.
+            submit: dict["submit"] as? String ?? "Run",
+            filter: dict["filter"] as? Bool ?? false,
+            complete: dict["complete"] as? Bool ?? false,
+            history: dict["history"] as? Bool ?? false
+        )
     }
 }
 
@@ -121,6 +309,16 @@ enum RowAction: String, Equatable, Sendable, CaseIterable {
     /// Still no plugin code in the page — the click is an HTTP call to
     /// the same command endpoint the panel already opens with.
     case run
+    /// Put the row's `fill` text into the panel's own `prompt`, focus
+    /// it, and leave the caret at the end.
+    ///
+    /// The others all *act* on a row. This one hands it to the field
+    /// above, which is what a list of suggestions under a text box has
+    /// always meant. The deep-link panel named it: clicking `account://`
+    /// used to open a bare scheme with no path, when what anyone wants
+    /// is that scheme in the box, ready for the rest of the URL. It
+    /// turns a list from a launcher into completion.
+    case fill
 }
 
 /// When a contribution is offered. A closed set, evaluated by the host

--- a/Sources/Baguette/Domain/Plugin/PluginCapability.swift
+++ b/Sources/Baguette/Domain/Plugin/PluginCapability.swift
@@ -39,6 +39,16 @@ enum PluginCapability: String, Equatable, Sendable, CaseIterable, Comparable {
     case apps
     /// Add photos or videos to the device's library.
     case media
+    /// Open a deep link, and read the URL schemes the device's apps
+    /// answer to. One capability for the pair, on the `interface`
+    /// precedent: a plugin that can open *any* URL is not meaningfully
+    /// restrained by hiding the list of which ones exist.
+    ///
+    /// Deliberately apart from `apps`, which installs software. This one
+    /// only launches what is already there, and a plugin that wants to
+    /// fire a deep link shouldn't have to be trusted to put an
+    /// executable on the device.
+    case openURL = "open-url"
     /// List simulators and their state.
     case simulators
 

--- a/Sources/Baguette/Domain/Plugin/PluginManifest.swift
+++ b/Sources/Baguette/Domain/Plugin/PluginManifest.swift
@@ -201,6 +201,9 @@ enum PluginManifestError: Error, Equatable, CustomStringConvertible {
     case unknownRowAction(name: String)
     case unknownCommandSource(id: String)
     case unknownCapability(name: String)
+    case missingPromptArg
+    case unknownRowControl(name: String)
+    case missingControlArg
 
     var description: String {
         switch self {
@@ -233,6 +236,21 @@ enum PluginManifestError: Error, Equatable, CustomStringConvertible {
                 """
         case .unknownCommandSource(let id):
             return "panel body names command \"\(id)\", which this plugin does not contribute"
+        case .missingPromptArg:
+            return """
+                a panel's "prompt" is missing a non-empty "arg" — without it \
+                the typed text has no key to arrive under
+                """
+        case .unknownRowControl(let name):
+            return """
+                unknown control kind \"\(name)\" — use one of: \
+                \(RowControl.allCases.map(\.rawValue).joined(separator: ", "))
+                """
+        case .missingControlArg:
+            return """
+                a panel's "control" is missing a non-empty "arg" — without it \
+                the ticked rows have no key to arrive under
+                """
         case .unknownCapability(let name):
             return """
                 unknown capability \"\(name)\" — use one of: \

--- a/Sources/Baguette/Domain/Plugin/PluginResult.swift
+++ b/Sources/Baguette/Domain/Plugin/PluginResult.swift
@@ -58,12 +58,37 @@ struct ResultRow: Equatable, Sendable {
     let frame: Rect?
     /// Payload for `RowAction.copy`.
     let copy: String?
+    /// Payload for `RowAction.fill` — what this row types into the
+    /// panel's prompt.
+    ///
+    /// Separate from `title` on purpose: a title is display text, so it
+    /// may be truncated, decorated or translated, and reusing it would
+    /// make every one of those a silent change to what gets typed.
+    let fill: String?
     /// Command id to invoke for `RowAction.run` — one of the ids this
     /// plugin contributes. Absent on the rows that just report.
     let run: String?
     /// Arguments handed to that command, in the context JSON it reads
     /// on stdin. Only meaningful alongside `run`.
     let args: PluginArgs?
+    /// Whether this row's control is on, when the panel declares one.
+    /// `nil` means the row isn't a control at all — which is how a
+    /// section header or a plain note keeps rendering as itself inside a
+    /// panel full of switches.
+    let state: RowState?
+    /// What a ticked row submits under the control's `arg`. Required
+    /// alongside `state`: a tick that carried nothing would be a control
+    /// the plugin can't act on.
+    let value: String?
+    /// Which set of options a `radio` row is exclusive within.
+    ///
+    /// This is what lets one panel ask more than one question. A
+    /// settings panel is normally several independent choices at once —
+    /// appearance, contrast and text size — and without groups, picking
+    /// "Dark" would unpick the text size. Rows naming none share one
+    /// implicit group, which is the single-question panel. Meaningless
+    /// for `switch` / `checkbox`, which have no exclusivity to express.
+    let group: String?
 
     init(
         title: String,
@@ -71,16 +96,24 @@ struct ResultRow: Equatable, Sendable {
         severity: RowSeverity = .info,
         frame: Rect? = nil,
         copy: String? = nil,
+        fill: String? = nil,
         run: String? = nil,
-        args: [String: Any]? = nil
+        args: [String: Any]? = nil,
+        state: RowState? = nil,
+        value: String? = nil,
+        group: String? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
         self.severity = severity
         self.frame = frame
         self.copy = copy
+        self.fill = fill
         self.run = run
         self.args = args.flatMap(PluginArgs.init)
+        self.state = state
+        self.value = value
+        self.group = group
     }
 
     static func parsing(dict: [String: Any], index: Int) throws -> ResultRow {
@@ -117,14 +150,37 @@ struct ResultRow: Equatable, Sendable {
             args = object
         }
 
+        // `state` / `value` travel together for the same reason `run` and
+        // `args` do: a tick with nothing to submit is a control the
+        // plugin can't act on, and rendering it anyway makes a switch
+        // that flips and changes nothing.
+        var state: RowState?
+        if let rawState = dict["state"] {
+            guard let name = rawState as? String, let parsed = RowState(rawValue: name) else {
+                throw PluginResultError.unknownRowState(
+                    name: (rawState as? String) ?? String(describing: rawState), index: index
+                )
+            }
+            guard let value = dict["value"] as? String, !value.isEmpty else {
+                throw PluginResultError.stateWithoutValue(index: index)
+            }
+            state = parsed
+        }
+
         return ResultRow(
             title: title,
             subtitle: dict["subtitle"] as? String,
             severity: severity,
             frame: try frameValue(dict["frame"], index: index),
             copy: dict["copy"] as? String,
+            fill: dict["fill"] as? String,
             run: run,
-            args: args
+            args: args,
+            state: state,
+            // Only meaningful alongside `state`; a bare `value` on a
+            // plain row is ignored rather than made up into a control.
+            value: state == nil ? nil : dict["value"] as? String,
+            group: state == nil ? nil : dict["group"] as? String
         )
     }
 
@@ -154,6 +210,17 @@ enum RowSeverity: String, Equatable, Sendable, CaseIterable {
     case info, warn, error
 }
 
+/// Whether a tickable row is on, as the **device** last reported it.
+///
+/// Not what the user has clicked since: the page tracks pending ticks
+/// separately, so a row whose local tick disagrees with this can be
+/// drawn as unconfirmed rather than settled. This value is always the
+/// plugin's last word, which is what makes "what you see is what the
+/// device reports" survive batching.
+enum RowState: String, Equatable, Sendable, CaseIterable {
+    case on, off
+}
+
 /// Why a plugin's answer couldn't be rendered. Every case names the
 /// offending row so the author can find it.
 enum PluginResultError: Error, Equatable, CustomStringConvertible {
@@ -164,11 +231,23 @@ enum PluginResultError: Error, Equatable, CustomStringConvertible {
     case malformedRun(index: Int)
     case malformedArgs(index: Int)
     case argsWithoutRun(index: Int)
+    case unknownRowState(name: String, index: Int)
+    case stateWithoutValue(index: Int)
 
     var description: String {
         switch self {
         case .malformedJSON:
             return "plugin did not print a JSON object on stdout"
+        case .unknownRowState(let name, let index):
+            return """
+                row \(index) has state \"\(name)\" — use one of: \
+                \(RowState.allCases.map(\.rawValue).joined(separator: ", "))
+                """
+        case .stateWithoutValue(let index):
+            return """
+                row \(index) has \"state\" but no non-empty \"value\" — \
+                ticking it would submit nothing
+                """
         case .malformedRun(let index):
             return "row \(index) has a \"run\" that isn't a non-empty command id"
         case .malformedArgs(let index):

--- a/Sources/Baguette/Domain/Plugin/PluginRoute.swift
+++ b/Sources/Baguette/Domain/Plugin/PluginRoute.swift
@@ -39,6 +39,11 @@ enum PluginRoute {
         case "location":          return .location
         case "apps":              return .apps
         case "media":             return .media
+        // Launching what's already installed, not installing it — see
+        // the note on `PluginCapability.openURL` for why that's a
+        // different power from `apps`.
+        case "openurl",
+             "schemes.json":      return .openURL
         // `/files` is the browser's drag-and-drop endpoint and routes by
         // file extension, so the capability it demands would depend on
         // the bytes rather than the path. A content-dependent check is

--- a/Sources/Baguette/Domain/Plugin/Plugins.swift
+++ b/Sources/Baguette/Domain/Plugin/Plugins.swift
@@ -81,12 +81,37 @@ private extension Plugin {
     }
 }
 
+private extension PanelPrompt {
+    /// What the page needs to draw the field and post what was typed.
+    /// `arg` travels because the browser builds `{"args": {arg: value}}`
+    /// — it's an object key, never markup.
+    var dictionary: [String: Any] {
+        var out: [String: Any] = [
+            "arg": arg, "submit": submit, "filter": filter,
+            "complete": complete, "history": history,
+        ]
+        if let placeholder { out["placeholder"] = placeholder }
+        return out
+    }
+}
+
+private extension PanelControl {
+    /// What the page needs to draw the ticks and post them back.
+    var dictionary: [String: Any] {
+        ["kind": kind.rawValue, "arg": arg, "submit": submit]
+    }
+}
+
 private extension PanelBody {
     func dictionary(qualifiedBy plugin: Plugin) -> [String: Any] {
         switch self {
-        case .list(let source, let rowAction):
-            var body: [String: Any] = ["kind": "list", "source": plugin.qualified(source)]
-            if let rowAction { body["rowAction"] = rowAction.rawValue }
+        case .list(let list):
+            var body: [String: Any] = ["kind": "list", "source": plugin.qualified(list.source)]
+            if let rowAction = list.rowAction { body["rowAction"] = rowAction.rawValue }
+            // Absent rather than null when unused, so a panel that
+            // predates a field projects byte-for-byte as it always did.
+            if let prompt = list.prompt { body["prompt"] = prompt.dictionary }
+            if let control = list.control { body["control"] = control.dictionary }
             return body
         }
     }

--- a/Sources/Baguette/Infrastructure/Apps/SimctlApps.swift
+++ b/Sources/Baguette/Infrastructure/Apps/SimctlApps.swift
@@ -73,6 +73,72 @@ final class SimctlApps: Apps, @unchecked Sendable {
         try await install(AppBundle(path: dest.appendingPathComponent(appName)))
     }
 
+    func open(_ link: DeepLink) async throws {
+        let status = try await exitStatus(of: xcrun, arguments: link.openArguments(udid: udid))
+        guard status == 0 else { throw AppsError.openFailed(status: status) }
+    }
+
+    func installed() async throws -> [InstalledApp] {
+        let (status, output) = try await capture(
+            of: xcrun, arguments: ["simctl", "listapps", udid]
+        )
+        guard status == 0 else { throw AppsError.listFailed(status: status) }
+
+        // listapps names the apps but not their URL schemes, so each
+        // app's own Info.plist supplies those. An app whose bundle has
+        // gone missing keeps its roster entry and simply contributes no
+        // completions — one unreadable bundle shouldn't empty the list.
+        return InstalledApp.all(fromListApps: output).map { app in
+            guard let bundle = app.bundlePath,
+                  let plist = try? Data(
+                      contentsOf: bundle.appendingPathComponent("Info.plist")
+                  )
+            else { return app }
+            return app.withSchemes(InstalledApp.schemes(inInfoPlist: plist))
+        }
+    }
+
+    /// Accumulates a child's stdout across arbitrarily-chunked callbacks
+    /// that may land on any queue.
+    private final class ByteBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var bytes = Data()
+
+        func append(_ chunk: Data) {
+            lock.lock(); defer { lock.unlock() }
+            bytes.append(chunk)
+        }
+
+        func collected() -> Data {
+            lock.lock(); defer { lock.unlock() }
+            return bytes
+        }
+    }
+
+    /// Run a one-shot child to completion and hand back its exit status
+    /// *and* everything it wrote. `listapps` answers on stdout rather
+    /// than through its exit code, and its output arrives in whatever
+    /// chunks the pipe delivers — so the bytes are accumulated whole and
+    /// parsed once at exit, never per chunk.
+    private func capture(
+        of executable: URL, arguments: [String]
+    ) async throws -> (Int32, Data) {
+        let buffer = ByteBox()
+        return try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<(Int32, Data), Error>) in
+            do {
+                try subprocess.run(
+                    executable: executable,
+                    arguments: arguments,
+                    onBytes: { buffer.append($0) },
+                    onExit: { continuation.resume(returning: ($0, buffer.collected())) }
+                )
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
     /// Total bytes of regular files under `root` — what the archive
     /// actually inflated to on disk.
     private static func regularFileBytes(under root: URL) -> Int64 {

--- a/Sources/Baguette/Infrastructure/Server/Server.swift
+++ b/Sources/Baguette/Infrastructure/Server/Server.swift
@@ -134,6 +134,7 @@ struct Server: Sendable {
         registerBakeryRoutes(on: router, rejectUntrustedBrowser: rejectUntrustedBrowser)
         registerInterfaceRoutes(on: router, rejectUntrustedBrowser: rejectUntrustedBrowser)
         registerCompanionScreenRoutes(on: router, rejectUntrustedBrowser: rejectUntrustedBrowser)
+        registerDeepLinkRoutes(on: router, rejectUntrustedBrowser: rejectUntrustedBrowser)
 
         // Simulator actions.
         router.post("/simulators/:udid/boot")     { [simulators] r, _ in
@@ -1110,7 +1111,10 @@ struct Server: Sendable {
             switch error {
             case .extractFailed, .archiveTooLarge, .noAppInArchive:
                 return .badArchive(reason: error.description)
-            case .installFailed:
+            // `openFailed` / `listFailed` can't reach an upload, but the
+            // switch has to name them: the compiler is the only thing
+            // that will notice when a new `AppsError` case does.
+            case .installFailed, .openFailed, .listFailed:
                 return .dispatchFailed
             }
         } catch {

--- a/Sources/Baguette/Infrastructure/Server/ServerDeepLinkRoutes.swift
+++ b/Sources/Baguette/Infrastructure/Server/ServerDeepLinkRoutes.swift
@@ -1,0 +1,187 @@
+import Foundation
+import HTTPTypes
+import Hummingbird
+import HummingbirdWebSocket
+import NIOCore
+
+/// The two deep-link routes, kept out of `Server.swift`'s main body
+/// alongside `ServerPluginRoutes` / `ServerBakeryRoutes` — that file's
+/// router-builder inference already grinds when too many closures share
+/// one function, and these are independently testable anyway.
+///
+/// Both are **plugin-reachable** (`PluginCapability.openURL`), which is
+/// what lets the deep-link plugin drive them instead of shelling out to
+/// `simctl` behind baguette's back. So each accepts either a trusted
+/// browser or a live capability grant, exactly as `describe-ui.json` and
+/// `input` do.
+extension Server {
+
+    // MARK: - registration
+
+    /// `POST /simulators/:udid/openurl?url=<encoded>`  open a deep link
+    /// `GET  /simulators/:udid/schemes.json[?q=…]`     ranked completions
+    ///
+    /// Ranking happens server-side so there is one ordering rule, tested
+    /// once, rather than a JS copy that drifts. `schemes.json` carries
+    /// the extension because it answers JSON to a `GET`, matching
+    /// `describe-ui.json` / `interface.json` / `simulators.json`.
+    func registerDeepLinkRoutes(
+        on router: Router<BasicWebSocketRequestContext>,
+        rejectUntrustedBrowser: @escaping @Sendable (Request) -> Response?
+    ) {
+        let simulators = self.simulators
+
+        router.post("/simulators/:udid/openurl") { r, _ in
+            if Self.presentsGrant(r) == false, let rejected = rejectUntrustedBrowser(r) {
+                return rejected
+            }
+            let url = r.uri.queryParameters.get("url").map { String($0) } ?? ""
+            switch await Self.openURL(
+                udid: Self.udidParam(r), url: url, simulators: simulators
+            ) {
+            case .opened(let routing):
+                return Self.deepLinkJSON(Self.openedJSONString(routing: routing))
+            case .notAURL:
+                return Self.pluginError(
+                    "not a URL (expected a scheme, e.g. myapp://path)", status: .badRequest
+                )
+            case .unknownDevice:
+                return Self.pluginError("unknown udid: \(Self.udidParam(r))", status: .notFound)
+            case .dispatchFailed:
+                return Self.pluginError(
+                    "xcrun simctl openurl failed", status: .internalServerError
+                )
+            }
+        }
+
+        router.get("/simulators/:udid/schemes.json") { r, _ in
+            if Self.presentsGrant(r) == false, let rejected = rejectUntrustedBrowser(r) {
+                return rejected
+            }
+            let query = r.uri.queryParameters.get("q").map { String($0) } ?? ""
+            switch await Self.schemes(
+                udid: Self.udidParam(r), query: query, simulators: simulators
+            ) {
+            case .ok(let suggestions):
+                return Self.deepLinkJSON(Self.schemesJSONString(suggestions))
+            case .unknownDevice:
+                return Self.pluginError("unknown udid: \(Self.udidParam(r))", status: .notFound)
+            case .listFailed:
+                return Self.pluginError(
+                    "xcrun simctl listapps failed", status: .internalServerError
+                )
+            }
+        }
+    }
+
+    static func deepLinkJSON(_ body: String) -> Response {
+        Response(
+            status: .ok,
+            headers: [.contentType: "application/json", .cacheControl: "no-cache"],
+            body: .init(byteBuffer: ByteBuffer(string: body))
+        )
+    }
+
+    // MARK: - openurl
+
+    /// Outcome of the openurl route. `.opened` carries **where the link
+    /// went**, not merely that dispatch worked: an https link dispatches
+    /// happily and then lands in Safari, so a bare "ok" would be a lie
+    /// the caller repeats back to the developer.
+    enum OpenURLOutcome: Equatable {
+        case opened(routing: DeepLink.Routing)
+        case notAURL
+        case unknownDevice
+        case dispatchFailed
+    }
+
+    /// Parse the typed text, look up the device, open the link. Split
+    /// out from the route closure so unit tests can drive every branch
+    /// (`MockSimulators` + `MockApps`) without booting Hummingbird.
+    ///
+    /// Parsing runs **before** the device lookup: "profile" isn't a URL
+    /// whichever device you aim it at, and saying so is more useful than
+    /// blaming a udid that may be perfectly fine.
+    static func openURL(
+        udid: String,
+        url: String,
+        simulators: any Simulators
+    ) async -> OpenURLOutcome {
+        guard let link = DeepLink.from(url) else { return .notAURL }
+        guard !udid.isEmpty, let sim = simulators.find(udid: udid) else {
+            return .unknownDevice
+        }
+        do {
+            try await sim.apps().open(link)
+        } catch {
+            return .dispatchFailed
+        }
+        return .opened(routing: link.routing)
+    }
+
+    /// What a caller gets back from a successful open. The warning copy
+    /// lives here rather than in the plugin or the page so there's one
+    /// explanation of the Safari fallback, not a server copy and a
+    /// drifting client copy.
+    static func openedJSONString(routing: DeepLink.Routing) -> String {
+        switch routing {
+        case .app:
+            return #"{"ok":true,"routing":"app"}"#
+        case .browser:
+            let warning = "This lands in Safari on the simulator, not your app. "
+                + "If an app claims the domain, iOS shows an \"Open in …?\" dialog "
+                + "that needs a tap, so it never completes unattended. "
+                + "Use the app's own scheme for an automated check."
+            let encoded = (try? JSONSerialization.data(
+                withJSONObject: ["ok": true, "routing": "browser", "warning": warning],
+                options: [.sortedKeys]
+            )).map { String(decoding: $0, as: UTF8.self) }
+            return encoded ?? #"{"ok":true,"routing":"browser"}"#
+        }
+    }
+
+    // MARK: - schemes.json
+
+    /// Outcome of the scheme-completion route.
+    enum SchemesOutcome: Equatable {
+        case ok([SchemeSuggestion])
+        case unknownDevice
+        case listFailed
+    }
+
+    /// The completion inventory for what's been typed so far. Ranking
+    /// happens here rather than in the caller so there's one ordering
+    /// rule, tested once, instead of a copy that drifts.
+    static func schemes(
+        udid: String,
+        query: String,
+        simulators: any Simulators
+    ) async -> SchemesOutcome {
+        guard !udid.isEmpty, let sim = simulators.find(udid: udid) else {
+            return .unknownDevice
+        }
+        do {
+            let installed = try await sim.apps().installed()
+            return .ok(SchemeSuggestion.matching(query, in: installed))
+        } catch {
+            return .listFailed
+        }
+    }
+
+    /// The inventory as a caller consumes it — one row per suggestion,
+    /// already ranked, carrying everything a row renders.
+    static func schemesJSONString(_ suggestions: [SchemeSuggestion]) -> String {
+        let rows = suggestions.map {
+            [
+                "scheme": $0.scheme,
+                "completion": $0.completion,
+                "app": $0.appName,
+                "bundleId": $0.bundleIdentifier,
+            ]
+        }
+        let encoded = (try? JSONSerialization.data(
+            withJSONObject: ["schemes": rows], options: [.sortedKeys]
+        )).map { String(decoding: $0, as: UTF8.self) }
+        return encoded ?? #"{"schemes":[]}"#
+    }
+}

--- a/Sources/Baguette/Infrastructure/Server/ServerPluginRoutes.swift
+++ b/Sources/Baguette/Infrastructure/Server/ServerPluginRoutes.swift
@@ -283,10 +283,16 @@ extension ResultRow {
         var out: [String: Any] = ["title": title, "severity": severity.rawValue]
         if let subtitle { out["subtitle"] = subtitle }
         if let copy { out["copy"] = copy }
+        if let fill { out["fill"] = fill }
         // Round-tripped verbatim: the browser sends `run` + `args` back
         // to the command that authored them. baguette is the postman.
         if let run { out["run"] = run }
         if let args { out["args"] = args.object }
+        // Absent on a plain row, so a panel that ships no controls
+        // projects exactly as it did before controls existed.
+        if let state { out["state"] = state.rawValue }
+        if let value { out["value"] = value }
+        if let group { out["group"] = group }
         if let frame {
             out["frame"] = [
                 "x": frame.origin.x, "y": frame.origin.y,

--- a/Sources/Baguette/Resources/Plugins/a11y/baguette-plugin.json
+++ b/Sources/Baguette/Resources/Plugins/a11y/baguette-plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "a11y",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "apiVersion": 1,
   "description": "Accessibility audit for the current screen, and the display settings to run it under",
   "icon": "accessibility",
@@ -23,7 +23,12 @@
         "title": "Display & Text Size",
         "icon": "wrench",
         "when": "simulator.booted",
-        "body": { "kind": "list", "source": "display", "rowAction": "run" }
+        "body": {
+          "kind": "list",
+          "source": "display",
+          "rowAction": "run",
+          "control": { "kind": "radio", "arg": "settings", "submit": "Apply" }
+        }
       }
     ]
   }

--- a/Sources/Baguette/Resources/Plugins/a11y/bin/display.py
+++ b/Sources/Baguette/Resources/Plugins/a11y/bin/display.py
@@ -6,13 +6,18 @@ one changes the conditions the screen is rendered under, so you can
 re-run that audit in dark mode, with Increase Contrast on, or at an
 accessibility text size — which is where layouts actually break.
 
-Every row is a `rowAction: "run"` row: clicking one calls back into this
-same command with `args`, which applies the change and prints the fresh
-state. The panel re-renders from that answer, so what you see is what
-the device reports, not what the click assumed.
+Every option is a radio row: the row says whether it is on, the manifest
+says to draw it as a radio, and baguette draws it. Ticking is local, so
+picking a size and an appearance costs one subprocess rather than two —
+press Apply and both go together. The panel then re-renders from what
+the command prints, so what you see is what the device reports, not what
+the clicks assumed.
+
+Each question is its own `group`, which is what keeps them independent:
+picking "Dark" must not unpick the text size.
 
   in   BAGUETTE_URL / BAGUETTE_UDID / BAGUETTE_TOKEN in the environment,
-       plus the clicked row's `args` in the JSON on stdin
+       plus the ticked rows as {"args": {"settings": [...]}} on stdin
   out  one JSON object on stdout: {"ok": bool, "message"?, "rows": [...]}
 """
 
@@ -54,18 +59,22 @@ def call(method, path, token, body=None):
         return json.load(response)
 
 
-def picked_row(title, subtitle, selected, args):
-    """A choice. The selected one is marked and carries no action —
-    re-applying what's already set would spawn simctl to change nothing."""
-    row = {
-        "title": ("● " if selected else "○ ") + title,
+def option(group, value, label, subtitle, selected):
+    """One choice within a question.
+
+    The row says what it *is* — on or off, which question it belongs to,
+    what it submits — and the host draws the radio. This used to write
+    "● " / "○ " into the title, which is a plugin drawing a control glyph
+    inside a string: unstyleable, and read aloud as a bullet.
+    """
+    return {
+        "title": label,
         "subtitle": subtitle,
         "severity": "info",
+        "state": "on" if selected else "off",
+        "value": f"{group}:{value}",
+        "group": group,
     }
-    if not selected:
-        row["run"] = "display"
-        row["args"] = args
-    return row
 
 
 def rows_for(state):
@@ -75,29 +84,50 @@ def rows_for(state):
 
     rows = [{"title": "Appearance", "severity": "info"}]
     for value, label in (("light", "Light"), ("dark", "Dark")):
-        rows.append(picked_row(
-            label, None, appearance == value, {"appearance": value}
-        ))
+        rows.append(option("appearance", value, label, None, appearance == value))
 
     rows.append({"title": "Increase Contrast", "severity": "info"})
     for value, label in (("disabled", "Off"), ("enabled", "On")):
-        rows.append(picked_row(
-            label, None, contrast == value, {"increaseContrast": value}
-        ))
+        rows.append(option("increaseContrast", value, label, None, contrast == value))
 
     rows.append({"title": "Text size", "severity": "info"})
     for value, label in OFFERED_SIZES:
-        rows.append(picked_row(
-            label,
+        rows.append(option(
+            "contentSize", value, label,
             value if value != size else f"{value} — current",
             size == value,
-            {"contentSize": value},
         ))
-    # A size outside the offered set is still reachable by stepping, and
-    # the current one is always named above.
-    rows.append(picked_row("Smaller", "one step down", False, {"contentSize": "decrement"}))
-    rows.append(picked_row("Larger", "one step up", False, {"contentSize": "increment"}))
+    # A size outside the offered set is still reachable by stepping. These
+    # are steps rather than choices, so they stay `run` rows — ticking a
+    # relative change and applying it later would apply it from wherever
+    # the size had got to by then, not from where it was when clicked.
+    for value, label, hint in (
+        ("decrement", "Smaller", "one step down"),
+        ("increment", "Larger", "one step up"),
+    ):
+        rows.append({
+            "title": label, "subtitle": hint, "severity": "info",
+            "run": "display", "args": {"contentSize": value},
+        })
     return rows
+
+
+def settings_from(args):
+    """Turn the ticked rows back into the interface payload.
+
+    The browser submits `{"settings": ["appearance:dark", …]}` — one flat
+    list, because that is what a tick set is. Each value carries its own
+    question, so unpacking is a split rather than a lookup table.
+    """
+    if "settings" in args:
+        picked = {}
+        for entry in args.get("settings") or []:
+            key, _, value = str(entry).partition(":")
+            if key and value:
+                picked[key] = value
+        return picked
+    # A `run` row (Smaller / Larger) posts the interface payload directly.
+    return args
 
 
 def main():
@@ -113,12 +143,12 @@ def main():
         context = json.load(sys.stdin)
     except Exception:  # noqa: BLE001 - stdin is optional
         context = {}
-    args = context.get("args") or {}
+    settings = settings_from(context.get("args") or {})
 
     url = f"{base}/simulators/{udid}/interface"
     try:
-        if args:
-            state = call("POST", url, token, body=args)
+        if settings:
+            state = call("POST", url, token, body=settings)
         else:
             state = call("GET", url + ".json", token)
     except urllib.error.HTTPError as error:

--- a/Sources/Baguette/Resources/Web/plugin-control.js
+++ b/Sources/Baguette/Resources/Web/plugin-control.js
@@ -1,0 +1,166 @@
+// PluginControl — what ticking a row in a plugin panel means.
+//
+// Before this, a plugin wanting a settings list wrote its state into the
+// row title: display.py shipped `"● Light"` / `"○ Dark"`. That is a
+// plugin drawing a control glyph inside a string, in a page whose whole
+// premise is that the host owns every pixel. Escaping made it safe, not
+// right — the host couldn't style it, a screen reader read a bullet, and
+// "which one is on" was legible only to a human eye.
+//
+// So a row says whether it is on (`state`) and what it submits
+// (`value`); the manifest says which glyph family draws it; and this
+// file says what clicking does.
+//
+//   "body": { "kind": "list", "source": "perms",
+//             "control": { "kind": "checkbox", "arg": "enabled",
+//                          "submit": "Apply" } }
+//
+// Ticking is LOCAL and batched. It costs no subprocess: the panel
+// accumulates ticks and posts them together when the submit button is
+// pressed, as `{"args": {"enabled": ["camera", "mic"]}}`. The trade is
+// that between the tick and the answer, a row shows state the device has
+// not confirmed — so `pending` exists, and the host marks those rows
+// rather than letting them look settled. A control that lies about the
+// device is worse than one that's slow.
+//
+// Ticks are plain objects passed in and returned, never held here: the
+// renderer owns the current set, this file only says what the next one
+// should be. That keeps every decision testable without a DOM, the same
+// arrangement plugin-row-action.js and plugin-prompt.js use.
+(function (root) {
+  'use strict';
+
+  class PluginControl {
+    /** @param {object|undefined} spec  the panel body's `control` */
+    constructor(spec) {
+      this.spec = spec || null;
+    }
+
+    /**
+     * Whether this panel has tickable rows at all.
+     *
+     * A control naming no `arg` is treated as absent. The host refuses
+     * such a manifest, but the page must not lean on that — ticks with
+     * nowhere to post would be a control that flips and changes nothing.
+     */
+    get present() {
+      return !!(this.spec && typeof this.spec.arg === 'string' && this.spec.arg
+                && typeof this.spec.kind === 'string' && this.spec.kind);
+    }
+
+    /** Which glyph family the host draws: switch / checkbox / radio. */
+    get kind() {
+      return this.present ? this.spec.kind : null;
+    }
+
+    /** The submit button's label. A label is chrome, so it defaults. */
+    get submitLabel() {
+      return (this.spec && this.spec.submit) || 'Apply';
+    }
+
+    /**
+     * Whether `row` is a control rather than a header or a plain note.
+     *
+     * Both halves are required: `state` says it has an on/off, `value`
+     * says what ticking it submits. A row with neither renders as it
+     * always did, which is how a settings panel keeps its section
+     * headings.
+     */
+    isControlRow(row) {
+      return !!(row && (row.state === 'on' || row.state === 'off') && row.value);
+    }
+
+    /**
+     * The starting ticks: what the device last reported.
+     *
+     * Not an empty set — a panel that opened showing every setting off
+     * would be describing a machine that doesn't exist, and inviting you
+     * to "fix" it.
+     */
+    initialTicks(rows) {
+      const ticks = {};
+      if (!this.present) return ticks;
+      for (const row of rows || []) {
+        if (this.isControlRow(row)) ticks[row.value] = row.state === 'on';
+      }
+      return ticks;
+    }
+
+    /**
+     * The ticks after clicking `row`. Returns a new object — the
+     * renderer still holds the previous one to compare against, and
+     * mutating in place would make "what changed" unanswerable.
+     *
+     * A radio turns its **group's** siblings off and cannot be turned
+     * off by re-clicking: "nothing chosen" is a state the device can't
+     * be in, so offering it would be offering a lie.
+     *
+     * The group is what makes a radio panel usable for more than one
+     * question. A settings panel is normally several independent choices
+     * at once — appearance, contrast and text size all at once — and
+     * without groups, picking "Dark" would silently unpick the text
+     * size. Rows naming no group share one implicit group, which is the
+     * single-question panel.
+     */
+    toggle(ticks, row, rows) {
+      if (!this.present || !this.isControlRow(row)) return { ...ticks };
+      if (this.kind !== 'radio') {
+        return { ...ticks, [row.value]: !ticks[row.value] };
+      }
+      const next = { ...ticks };
+      for (const sibling of rows || []) {
+        if (!this.isControlRow(sibling)) continue;
+        if ((sibling.group || null) !== (row.group || null)) continue;
+        next[sibling.value] = false;
+      }
+      next[row.value] = true;
+      return next;
+    }
+
+    /**
+     * Values whose tick disagrees with what the device reported — the
+     * rows that are showing an unconfirmed edit.
+     *
+     * This is the cost of batching made visible. The host draws these
+     * differently so you can tell a setting you asked for from a setting
+     * the device actually has.
+     */
+    pending(ticks, rows) {
+      if (!this.present) return [];
+      return (rows || [])
+        .filter((row) => this.isControlRow(row))
+        .filter((row) => !!ticks[row.value] !== (row.state === 'on'))
+        .map((row) => row.value);
+    }
+
+    /** Whether there is anything to submit. */
+    changed(ticks, rows) {
+      return this.pending(ticks, rows).length > 0;
+    }
+
+    /**
+     * The `args` object for the current ticks, or `null` when the panel
+     * has no control.
+     *
+     * **Always an array**, including for a radio, which yields one
+     * element — one shape means a plugin has one branch to write rather
+     * than a scalar case it discovers by reading the docs twice. An
+     * empty array is a real instruction ("turn all of these off"), not a
+     * no-op, so it is submitted rather than collapsed away.
+     *
+     * Ordered by row order so the plugin sees a stable list rather than
+     * whichever sequence the ticks happened to be clicked in.
+     */
+    args(ticks, rows) {
+      if (!this.present) return null;
+      const on = (rows || [])
+        .filter((row) => this.isControlRow(row))
+        .filter((row) => !!ticks[row.value])
+        .map((row) => row.value);
+      return { [this.spec.arg]: on };
+    }
+  }
+
+  root.Baguette = root.Baguette || {};
+  root.Baguette._PluginControl = PluginControl;
+})(window);

--- a/Sources/Baguette/Resources/Web/plugin-control.js
+++ b/Sources/Baguette/Resources/Web/plugin-control.js
@@ -45,10 +45,20 @@
      */
     get present() {
       return !!(this.spec && typeof this.spec.arg === 'string' && this.spec.arg
-                && typeof this.spec.kind === 'string' && this.spec.kind);
+                && PluginControl.kinds.includes(this.spec.kind));
     }
 
-    /** Which glyph family the host draws: switch / checkbox / radio. */
+    /**
+     * Which glyph family the host draws: switch / checkbox / radio.
+     *
+     * Resolved against the closed set rather than passed through. The
+     * Swift parser already restricts it, but this file must not lean on
+     * that: `/plugins.json` is the same untrusted manifest text every
+     * other string here is escaped for, and `kind` is interpolated
+     * straight into `data-control` and `role` attributes — one malformed
+     * value would close the attribute and open one of its own. Same
+     * treatment `SEVERITIES` gets in sim-plugins.js.
+     */
     get kind() {
       return this.present ? this.spec.kind : null;
     }
@@ -67,6 +77,7 @@
      * headings.
      */
     isControlRow(row) {
+      if (!this.present) return false;   // no control declared, or one we can't draw
       return !!(row && (row.state === 'on' || row.state === 'off') && row.value);
     }
 
@@ -160,6 +171,12 @@
       return { [this.spec.arg]: on };
     }
   }
+
+  /// The glyph families this page can draw, mirroring `RowControl` in
+  /// Domain/Plugin/PanelBody.swift. A closed set on both sides: the host
+  /// refuses an unknown one at parse time, and the page refuses to
+  /// render one it was somehow handed anyway.
+  PluginControl.kinds = ['switch', 'checkbox', 'radio'];
 
   root.Baguette = root.Baguette || {};
   root.Baguette._PluginControl = PluginControl;

--- a/Sources/Baguette/Resources/Web/plugin-prompt.js
+++ b/Sources/Baguette/Resources/Web/plugin-prompt.js
@@ -161,7 +161,12 @@
       if (!needle) return true;
       if (!row) return false;
 
-      const hay = ((row.title || '') + ' ' + (row.subtitle || '')).toLowerCase();
+      // `fill` is searched alongside the display fields: it is the text
+      // that actually goes into the box, while a title may be decorated
+      // or translated. Searching only the label hides the completion
+      // whenever the two differ.
+      const hay = [row.title, row.subtitle, row.fill]
+        .filter(Boolean).join(' ').toLowerCase();
       if (hay.includes(needle)) return true;
 
       // A suggestion you have typed *past* stays visible. Picking

--- a/Sources/Baguette/Resources/Web/plugin-prompt.js
+++ b/Sources/Baguette/Resources/Web/plugin-prompt.js
@@ -1,0 +1,186 @@
+// PluginPrompt — what a panel's text field means.
+//
+// Every panel before this one was a report: the host ran a command and
+// drew what came back. A deep-link bar can't work that way, because the
+// interesting value is the one nobody has typed yet. A panel may declare
+// a `prompt`, and submitting it invokes that panel's own `source`
+// command with the typed text under the key the manifest named:
+//
+//   "prompt": { "arg": "url", "placeholder": "myapp://path",
+//               "submit": "Open", "filter": true }
+//
+// which posts `{"args":{"url":"<typed>"}}` — the same body a
+// `rowAction: "run"` click posts, to the same endpoint. So this is a
+// widget, not a new execution model, and no plugin code runs in the page.
+//
+// Split out of sim-plugins.js so the decisions are testable without a
+// DOM, exactly as plugin-row-action.js is: this file says what should
+// happen, sim-plugins.js does it.
+(function (root) {
+  'use strict';
+
+  class PluginPrompt {
+    /** @param {object|undefined} spec  the panel body's `prompt` */
+    constructor(spec) {
+      this.spec = spec || null;
+    }
+
+    /**
+     * Whether to draw a field at all.
+     *
+     * A prompt naming no `arg` is treated as absent rather than drawn.
+     * The host refuses such a manifest, but the page must not lean on
+     * that — a field that submits into nowhere looks exactly like a
+     * working control and does nothing.
+     */
+    get present() {
+      return !!(this.spec && typeof this.spec.arg === 'string' && this.spec.arg);
+    }
+
+    /** Greyed hint inside the empty field. */
+    get placeholder() {
+      return (this.spec && this.spec.placeholder) || '';
+    }
+
+    /** The submit button's label. A label is chrome, so it defaults. */
+    get submitLabel() {
+      return (this.spec && this.spec.submit) || 'Run';
+    }
+
+    /** Whether typing also narrows the rows already on screen. */
+    get filters() {
+      return !!(this.spec && this.spec.filter);
+    }
+
+    /** Whether the field finishes your sentence as you type. */
+    get completes() {
+      return !!(this.spec && this.spec.complete);
+    }
+
+    /** Whether what you submit is remembered for `↑` / `↓`. */
+    get remembers() {
+      return !!(this.spec && this.spec.history);
+    }
+
+    /**
+     * Everything the bar may complete to, best guess first.
+     *
+     * History leads: `account://hello` is a thing you actually did,
+     * `account://` is merely a scheme that exists on the device. Rows
+     * follow in the order the plugin ranked them. Deduped, because a
+     * link you used *and* that is installed is one candidate, not two.
+     */
+    candidates(rows, history) {
+      const out = [];
+      const seen = new Set();
+      const add = (text) => {
+        const value = String(text == null ? '' : text);
+        if (!value || seen.has(value)) return;
+        seen.add(value);
+        out.push(value);
+      };
+      for (const entry of history || []) add(entry);
+      for (const row of rows || []) add(row && (row.fill || row.title));
+      return out;
+    }
+
+    /**
+     * The part of the best candidate you haven't typed yet — drawn
+     * greyed after the caret, and what `Tab` / `→` accepts.
+     *
+     * Empty unless the panel asked for completion, and empty for an
+     * empty field: a bar that starts guessing before you've typed
+     * anything is noise.
+     */
+    ghost(value, candidates) {
+      if (!this.completes) return '';
+      const typed = String(value == null ? '' : value);
+      if (!typed) return '';
+      const lower = typed.toLowerCase();
+      const hit = (candidates || []).find(
+        (c) => c.length > typed.length && c.toLowerCase().startsWith(lower)
+      );
+      return hit ? hit.slice(typed.length) : '';
+    }
+
+    /**
+     * The field's value once the ghost is accepted.
+     *
+     * Built by appending the remainder to what was typed rather than
+     * swapping in the candidate, so typing `ACC` completes to
+     * `ACCount://hello` — the bar finishes your word instead of
+     * rewriting it under the caret.
+     */
+    accepted(value, candidates) {
+      const typed = String(value == null ? '' : value);
+      return typed + this.ghost(typed, candidates);
+    }
+
+    /**
+     * `history` with `value` at the front. A link you re-open moves up
+     * rather than appearing twice, and the list is capped so it stays a
+     * shortlist you can arrow through rather than a log.
+     */
+    remember(history, value) {
+      const existing = history || [];
+      if (!this.remembers) return existing;
+      const entry = String(value == null ? '' : value).trim();
+      if (!entry) return existing;
+      return [entry, ...existing.filter((e) => e !== entry)]
+        .slice(0, PluginPrompt.historyLimit);
+    }
+
+    /**
+     * The `args` object for what was typed, or `null` when there is
+     * nothing to send — a blank submit would spawn a subprocess only to
+     * be told the field was empty.
+     *
+     * Trimmed, because pasting a link routinely brings a trailing
+     * newline and echoing it back untrimmed makes the answer look wrong.
+     */
+    args(value) {
+      if (!this.present) return null;
+      const trimmed = String(value == null ? '' : value).trim();
+      if (!trimmed) return null;
+      return { [this.spec.arg]: trimmed };
+    }
+
+    /**
+     * Whether `row` survives what's typed so far.
+     *
+     * Only when the manifest asked for it. A command is a subprocess
+     * with a bounded budget, so re-running it per keystroke is the wrong
+     * shape — but the rows it already returned are right here, and
+     * narrowing them locally gives back the feel of completion for the
+     * price of a string comparison. A panel that didn't ask keeps every
+     * row: its list is a reference, not a search result.
+     */
+    matches(row, value) {
+      if (!this.filters) return true;
+      const needle = String(value == null ? '' : value).trim().toLowerCase();
+      if (!needle) return true;
+      if (!row) return false;
+
+      const hay = ((row.title || '') + ' ' + (row.subtitle || '')).toLowerCase();
+      if (hay.includes(needle)) return true;
+
+      // A suggestion you have typed *past* stays visible. Picking
+      // `account://` fills the box and then you type the path; on a
+      // substring test alone the row you just picked would vanish at the
+      // next character and the list would read "Nothing matches" for the
+      // rest of the URL — the list fighting the thing it exists to help
+      // with. Matched against `fill` where a row has one, since that's
+      // the text that actually went into the field.
+      const own = String(row.fill || row.title || '').toLowerCase();
+      return !!own && needle.startsWith(own);
+    }
+  }
+
+  /// How many submissions a panel keeps. Long enough to arrow back to
+  /// this morning's link, short enough that arrowing through it is
+  /// faster than retyping.
+  PluginPrompt.historyLimit = 25;
+
+  root.Baguette = root.Baguette || {};
+  root.Baguette._PluginPrompt = PluginPrompt;
+})(window);

--- a/Sources/Baguette/Resources/Web/plugin-row-action.js
+++ b/Sources/Baguette/Resources/Web/plugin-row-action.js
@@ -34,6 +34,7 @@
      *          |{kind:'tap', point:{x:number,y:number}}
      *          |{kind:'copy', text:string}
      *          |{kind:'run', command:string, args:object}
+     *          |{kind:'fill', text:string}
      *          |null}
      */
     intent(row) {
@@ -50,6 +51,11 @@
           // and demanding one would make every such row inert. Args
           // default to {} so the caller has a single shape to post.
           return row.run ? { kind: 'run', command: row.run, args: row.args || {} } : null;
+        case 'fill':
+          // The row's own text, never its title: a title is display
+          // text, so truncating or translating it would silently change
+          // what gets typed into the field.
+          return row.fill ? { kind: 'fill', text: row.fill } : null;
         default:
           return null;
       }

--- a/Sources/Baguette/Resources/Web/sim-native.html
+++ b/Sources/Baguette/Resources/Web/sim-native.html
@@ -1816,6 +1816,148 @@
   #simNativeView .plugin-row-sub {
     color: var(--nv-text-muted); font-size: 11px; overflow-wrap: anywhere;
   }
+  /* A row saying the filter matched nothing — a note, not an entry, so
+     it carries no severity dot and doesn't look clickable. */
+  #simNativeView .plugin-row-empty { cursor: default; padding-left: 14px; }
+  #simNativeView .plugin-row-empty:hover { background: none; }
+
+  /* A panel's text field (`prompt`). Sits above the rows, inside the
+     scroll container's sticky top so it stays reachable in a long list —
+     it's the control, the rows below it are the reference. Metrics are
+     shared with the add-a-bakery modal's field so the two read as the
+     same widget. */
+  #simNativeView .plugin-prompt {
+    display: flex; gap: 8px; padding: 10px 14px;
+    position: sticky; top: 0; z-index: 1;
+    background: var(--nv-bar-bg);
+    border-bottom: 1px solid var(--nv-bar-border);
+  }
+  /* The field stacks an input over a ghost layer. Both carry identical
+     box metrics and the same font, which is what lets the un-typed
+     remainder line up with the caret without measuring any text. */
+  #simNativeView .plugin-prompt-field { position: relative; flex: 1; min-width: 0; }
+  #simNativeView .plugin-prompt-input,
+  #simNativeView .plugin-prompt-ghost {
+    padding: 6px 8px; border-radius: 8px;
+    border: 1px solid transparent;
+    font: 400 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+    box-sizing: border-box;
+  }
+  #simNativeView .plugin-prompt-input {
+    position: relative; width: 100%;
+    appearance: none; -webkit-appearance: none;
+    background: var(--nv-fmt-track-bg);
+    border-color: var(--nv-bar-border);
+    color: var(--nv-text);
+    min-width: 0;
+  }
+  #simNativeView .plugin-prompt-input:focus {
+    outline: none; border-color: var(--nv-accent);
+  }
+  #simNativeView .plugin-prompt-ghost {
+    position: absolute; inset: 0; z-index: 1;
+    white-space: pre; overflow: hidden;
+    pointer-events: none;
+  }
+  /* The typed half is drawn and then made invisible — it is the spacer
+     that puts the remainder under the caret. */
+  #simNativeView .plugin-prompt-typed { color: transparent; }
+  #simNativeView .plugin-prompt-rest { color: var(--nv-text-muted); opacity: 0.75; }
+  #simNativeView .plugin-prompt-go { flex: 0 0 auto; padding: 6px 12px; }
+
+  /* Tickable rows. The glyph family is chosen by the manifest but drawn
+     entirely here — a plugin names `switch` / `checkbox` / `radio` and
+     never supplies a mark of its own. */
+  /* Centring is done by the layout, not by arithmetic: the content box
+     is 12px (15 minus two 1.5px borders), so any hand-computed margin
+     has to be a half-pixel to land in the middle — and the first attempt
+     used 3px, leaving the dot a pixel high. */
+  #simNativeView .plugin-tick {
+    flex: 0 0 auto; margin-top: 1px;
+    width: 15px; height: 15px; box-sizing: border-box;
+    border: 1.5px solid var(--nv-text-muted);
+    background: transparent;
+    display: flex; align-items: center; justify-content: center;
+    transition: background 0.12s ease, border-color 0.12s ease;
+  }
+  #simNativeView .plugin-tick[data-control="checkbox"] { border-radius: 4px; }
+  #simNativeView .plugin-tick[data-control="radio"]    { border-radius: 50%; }
+  #simNativeView .plugin-tick[data-on="true"] {
+    background: var(--nv-accent); border-color: var(--nv-accent);
+  }
+  /* The checkmark / dot, drawn with a pseudo-element so the row markup
+     carries no glyph of its own. */
+  #simNativeView .plugin-tick[data-control="checkbox"][data-on="true"]::after {
+    content: ''; width: 3px; height: 7px;
+    border: solid var(--nv-accent-text);
+    border-width: 0 1.6px 1.6px 0;
+    /* A rotated tick's visual mass sits below its box centre, so the
+       geometric centre reads a pixel low. This is the one nudge that is
+       an optical correction rather than a miscalculation. */
+    margin-bottom: 2px;
+    transform: rotate(45deg);
+  }
+  #simNativeView .plugin-tick[data-control="radio"][data-on="true"]::after {
+    content: ''; width: 5px; height: 5px;
+    border-radius: 50%; background: var(--nv-accent-text);
+  }
+  /* A switch is a pill, so it overrides the square metrics above. */
+  #simNativeView .plugin-tick[data-control="switch"] {
+    width: 26px; height: 15px; border-radius: 999px;
+    position: relative;
+  }
+  #simNativeView .plugin-tick[data-control="switch"]::after {
+    content: ''; position: absolute; top: 1.5px; left: 1.5px;
+    width: 9px; height: 9px; border-radius: 50%;
+    background: var(--nv-text-muted);
+    transition: transform 0.12s ease, background 0.12s ease;
+  }
+  #simNativeView .plugin-tick[data-control="switch"][data-on="true"]::after {
+    background: var(--nv-accent-text); transform: translateX(11px);
+  }
+
+  /* A section heading inside a panel of controls. It carries no dot:
+     an `info` dot in the same column as a radio reads as a third,
+     disabled control state, and once every row in the gutter is a
+     circle the hierarchy is gone. Set in small caps against the
+     options rather than looking like one of them. */
+  #simNativeView .plugin-row-heading {
+    padding: 14px 14px 4px;
+    font: 600 9.5px/1 -apple-system, sans-serif;
+    letter-spacing: 0.10em; text-transform: uppercase;
+    color: var(--nv-text-faint, var(--nv-text-muted));
+  }
+  #simNativeView .plugin-row-heading:first-child { padding-top: 10px; }
+  #simNativeView .plugin-row-heading .plugin-row-title { font: inherit; letter-spacing: inherit; }
+  /* An ordinary action row among controls — "Smaller" / "Larger". No
+     tick, so it aligns with the option labels instead of hanging in the
+     control column pretending to be one. */
+  #simNativeView .plugin-row-inset { padding-left: 37px; }
+  #simNativeView .plugin-row-inset .plugin-dot { display: none; }
+
+  /* A row whose tick hasn't been confirmed by the device yet. Batching
+     buys one subprocess per Apply instead of one per tick; this is the
+     price, drawn rather than hidden — a control that looks settled while
+     the device says otherwise is worse than one that's slow. */
+  #simNativeView .plugin-row-pending {
+    background: color-mix(in srgb, var(--nv-accent) 8%, transparent);
+  }
+  #simNativeView .plugin-row-pending .plugin-row-title { font-style: italic; }
+  #simNativeView .plugin-row-pending .plugin-tick {
+    border-style: dashed;
+  }
+
+  /* The batch-submit bar. Outside the scrolling body so it stays put —
+     a submit button you have to scroll to find is one you forget to
+     press, and with batching that means losing the edit. */
+  #simNativeView .plugin-apply {
+    display: flex; justify-content: flex-end;
+    padding: 10px 14px;
+    border-top: 1px solid var(--nv-bar-border);
+  }
+  #simNativeView .plugin-apply-btn { padding: 6px 14px; }
+  #simNativeView .plugin-apply-btn:disabled { opacity: 0.4; cursor: default; }
+
   /* The box drawn over the live screen for a `highlight` row. */
   #simNativeView .plugin-highlight {
     position: absolute; z-index: 30; pointer-events: none;

--- a/Sources/Baguette/Resources/Web/sim-plugins.js
+++ b/Sources/Baguette/Resources/Web/sim-plugins.js
@@ -93,6 +93,26 @@
       this.log = log || (() => {});
       this.plugins = [];
       this.openPanelID = null;
+      // What's typed in the open panel's prompt, if it has one. Held
+      // here rather than read off the DOM because every command answer
+      // re-renders the card — losing what you typed on the round trip
+      // would make "tweak the path and fire again" impossible.
+      this.promptValue = '';
+      // Whether the field should hold focus after a render. Stays false
+      // through the "Running…" placeholder — grabbing focus before
+      // there's a field to type into would just bounce — and is set once
+      // the panel's first answer draws one. You opened a panel with a
+      // text field to type in it.
+      this.promptFocused = false;
+      this.openPluginName = null;
+      // The rows the open panel last returned, kept so `filter` can
+      // narrow them without re-running the command.
+      this.rows = [];
+      // Local tick state for a panel with controls: `{value: bool}`.
+      // Diverges from the rows' reported state between a tick and the
+      // Apply that confirms it, which is exactly what marks a row
+      // pending. Rebuilt from every fresh answer.
+      this.ticks = {};
       this.rail = null;
       this.host = null;
       // The hover flyout: at most one open, owned by one group button.
@@ -361,6 +381,18 @@
 
     close() {
       this.openPanelID = null;
+      this.openPluginName = null;
+      this.promptValue = '';
+      this.promptFocused = false;
+      this.rows = [];
+      this.ticks = {};
+      // What's been submitted from this panel's prompt, newest first,
+      // and where ↑/↓ currently sits in it (-1 = not browsing).
+      this.history = [];
+      this.historyAt = -1;
+      // Escape hides the ghost without clearing the field; typing again
+      // brings it back.
+      this.ghostSuppressed = false;
       this.host.innerHTML = '';
       this.host.hidden = true;
       this.onHighlight(null);
@@ -369,7 +401,19 @@
 
     async open(pluginName, panel) {
       this.openPanelID = panel.id;
+      this.openPluginName = pluginName;
       this.host.hidden = false;
+      // A fresh panel starts with an empty field and no rows; carrying
+      // the last panel's text across would submit it to a different
+      // plugin's command. Switching panels goes straight through here
+      // without passing `close`, so this is the only place that runs.
+      this.promptValue = '';
+      this.promptFocused = false;
+      this.rows = [];
+      this.ticks = {};
+      this.historyAt = -1;
+      this.ghostSuppressed = false;
+      this.history = this.promptFor(panel).remembers ? this.loadHistory(panel) : [];
       this.renderShell(pluginName, panel, '<div class="plugin-status">Running…</div>');
 
       const body = panel.body || {};
@@ -380,6 +424,157 @@
 
       const [id, cmd] = String(body.source).split(':');
       await this.invoke(pluginName, panel, id, cmd, null);
+    }
+
+    /// The panel's declared text field, as a decision object. Absent for
+    /// every panel that doesn't declare one, which is all of them until
+    /// a manifest opts in.
+    promptFor(panel) {
+      return new window.Baguette._PluginPrompt((panel.body || {}).prompt);
+    }
+
+    // --- inline completion + history ----------------------------------
+
+    /// Where history lives: per panel, so the deep-link bar and a
+    /// settings panel don't arrow through each other's entries.
+    historyKey(panel) {
+      return 'baguette.plugin-prompt.' + String(panel.id || '');
+    }
+
+    /// Reading is defensive because `localStorage` throws outright in
+    /// private mode and in some embedded webviews — a bar that can't
+    /// remember must still type.
+    loadHistory(panel) {
+      try {
+        const raw = window.localStorage.getItem(this.historyKey(panel));
+        const parsed = raw ? JSON.parse(raw) : [];
+        return Array.isArray(parsed) ? parsed.filter((e) => typeof e === 'string') : [];
+      } catch (_) {
+        return [];
+      }
+    }
+
+    saveHistory(panel, history) {
+      try {
+        window.localStorage.setItem(this.historyKey(panel), JSON.stringify(history));
+      } catch (_) { /* full, or storage denied — not worth failing a click over */ }
+    }
+
+    /// What the bar may complete to: what you've used, then what the
+    /// plugin listed. Filtered rows only, so the ghost never offers
+    /// something the list is currently hiding.
+    promptCandidates(panel) {
+      const prompt = this.promptFor(panel);
+      const visible = this.rows.filter((row) => prompt.matches(row, this.promptValue));
+      return prompt.candidates(visible, this.history);
+    }
+
+    promptGhost(panel) {
+      if (this.ghostSuppressed) return '';
+      return this.promptFor(panel).ghost(this.promptValue, this.promptCandidates(panel));
+    }
+
+    /**
+     * Draw the un-typed remainder behind the field.
+     *
+     * The typed prefix is rendered too, but transparent — that's what
+     * makes the remainder line up with the caret without measuring text.
+     * Both halves go in via `textContent`, so a plugin's row text can't
+     * become markup on the way.
+     */
+    paintGhost(panel) {
+      const ghost = this.host.querySelector('.plugin-prompt-ghost');
+      if (!ghost) return;
+      ghost.textContent = '';
+      const rest = this.promptGhost(panel);
+      if (!rest) return;
+
+      const typed = document.createElement('span');
+      typed.className = 'plugin-prompt-typed';
+      typed.textContent = this.promptValue;
+      const remainder = document.createElement('span');
+      remainder.className = 'plugin-prompt-rest';
+      remainder.textContent = rest;
+      ghost.appendChild(typed);
+      ghost.appendChild(remainder);
+    }
+
+    /**
+     * Step through what's been submitted before. `↑` goes older.
+     *
+     * Stepping back past the newest entry restores the field to empty
+     * rather than sticking on the first one, so arrowing up and back
+     * down leaves you where you started.
+     */
+    recallHistory(panel, direction) {
+      if (!this.history.length) return;
+      const next = Math.min(this.history.length - 1, Math.max(-1, this.historyAt + direction));
+      this.historyAt = next;
+      this.promptValue = next < 0 ? '' : this.history[next];
+      // A recalled value is a whole entry, so a ghost completing it
+      // further would be suggesting something you didn't ask for.
+      this.ghostSuppressed = true;
+      const input = this.host.querySelector('.plugin-prompt-input');
+      if (input) {
+        input.value = this.promptValue;
+        input.setSelectionRange(this.promptValue.length, this.promptValue.length);
+      }
+      this.paintGhost(panel);
+      if (this.promptFor(panel).filters) {
+        this.paintRows(panel, (panel.body || {}).rowAction);
+      }
+    }
+
+    /**
+     * Put a row's text into the prompt and leave the caret after it.
+     *
+     * The point is to keep typing, so this deliberately does **not**
+     * submit: `account://` on its own is a scheme with no path, which is
+     * almost never what anyone means to open. The field becomes what you
+     * picked, and Enter is still yours to press.
+     */
+    fillPrompt(panel, text, rowAction) {
+      this.promptValue = text;
+      this.promptFocused = true;
+      // Picking a row is a fresh intent, so a ghost dismissed earlier is
+      // welcome again — it's how you get from `account://` to the path
+      // you used last time in one more keystroke.
+      this.ghostSuppressed = false;
+      this.historyAt = -1;
+      const input = this.host.querySelector('.plugin-prompt-input');
+      if (input) {
+        input.value = text;
+        input.focus();
+        input.setSelectionRange(text.length, text.length);
+      }
+      this.paintGhost(panel);
+      // Repaint the rows against the new filter value, but never through
+      // renderShell — that would rebuild the field and drop the caret we
+      // just placed.
+      if (this.promptFor(panel).filters) this.paintRows(panel, rowAction);
+    }
+
+    /**
+     * Submit the prompt: run the panel's own `source` command with what
+     * was typed. Identical to a `rowAction: "run"` click — same body,
+     * same endpoint — so the panel re-renders from what the command
+     * actually answered rather than from what the submit assumed.
+     */
+    submitPrompt(pluginName, panel) {
+      const prompt = this.promptFor(panel);
+      const args = prompt.args(this.promptValue);
+      if (!args) return;   // nothing typed; don't spend a subprocess
+      // Remembered on submit rather than on success: you typed it and
+      // meant it, and a link that failed is exactly the one you want to
+      // arrow back to and fix.
+      if (prompt.remembers) {
+        this.history = prompt.remember(this.history, this.promptValue);
+        this.historyAt = -1;
+        this.saveHistory(panel, this.history);
+      }
+      const [id, cmd] = String((panel.body || {}).source || '').split(':');
+      this.renderShell(pluginName, panel, '<div class="plugin-status">Running…</div>');
+      this.invoke(pluginName, panel, id, cmd, args);
     }
 
     /**
@@ -460,6 +655,8 @@
     }
 
     renderShell(pluginName, panel, innerHTML) {
+      const prompt = this.promptFor(panel);
+      const control = this.controlFor(panel);
       this.host.innerHTML =
         '<div class="plugin-card">'
         + '<div class="plugin-head">'
@@ -467,23 +664,262 @@
         +   '<span class="plugin-tag">' + escapeHTML(pluginName) + '</span>'
         +   '<button class="plugin-close" aria-label="Close">✕</button>'
         + '</div>'
-        + '<div class="plugin-body">' + innerHTML + '</div>'
+        + '<div class="plugin-body">'
+        +   (prompt.present ? '<div class="plugin-prompt"></div>' : '')
+        +   innerHTML
+        + '</div>'
+        // Outside `.plugin-body` so it stays put while the rows scroll —
+        // a submit button you have to scroll to find is one you forget
+        // to press, which with batching means losing the edit.
+        + (control.present ? '<div class="plugin-apply"></div>' : '')
         + '</div>';
       const close = this.host.querySelector('.plugin-close');
       if (close) close.addEventListener('click', () => this.close());
+      if (prompt.present) this.mountPrompt(pluginName, panel, prompt);
+      if (control.present) this.mountApply(pluginName, panel, control);
+    }
+
+    /**
+     * The batch-submit button, at the foot of a panel with controls.
+     *
+     * It says how many rows are waiting, because the whole cost of
+     * batching is that those rows are showing something the device
+     * hasn't confirmed — and a button that didn't count them would let
+     * you close the panel believing you'd applied something.
+     */
+    mountApply(pluginName, panel, control) {
+      const slot = this.host.querySelector('.plugin-apply');
+      if (!slot) return;
+
+      const button = document.createElement('button');
+      button.className = 'plugin-btn plugin-apply-btn';
+      slot.appendChild(button);
+      button.addEventListener('click', () => this.submitTicks(pluginName, panel, control));
+      this.paintApplyButton(panel);
+    }
+
+    /// Keep the button's label and enabled state honest as ticks change.
+    paintApplyButton(panel) {
+      const button = this.host.querySelector('.plugin-apply-btn');
+      if (!button) return;
+      const control = this.controlFor(panel);
+      const waiting = control.pending(this.ticks, this.rows).length;
+      button.textContent = waiting
+        ? control.submitLabel + ' (' + waiting + ')'
+        : control.submitLabel;
+      // Nothing pending means nothing to say to the device. Disabled
+      // rather than hidden, so the button doesn't appear and vanish
+      // under the cursor as you tick and untick.
+      button.disabled = waiting === 0;
+      const slot = this.host.querySelector('.plugin-apply');
+      if (slot) slot.classList.toggle('plugin-apply-dirty', waiting > 0);
+    }
+
+    /**
+     * Send every ticked value at once, then re-render from the answer.
+     *
+     * The panel deliberately does not keep its local ticks afterwards:
+     * `renderRows` rebuilds them from what the plugin reports, so a
+     * setting the device refused snaps back to the truth instead of
+     * staying stuck the way it was clicked.
+     */
+    submitTicks(pluginName, panel, control) {
+      const args = control.args(this.ticks, this.rows);
+      if (!args) return;
+      const [id, cmd] = String((panel.body || {}).source || '').split(':');
+      this.renderShell(pluginName, panel, '<div class="plugin-status">Applying…</div>');
+      this.invoke(pluginName, panel, id, cmd, args);
+    }
+
+    /**
+     * Build the text field with DOM calls rather than an HTML string.
+     *
+     * `placeholder` and the button label come from a manifest, which is
+     * untrusted text destined for the origin `isTrustedBrowserRequest`
+     * spends ~70 lines defending — so they go in via `setAttribute` and
+     * `textContent`, never `innerHTML`. Same rule as every other
+     * manifest string in this file.
+     */
+    mountPrompt(pluginName, panel, prompt) {
+      const slot = this.host.querySelector('.plugin-prompt');
+      if (!slot) return;
+
+      // The ghost sits *behind* the input, sharing its metrics, with the
+      // typed prefix rendered transparent so only the remainder shows.
+      // An overlay rather than a second value in the field itself, which
+      // would put text the user hasn't accepted into what Enter submits.
+      const field = document.createElement('div');
+      field.className = 'plugin-prompt-field';
+      const ghost = document.createElement('div');
+      ghost.className = 'plugin-prompt-ghost';
+      ghost.setAttribute('aria-hidden', 'true');
+
+      const input = document.createElement('input');
+      input.className = 'plugin-prompt-input';
+      input.type = 'text';
+      input.spellcheck = false;
+      input.setAttribute('placeholder', prompt.placeholder);
+      input.setAttribute('aria-label', panel.title);
+      input.value = this.promptValue;
+
+      const go = document.createElement('button');
+      go.className = 'plugin-btn plugin-prompt-go';
+      go.textContent = prompt.submitLabel;
+
+      field.appendChild(ghost);
+      field.appendChild(input);
+      slot.appendChild(field);
+      slot.appendChild(go);
+
+      const rowAction = (panel.body || {}).rowAction;
+      const retype = () => {
+        this.promptValue = input.value;
+        this.paintGhost(panel);
+        if (prompt.filters) this.paintRows(panel, rowAction);
+      };
+
+      input.addEventListener('input', () => {
+        // Typing leaves history browsing — otherwise the next ↑ would
+        // jump from a value you've since edited.
+        this.historyAt = -1;
+        // And it revives a ghost dismissed with Escape or stood down by
+        // a history recall. Suppression is about *that* value; once you
+        // type a different one there's a fresh suggestion to make, and
+        // leaving the flag set silently killed completion for the rest
+        // of the session.
+        this.ghostSuppressed = false;
+        retype();
+      });
+      input.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') { this.submitPrompt(pluginName, panel); return; }
+
+        // Accept the ghost. `→` only counts at the very end of the
+        // field, so moving the caret through what you typed still moves
+        // the caret.
+        const atEnd = input.selectionStart === input.value.length
+                   && input.selectionEnd === input.value.length;
+        if ((event.key === 'Tab' || (event.key === 'ArrowRight' && atEnd))
+            && this.promptGhost(panel)) {
+          event.preventDefault();
+          input.value = prompt.accepted(input.value, this.promptCandidates(panel));
+          retype();
+          return;
+        }
+
+        if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && prompt.remembers) {
+          event.preventDefault();
+          this.recallHistory(panel, event.key === 'ArrowUp' ? 1 : -1);
+          return;
+        }
+
+        // Give up the suggestion without giving up what you typed.
+        if (event.key === 'Escape' && this.promptGhost(panel)) {
+          event.preventDefault();
+          this.ghostSuppressed = true;
+          this.paintGhost(panel);
+        }
+      });
+      go.addEventListener('click', () => this.submitPrompt(pluginName, panel));
+      this.paintGhost(panel);
+
+      // Re-focus after a re-render, so submitting and then typing again
+      // doesn't need a click. Caret to the end rather than selecting all
+      // — you're usually editing the path, not replacing the URL.
+      if (this.promptFocused) {
+        input.focus();
+        input.setSelectionRange(input.value.length, input.value.length);
+      }
     }
 
     renderRows(pluginName, panel, rows, rowAction) {
-      if (!rows.length) {
+      this.rows = rows;
+      const prompt = this.promptFor(panel);
+      // A panel with a field is never "empty": the field is the point,
+      // and replacing it with "Nothing to report" would take away the
+      // only way to ask for something.
+      if (!rows.length && !prompt.present) {
         this.renderShell(pluginName, panel, '<div class="plugin-status">Nothing to report</div>');
         return;
       }
+      // The first answer is what draws the field, so this is the render
+      // that may take focus — you opened a panel with a text box to type
+      // in it. Every later render then restores it.
+      if (prompt.present) this.promptFocused = true;
+      // A fresh answer is the device's word on every control, so the
+      // pending ticks it just confirmed (or refused) are replaced by it
+      // rather than surviving to contradict it.
+      this.ticks = this.controlFor(panel).initialTicks(rows);
+      this.renderShell(pluginName, panel, this.rowsHTML(rows, rowAction, prompt, panel));
+      this.wireRows(pluginName, panel, rowAction);
+    }
+
+    /// Re-draw just the row list against the current filter and ticks,
+    /// leaving the field alone — repainting the whole card on every
+    /// keystroke would tear down the input being typed into.
+    paintRows(panel, rowAction) {
+      const prompt = this.promptFor(panel);
+      const list = this.host.querySelector('.plugin-rows');
+      const body = this.host.querySelector('.plugin-body');
+      const html = this.rowsHTML(this.rows, rowAction, prompt, panel);
+      if (list) list.outerHTML = html;
+      else if (body) body.insertAdjacentHTML('beforeend', html);
+      this.wireRows(null, panel, rowAction);
+      this.paintApplyButton(panel);
+    }
+
+    /// The panel's declared row controls, as a decision object.
+    controlFor(panel) {
+      return new window.Baguette._PluginControl((panel.body || {}).control);
+    }
+
+    rowsHTML(rows, rowAction, prompt, panel) {
       const action = new window.Baguette._PluginRowAction(rowAction);
-      const items = rows.map((row, index) => {
+      const control = this.controlFor(panel);
+      const pending = new Set(control.pending(this.ticks, rows));
+      // Carry each row's index in the *unfiltered* list, because that's
+      // what the click handler looks the row up by — filtering must not
+      // silently renumber which row a click resolves to.
+      const visible = rows
+        .map((row, index) => ({ row, index }))
+        .filter(({ row }) => prompt.matches(row, this.promptValue));
+      if (!visible.length) {
+        return '<ul class="plugin-rows"><li class="plugin-row plugin-row-empty">'
+             + '<span class="plugin-row-text"><span class="plugin-row-sub">'
+             + (rows.length ? 'Nothing matches' : 'Nothing to report')
+             + '</span></span></li></ul>';
+      }
+      const items = visible.map(({ row, index }) => {
         const severity = SEVERITIES.includes(row.severity) ? row.severity : 'info';
-        const clickable = action.actionable(row) ? ' plugin-row-clickable' : '';
-        return '<li class="plugin-row' + clickable + '" data-index="' + index + '">'
-             + '<span class="plugin-dot" data-severity="' + severity + '"></span>'
+        const ticked = control.isControlRow(row);
+        // A control row is clickable because it ticks; a plain row falls
+        // through to whatever `rowAction` the panel declared. That's how
+        // a settings list keeps its section headings and can still mix
+        // in an ordinary action row.
+        const clickable = (ticked || action.actionable(row)) ? ' plugin-row-clickable' : '';
+        const unconfirmed = pending.has(row.value) ? ' plugin-row-pending' : '';
+        // In a panel of controls, a plain informational row is a section
+        // heading — the only thing display.py uses one for. Saying so in
+        // the markup is what lets it stop competing with the ticks: an
+        // `info` dot sitting in the same column as a radio reads as a
+        // third, disabled control state, and once every row in the
+        // gutter is a circle the hierarchy is gone. A `warn` / `error`
+        // dot still draws, because that one carries real meaning.
+        const heading = control.present && !ticked
+          && !action.actionable(row) && severity === 'info';
+        return '<li class="plugin-row' + clickable + unconfirmed
+             + (heading ? ' plugin-row-heading' : '')
+             + (control.present && !ticked && !heading ? ' plugin-row-inset' : '')
+             + '" data-index="' + index + '">'
+             + (ticked
+                  // The glyph is host markup driven by a boolean; the
+                  // manifest only ever chose which family to draw.
+                  ? '<span class="plugin-tick" data-control="' + control.kind + '"'
+                    + ' data-on="' + (this.ticks[row.value] ? 'true' : 'false') + '"'
+                    + ' role="' + (control.kind === 'radio' ? 'radio' : 'checkbox') + '"'
+                    + ' aria-checked="' + (this.ticks[row.value] ? 'true' : 'false') + '"></span>'
+                  : heading
+                      ? ''
+                      : '<span class="plugin-dot" data-severity="' + severity + '"></span>')
              + '<span class="plugin-row-text">'
              +   '<span class="plugin-row-title">' + escapeHTML(row.title) + '</span>'
              +   (row.subtitle
@@ -491,15 +927,33 @@
                    : '')
              + '</span></li>';
       }).join('');
-      this.renderShell(pluginName, panel, '<ul class="plugin-rows">' + items + '</ul>');
+      return '<ul class="plugin-rows">' + items + '</ul>';
+    }
 
+    /// Attach the row-click handler to whichever `.plugin-rows` is on
+    /// screen now. Re-attached after each paint because filtering
+    /// replaces the list element.
+    wireRows(pluginName, panel, rowAction) {
+      const name = pluginName || this.openPluginName;
+      const action = new window.Baguette._PluginRowAction(rowAction);
+      const control = this.controlFor(panel);
       const list = this.host.querySelector('.plugin-rows');
-      if (!list || !rowAction) return;
+      // A control-only panel declares no `rowAction` and still needs its
+      // clicks — bailing on `!rowAction` alone would leave every tick
+      // inert on exactly the panels this feature exists for.
+      if (!list || (!rowAction && !control.present)) return;
       list.addEventListener('click', (event) => {
         const li = event.target.closest('.plugin-row');
         if (!li) return;
-        const row = rows[Number(li.dataset.index)];
+        const row = this.rows[Number(li.dataset.index)];
         if (!row) return;
+        // A tickable row ticks. It costs no subprocess — the panel
+        // accumulates and sends them together when Apply is pressed.
+        if (control.isControlRow(row)) {
+          this.ticks = control.toggle(this.ticks, row, this.rows);
+          this.paintRows(panel, rowAction);
+          return;
+        }
         const intent = action.intent(row);
         if (!intent) return;   // an inert row stays inert, selection included
         for (const other of list.querySelectorAll('.plugin-row')) {
@@ -508,12 +962,13 @@
         if (intent.kind === 'highlight') this.onHighlight(intent.frame);
         if (intent.kind === 'tap') this.onTap(intent.point);
         if (intent.kind === 'copy') this.copyToClipboard(intent.text, li);
+        if (intent.kind === 'fill') this.fillPrompt(panel, intent.text, rowAction);
         if (intent.kind === 'run') {
           // The row names a command within its own plugin; the plugin
           // id comes from the panel's own source, so a row can never
           // reach into a different plugin.
           const pluginID = String((panel.body || {}).source || '').split(':')[0];
-          this.invoke(pluginName, panel, pluginID, intent.command, intent.args);
+          this.invoke(name, panel, pluginID, intent.command, intent.args);
         }
       });
     }

--- a/Sources/Baguette/Resources/Web/sim.html
+++ b/Sources/Baguette/Resources/Web/sim.html
@@ -65,8 +65,12 @@
 <!-- Plugin contributions. Renders manifest-declared toolbar buttons +
      panels from /plugins.json. Host-rendered only: no plugin script,
      CSS or markup is ever loaded into this page. `plugin-row-action.js`
-     carries the click semantics and must load first. -->
+     carries the click semantics, `plugin-prompt.js` the text-field
+     semantics and `plugin-control.js` the tick semantics; all three must
+     load first. -->
 <script src="/plugin-row-action.js"></script>
+<script src="/plugin-prompt.js"></script>
+<script src="/plugin-control.js"></script>
 <script src="/sim-plugins.js"></script>
 <!-- Companion screens — the CarPlay display and the paired Apple Watch,
      offered from their own rail. `screens/companion-screens.js` is the

--- a/Tests/BaguetteTests/App/Commands/CommandParsingTests.swift
+++ b/Tests/BaguetteTests/App/Commands/CommandParsingTests.swift
@@ -31,6 +31,10 @@ struct CommandParsingTests {
     @Test func `openurl parses the url argument`() throws {
         let cmd = try OpenURLCommand.parse(["--udid", "U", "myapp://profile/42"])
         #expect(cmd.url == "myapp://profile/42")
+        // The udid too, or this passes unchanged if `DeviceOption` ever
+        // stops binding for this command — which is the wiring the test
+        // exists to pin.
+        #expect(cmd.options.udid == "U")
         #expect(OpenURLCommand.configuration.commandName == "openurl")
     }
 

--- a/Tests/BaguetteTests/App/Commands/CommandParsingTests.swift
+++ b/Tests/BaguetteTests/App/Commands/CommandParsingTests.swift
@@ -21,8 +21,27 @@ struct CommandParsingTests {
             "key", "type", "paste", "clipboard",
             "chrome", "screenshot", "render-3d", "describe-ui", "logs", "serve",
             "orientation", "shake", "status-bar", "location", "install", "add-media",
+            "openurl", "schemes",
             "plugin", "bakery", "diag-digitizer-trackpad", "lifetime", "interface",
         ])
+    }
+
+    // MARK: - openurl / schemes
+
+    @Test func `openurl parses the url argument`() throws {
+        let cmd = try OpenURLCommand.parse(["--udid", "U", "myapp://profile/42"])
+        #expect(cmd.url == "myapp://profile/42")
+        #expect(OpenURLCommand.configuration.commandName == "openurl")
+    }
+
+    @Test func `openurl requires a url`() {
+        #expect(throws: (any Error).self) { try OpenURLCommand.parse(["--udid", "U"]) }
+    }
+
+    @Test func `schemes parses --udid`() throws {
+        let cmd = try SchemesCommand.parse(["--udid", "U"])
+        #expect(cmd.options.udid == "U")
+        #expect(SchemesCommand.configuration.commandName == "schemes")
     }
 
     @Test func `bakery exposes the whole source lifecycle`() {

--- a/Tests/BaguetteTests/Apps/DeepLinkTests.swift
+++ b/Tests/BaguetteTests/Apps/DeepLinkTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// Pure-value coverage for `DeepLink` — what a developer means when they
+/// type a URL into the console and expect it to land in their app.
+///
+/// The load-bearing behaviour is the routing verdict. A custom scheme
+/// (`myapp://…`) reaches the app that registered it, but an `https://…`
+/// universal link is handed to Safari by the simulator rather than the
+/// app — long-standing simulator behaviour that every existing tool
+/// (`simctl openurl`, `idb open`, Maestro's `openLink`) performs
+/// silently. Modelling the verdict as a value lets the console warn
+/// *before* dispatch instead of leaving the developer to wonder why
+/// Safari opened.
+@Suite("DeepLink")
+struct DeepLinkTests {
+
+    @Test func `a custom scheme link routes to the app that registered it`() {
+        let link = DeepLink.from("myapp://profile/42")
+        #expect(link?.scheme == "myapp")
+        #expect(link?.routing == .app)
+    }
+
+    @Test func `an https link routes to the browser, not the app`() {
+        let link = DeepLink.from("https://example.com/profile/42")
+        #expect(link?.scheme == "https")
+        #expect(link?.routing == .browser)
+    }
+
+    @Test func `an http link routes to the browser too`() {
+        #expect(DeepLink.from("http://example.com")?.routing == .browser)
+    }
+
+    @Test func `a scheme is normalised to lower case`() {
+        let link = DeepLink.from("MyApp://Profile")
+        #expect(link?.scheme == "myapp")
+        #expect(link?.routing == .app)
+    }
+
+    @Test func `a pasted link is trimmed before parsing`() {
+        #expect(DeepLink.from("  myapp://profile\n")?.scheme == "myapp")
+    }
+
+    @Test func `a bare word is not a deep link`() {
+        #expect(DeepLink.from("profile") == nil)
+    }
+
+    @Test func `empty input is not a deep link`() {
+        #expect(DeepLink.from("   ") == nil)
+    }
+
+    @Test func `openArguments projects the simctl openurl argv tail`() {
+        let link = DeepLink.from("myapp://profile/42")
+        #expect(link?.openArguments(udid: "U") == ["simctl", "openurl", "U", "myapp://profile/42"])
+    }
+}

--- a/Tests/BaguetteTests/Apps/InstalledAppTests.swift
+++ b/Tests/BaguetteTests/Apps/InstalledAppTests.swift
@@ -148,6 +148,28 @@ struct InstalledAppTests {
         #expect(InstalledApp.schemes(inInfoPlist: Data("nonsense".utf8)) == [])
     }
 
+    // MARK: - the invariant holds however the value is built
+
+    @Test func `schemes are normalised by the initialiser, not just by the parser`() {
+        // The type documents lower-cased, de-duplicated schemes, and
+        // `SchemeSuggestion.matching` relies on it — it lower-cases the
+        // needle and then compares against the stored scheme, so an
+        // upper-cased one silently never matches. Only the plist parser
+        // enforced it, which left every other way of building one free
+        // to break it.
+        let app = InstalledApp(
+            bundleIdentifier: "com.example.MyApp",
+            name: "My App",
+            schemes: ["MyApp", "myapp", "COM.Example.MyApp"]
+        )
+        #expect(app.schemes == ["myapp", "com.example.myapp"])
+    }
+
+    @Test func `an upper-cased scheme is still matchable once normalised`() {
+        let apps = [InstalledApp(bundleIdentifier: "a", name: "A", schemes: ["MyApp"])]
+        #expect(SchemeSuggestion.matching("myapp", in: apps).map(\.scheme) == ["myapp"])
+    }
+
     @Test func `an app takes on the schemes read from its bundle`() {
         let app = Self.app("com.example.MyApp")?.withSchemes(["myapp"])
         #expect(app?.schemes == ["myapp"])

--- a/Tests/BaguetteTests/Apps/InstalledAppTests.swift
+++ b/Tests/BaguetteTests/Apps/InstalledAppTests.swift
@@ -1,0 +1,156 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// Pure-value coverage for `InstalledApp` — "the apps on this device,
+/// and the URL schemes each one answers to." This is the data source
+/// behind console completion: typing `myap` can only suggest
+/// `myapp://` once something has read the device's schemes.
+///
+/// Reading them takes **two** steps, which is the load-bearing fact
+/// here. `xcrun simctl listapps <udid>` emits an old-style property list
+/// keyed by bundle identifier, but it carries only a curated subset of
+/// each app's metadata — verified against Xcode 26: `ApplicationType`,
+/// `Bundle`, `BundleContainer`, `CFBundleDisplayName`,
+/// `CFBundleExecutable`, `CFBundleIdentifier`, `CFBundleName`,
+/// `CFBundleShortVersionString`, `CFBundleVersion`, `DataContainer`,
+/// `GroupContainers`, `IsAppClip`, `IsDeveloperApp`, `IsFirstParty`,
+/// `IsHidden`, `IsRemovable`, `Path`, `SBAppTags`. **`CFBundleURLTypes`
+/// is not among them**, so schemes cannot come from `listapps` alone.
+///
+/// What `listapps` does give is `Path` — the app's real on-disk bundle.
+/// So schemes come from `<Path>/Info.plist`, and we never have to guess
+/// CoreSimulator's container layout or its per-install UUIDs. The two
+/// parses are separate pure functions; `SimctlApps` composes them.
+@Suite("InstalledApp")
+struct InstalledAppTests {
+
+    /// Shape of real `simctl listapps` output, trimmed to the keys we
+    /// read. Deliberately carries no `CFBundleURLTypes`, because the
+    /// real command doesn't.
+    private static let listAppsOutput = """
+    {
+        "com.example.MyApp" =     {
+            ApplicationType = User;
+            Bundle = "file:///tmp/Apps/MyApp.app/";
+            CFBundleDisplayName = "My App";
+            CFBundleIdentifier = "com.example.MyApp";
+            CFBundleName = MyApp;
+            Path = "/tmp/Apps/MyApp.app";
+        };
+        "com.example.Pathless" =     {
+            ApplicationType = User;
+            CFBundleIdentifier = "com.example.Pathless";
+            CFBundleName = Pathless;
+        };
+    }
+    """
+
+    private static func parse() -> [InstalledApp] {
+        InstalledApp.all(fromListApps: Data(listAppsOutput.utf8))
+    }
+
+    private static func app(_ identifier: String) -> InstalledApp? {
+        parse().first { $0.bundleIdentifier == identifier }
+    }
+
+    // MARK: - the listapps inventory
+
+    @Test func `reads every installed app, ordered by bundle identifier`() {
+        #expect(Self.parse().map(\.bundleIdentifier) == ["com.example.MyApp", "com.example.Pathless"])
+    }
+
+    @Test func `an app carries its on-disk bundle path`() {
+        #expect(Self.app("com.example.MyApp")?.bundlePath == URL(fileURLWithPath: "/tmp/Apps/MyApp.app"))
+    }
+
+    @Test func `an app listapps gives no path for has none`() {
+        #expect(Self.app("com.example.Pathless")?.bundlePath == nil)
+    }
+
+    @Test func `listapps alone yields no schemes`() {
+        // Not an edge case — simctl listapps never reports
+        // CFBundleURLTypes, so this is the normal result of step one.
+        #expect(Self.parse().allSatisfy { $0.schemes.isEmpty })
+    }
+
+    @Test func `an app is named by its display name`() {
+        #expect(Self.app("com.example.MyApp")?.name == "My App")
+    }
+
+    @Test func `an app with no display name falls back to its bundle name`() {
+        #expect(Self.app("com.example.Pathless")?.name == "Pathless")
+    }
+
+    @Test func `unparseable output yields no apps`() {
+        #expect(InstalledApp.all(fromListApps: Data("not a plist".utf8)) == [])
+    }
+
+    @Test func `empty output yields no apps`() {
+        #expect(InstalledApp.all(fromListApps: Data()) == [])
+    }
+
+    // MARK: - schemes, read from the bundle's Info.plist
+
+    /// Two URL-type entries on one app is the common case, not an edge
+    /// case: tooling such as Expo appends its own `exp+…` dev-client
+    /// scheme as a second entry alongside the app's own.
+    private static func infoPlist(_ body: String) -> Data {
+        Data("""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>\(body)</dict></plist>
+        """.utf8)
+    }
+
+    private static let urlTypes = infoPlist("""
+        <key>CFBundleURLTypes</key>
+        <array>
+          <dict><key>CFBundleURLSchemes</key>
+            <array><string>myapp</string><string>com.example.myapp</string></array>
+          </dict>
+          <dict><key>CFBundleURLSchemes</key>
+            <array><string>exp+myapp</string></array>
+          </dict>
+        </array>
+        """)
+
+    @Test func `schemes are read across every URL type entry`() {
+        #expect(InstalledApp.schemes(inInfoPlist: Self.urlTypes)
+                == ["myapp", "com.example.myapp", "exp+myapp"])
+    }
+
+    @Test func `schemes are normalised to lower case for matching`() {
+        let plist = Self.infoPlist("""
+            <key>CFBundleURLTypes</key>
+            <array><dict><key>CFBundleURLSchemes</key>
+              <array><string>MyApp</string></array></dict></array>
+            """)
+        #expect(InstalledApp.schemes(inInfoPlist: plist) == ["myapp"])
+    }
+
+    @Test func `a repeated scheme is only listed once`() {
+        let plist = Self.infoPlist("""
+            <key>CFBundleURLTypes</key>
+            <array>
+              <dict><key>CFBundleURLSchemes</key><array><string>myapp</string></array></dict>
+              <dict><key>CFBundleURLSchemes</key><array><string>MYAPP</string></array></dict>
+            </array>
+            """)
+        #expect(InstalledApp.schemes(inInfoPlist: plist) == ["myapp"])
+    }
+
+    @Test func `an app registering no URL types has no schemes`() {
+        #expect(InstalledApp.schemes(inInfoPlist: Self.infoPlist("<key>CFBundleName</key><string>X</string>")) == [])
+    }
+
+    @Test func `an unreadable Info.plist yields no schemes`() {
+        #expect(InstalledApp.schemes(inInfoPlist: Data("nonsense".utf8)) == [])
+    }
+
+    @Test func `an app takes on the schemes read from its bundle`() {
+        let app = Self.app("com.example.MyApp")?.withSchemes(["myapp"])
+        #expect(app?.schemes == ["myapp"])
+        #expect(app?.bundleIdentifier == "com.example.MyApp")
+    }
+}

--- a/Tests/BaguetteTests/Apps/SchemeSuggestionTests.swift
+++ b/Tests/BaguetteTests/Apps/SchemeSuggestionTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// Pure-value coverage for `SchemeSuggestion` — the completion behind
+/// the console's URL bar: type a few characters, get the schemes that
+/// installed apps actually answer to.
+///
+/// Ranking carries the weight here. Apps routinely register three or
+/// more schemes for one app — a readable one, a reverse-DNS one, and a
+/// tool-injected dev-client one — and only the readable scheme is what a
+/// developer means to type. Listing them unranked would bury the useful
+/// suggestion under noise, so the ordering is a specified behaviour, not
+/// an accident of dictionary iteration.
+@Suite("SchemeSuggestion")
+struct SchemeSuggestionTests {
+
+    private static let apps = [
+        InstalledApp(
+            bundleIdentifier: "com.example.MyApp",
+            name: "My App",
+            schemes: ["com.example.myapp", "exp+myapp", "myapp"]
+        ),
+        InstalledApp(
+            bundleIdentifier: "com.example.Other",
+            name: "Other",
+            schemes: ["othertool"]
+        ),
+        InstalledApp(
+            bundleIdentifier: "com.example.Bare",
+            name: "Bare",
+            schemes: []
+        ),
+    ]
+
+    private static func schemes(for prefix: String) -> [String] {
+        SchemeSuggestion.matching(prefix, in: apps).map(\.scheme)
+    }
+
+    @Test func `a prefix suggests every scheme containing it, its own first`() {
+        // All three of MyApp's schemes contain "myap"; the readable one
+        // is what the developer meant, so it leads and the aliases
+        // follow rather than being hidden.
+        #expect(Self.schemes(for: "myap") == ["myapp", "com.example.myapp", "exp+myapp"])
+    }
+
+    @Test func `a readable scheme outranks its reverse-DNS twin`() {
+        // Both match "com.example.myapp"'s app, but "myapp" is the one a
+        // developer means to type.
+        let ranked = Self.schemes(for: "")
+        #expect(ranked.firstIndex(of: "myapp")! < ranked.firstIndex(of: "com.example.myapp")!)
+    }
+
+    @Test func `a tool-injected scheme is ranked below the app's own`() {
+        let ranked = Self.schemes(for: "")
+        #expect(ranked.firstIndex(of: "myapp")! < ranked.firstIndex(of: "exp+myapp")!)
+    }
+
+    @Test func `a prefix match outranks a mid-string match`() {
+        // "other" prefixes "othertool"; it only appears mid-string in
+        // nothing else here, so add the contrast directly.
+        let apps = [
+            InstalledApp(bundleIdentifier: "a", name: "A", schemes: ["superapp"]),
+            InstalledApp(bundleIdentifier: "b", name: "B", schemes: ["app"]),
+        ]
+        #expect(SchemeSuggestion.matching("app", in: apps).map(\.scheme) == ["app", "superapp"])
+    }
+
+    @Test func `matching ignores case`() {
+        #expect(Self.schemes(for: "MYAPP") == ["myapp", "com.example.myapp", "exp+myapp"])
+    }
+
+    @Test func `an empty prefix suggests every scheme`() {
+        #expect(Self.schemes(for: "").count == 4)
+    }
+
+    @Test func `a prefix matching nothing suggests nothing`() {
+        #expect(Self.schemes(for: "zzz") == [])
+    }
+
+    @Test func `a suggestion carries the app it belongs to`() {
+        let suggestion = SchemeSuggestion.matching("myap", in: Self.apps).first
+        #expect(suggestion?.appName == "My App")
+        #expect(suggestion?.bundleIdentifier == "com.example.MyApp")
+    }
+
+    @Test func `a suggestion completes to a typeable URL prefix`() {
+        #expect(SchemeSuggestion.matching("myap", in: Self.apps).first?.completion == "myapp://")
+    }
+}

--- a/Tests/BaguetteTests/Apps/SimctlAppsTests.swift
+++ b/Tests/BaguetteTests/Apps/SimctlAppsTests.swift
@@ -334,4 +334,54 @@ struct SimctlAppsTests {
         }
         #expect(caught == .listFailed(status: 2))
     }
+
+    // MARK: - what a failure tells the user
+
+    @Test func `every app failure names the command that produced it`() {
+        // These strings are the whole of what a user sees when simctl
+        // refuses: the CLI prints them and the upload route puts them in
+        // its 4xx body. Naming the verb is what turns "it failed" into
+        // something you can re-run by hand to see the real error.
+        #expect(AppsError.installFailed(status: 1).description
+                == "xcrun simctl install exited 1")
+        #expect(AppsError.openFailed(status: 4).description
+                == "xcrun simctl openurl exited 4")
+        #expect(AppsError.listFailed(status: 2).description
+                == "xcrun simctl listapps exited 2")
+        #expect(AppsError.extractFailed(status: 5).description
+                == "ditto -x -k exited 5 (corrupt zip?)")
+        #expect(AppsError.noAppInArchive.description
+                == "no single .app bundle at the top level of the zip")
+        #expect(AppsError.archiveTooLarge(bytes: 9, limit: 4).description
+                == "archive inflates to 9 bytes, over the 4-byte cap (zip bomb?)")
+    }
+
+    // MARK: - the child that never starts
+
+    struct SpawnRefused: Error, Equatable {}
+
+    /// A `Subprocess` that refuses to launch — a missing binary, or a
+    /// path we aren't allowed to execute.
+    private func refusingToSpawn() -> SimctlApps {
+        let sub = MockSubprocess()
+        given(sub).run(
+            executable: .any, arguments: .any, onBytes: .any, onExit: .any
+        ).willThrow(SpawnRefused())
+        given(sub).terminate().willReturn()
+        return SimctlApps(udid: "U", subprocess: sub)
+    }
+
+    @Test func `a child that never starts surfaces instead of hanging`() async {
+        // Every verb here waits on a continuation the child's exit
+        // callback resumes. A spawn that throws means that callback never
+        // fires, so the error has to be resumed by hand — miss it and the
+        // caller waits forever on a process that was never there, which
+        // is worse than any failure it could report.
+        var caught: [Error] = []
+        do { try await refusingToSpawn().open(DeepLink.from("myapp://x")!) } catch { caught.append(error) }
+        do { _ = try await refusingToSpawn().installed() } catch { caught.append(error) }
+
+        #expect(caught.count == 2)
+        #expect(caught.allSatisfy { $0 is SpawnRefused })
+    }
 }

--- a/Tests/BaguetteTests/Apps/SimctlAppsTests.swift
+++ b/Tests/BaguetteTests/Apps/SimctlAppsTests.swift
@@ -200,4 +200,138 @@ struct SimctlAppsTests {
         }
         #expect(caught == .installFailed(status: 5))
     }
+
+    // MARK: deep links — openurl + the scheme inventory behind completion
+
+    /// Stub that plays a child which writes `output` to stdout and then
+    /// exits — the shape of `simctl listapps`, which answers on stdout
+    /// rather than through its exit code alone.
+    private func makeListingApps(
+        output: String, exitCode: Int32 = 0
+    ) -> (SimctlApps, Captures) {
+        let sub = MockSubprocess()
+        let captures = Captures()
+        given(sub).run(
+            executable: .any, arguments: .any, onBytes: .any, onExit: .any
+        ).willProduce { exe, args, onBytes, onExit in
+            captures.ran = true
+            captures.executable = exe
+            captures.arguments = args
+            onBytes(Data(output.utf8))
+            onExit(exitCode)
+        }
+        given(sub).terminate().willReturn()
+        return (SimctlApps(udid: "U", subprocess: sub), captures)
+    }
+
+    @Test func `opening a deep link spawns xcrun simctl openurl`() async throws {
+        let (apps, captures) = makeApps()
+        try await apps.open(DeepLink.from("myapp://profile/42")!)
+
+        #expect(captures.executable == URL(fileURLWithPath: "/usr/bin/xcrun"))
+        #expect(captures.arguments == ["simctl", "openurl", "U", "myapp://profile/42"])
+    }
+
+    @Test func `a non-zero simctl exit propagates as an open failure`() async {
+        let (apps, _) = makeApps(exitCode: 4)
+        var caught: AppsError?
+        do {
+            try await apps.open(DeepLink.from("myapp://profile")!)
+        } catch {
+            caught = error as? AppsError
+        }
+        #expect(caught == .openFailed(status: 4))
+    }
+
+    @Test func `the installed inventory spawns xcrun simctl listapps`() async throws {
+        let (apps, captures) = makeListingApps(output: "{ }")
+        _ = try await apps.installed()
+
+        #expect(captures.arguments == ["simctl", "listapps", "U"])
+    }
+
+    /// Materialise a throwaway `.app` carrying an `Info.plist` — the
+    /// second half of the inventory read. `listapps` reports the path;
+    /// the schemes come from the bundle it points at.
+    private func makeBundle(schemes: [String]) throws -> (URL, () -> Void) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("baguette-apps-\(UUID().uuidString)")
+        let bundle = dir.appendingPathComponent("MyApp.app")
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+        let entries = schemes.map { "<string>\($0)</string>" }.joined()
+        try Data("""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>
+          <key>CFBundleURLTypes</key>
+          <array><dict><key>CFBundleURLSchemes</key><array>\(entries)</array></dict></array>
+        </dict></plist>
+        """.utf8).write(to: bundle.appendingPathComponent("Info.plist"))
+        return (bundle, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    @Test func `the installed inventory reads schemes from each app's bundle`() async throws {
+        // simctl listapps reports no CFBundleURLTypes, so the schemes
+        // have to come from the Info.plist at the path it reports.
+        let (bundle, cleanup) = try makeBundle(schemes: ["myapp"])
+        defer { cleanup() }
+
+        let (apps, _) = makeListingApps(output: """
+        {
+            "com.example.MyApp" = {
+                CFBundleIdentifier = "com.example.MyApp";
+                CFBundleName = MyApp;
+                Path = "\(bundle.path)";
+            };
+        }
+        """)
+        let inventory = try await apps.installed()
+
+        #expect(inventory.map(\.bundleIdentifier) == ["com.example.MyApp"])
+        #expect(inventory.first?.schemes == ["myapp"])
+    }
+
+    @Test func `an app whose bundle has vanished still lists, with no schemes`() async throws {
+        let (apps, _) = makeListingApps(output: """
+        {
+            "com.example.Gone" = {
+                CFBundleIdentifier = "com.example.Gone";
+                CFBundleName = Gone;
+                Path = "/nowhere/Gone.app";
+            };
+        }
+        """)
+        let inventory = try await apps.installed()
+
+        #expect(inventory.map(\.bundleIdentifier) == ["com.example.Gone"])
+        #expect(inventory.first?.schemes == [])
+    }
+
+    @Test func `stdout arriving in several chunks still parses`() async throws {
+        // A child's output lands in arbitrary chunks; the adapter has to
+        // accumulate before parsing rather than parse each chunk.
+        let sub = MockSubprocess()
+        given(sub).run(
+            executable: .any, arguments: .any, onBytes: .any, onExit: .any
+        ).willProduce { _, _, onBytes, onExit in
+            onBytes(Data(#"{ "com.example.MyApp" = { CFBundleN"#.utf8))
+            onBytes(Data(#"ame = MyApp; }; }"#.utf8))
+            onExit(0)
+        }
+        given(sub).terminate().willReturn()
+
+        let inventory = try await SimctlApps(udid: "U", subprocess: sub).installed()
+        #expect(inventory.map(\.bundleIdentifier) == ["com.example.MyApp"])
+    }
+
+    @Test func `a non-zero simctl exit propagates as a listing failure`() async {
+        let (apps, _) = makeListingApps(output: "", exitCode: 2)
+        var caught: AppsError?
+        do {
+            _ = try await apps.installed()
+        } catch {
+            caught = error as? AppsError
+        }
+        #expect(caught == .listFailed(status: 2))
+    }
 }

--- a/Tests/BaguetteTests/Plugin/DeepLinkPluginTests.swift
+++ b/Tests/BaguetteTests/Plugin/DeepLinkPluginTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// The deep-link plugin baguette publishes, parsed exactly as an
+/// installed copy would be.
+///
+/// It ships in this repo's own bakery (`baguette.json` → `plugins/`)
+/// rather than in `Sources/Baguette/Resources/Plugins/`, which is what
+/// makes the a11y audit arrive bundled. That's deliberate: it's an
+/// official plugin you still choose to install. The cost of that choice
+/// is that nothing in the build would notice a manifest that stopped
+/// parsing — `serve` skips a bad manifest with a log line, so a broken
+/// official plugin would present as a rail entry that silently never
+/// appears. These tests are what notices.
+@Suite("DeepLink plugin")
+struct DeepLinkPluginTests {
+
+    /// The repo root, walked up from this file rather than from the
+    /// process's working directory — `swift test` doesn't promise one.
+    private static var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)          // …/Tests/BaguetteTests/Plugin/<this>.swift
+            .deletingLastPathComponent()          // …/Plugin
+            .deletingLastPathComponent()          // …/BaguetteTests
+            .deletingLastPathComponent()          // …/Tests
+            .deletingLastPathComponent()          // repo root
+    }
+
+    private static let pluginDirectory = repoRoot.appendingPathComponent("plugins/deeplink")
+
+    private func manifest() throws -> PluginManifest {
+        try PluginManifest.parsing(json: try Data(
+            contentsOf: Self.pluginDirectory
+                .appendingPathComponent(FileSystemPlugins.manifestFilename)
+        ))
+    }
+
+    @Test func `the published manifest parses, with nothing to warn about`() throws {
+        let manifest = try manifest()
+        #expect(manifest.name == "deeplink")
+        #expect(manifest.apiVersion == 1)
+        #expect(manifest.icon == .link)
+        // A warning here means a mistyped icon silently degrading to the
+        // puzzle piece — fine for a stranger's plugin, not for ours.
+        #expect(manifest.warnings.isEmpty)
+    }
+
+    @Test func `it asks for the power to open links and nothing more`() throws {
+        // The pre-install trust screen (`baguette plugin show`) prints
+        // this list. It must not creep: `apps` next door installs
+        // software, and `input` can tap through any consent dialog.
+        #expect(try manifest().capabilities == [.openURL])
+    }
+
+    @Test func `its panel offers a field to type a link into`() throws {
+        let panel = try #require(try manifest().panels.first)
+        #expect(panel.when == .simulatorBooted)
+        guard case .list(let list) = panel.body else {
+            Issue.record("expected a list body"); return
+        }
+        #expect(list.source == "open")
+        // The rows are a completion source, not a launcher. Clicking
+        // `account://` fills the field so you can type the path —
+        // opening a bare scheme with no path is almost never what
+        // anyone means, and it used to be all a click could do.
+        #expect(list.rowAction == .fill)
+        #expect(list.prompt?.arg == "url")
+        #expect(list.prompt?.filter == true)
+    }
+
+    @Test func `the command it runs is a file that is actually there`() throws {
+        // A manifest naming a script that didn't ship parses perfectly
+        // and then fails on first click, which is the worst time to find
+        // out. The interpreter is absolute; the script is relative to
+        // the plugin directory, which is the command's cwd.
+        let command = try #require(try manifest().commands.first)
+        #expect(command.id == "open")
+        let script = try #require(command.run.last)
+        #expect(
+            FileManager.default.fileExists(
+                atPath: Self.pluginDirectory.appendingPathComponent(script).path
+            ),
+            "\(script) is named by the manifest but not present in plugins/deeplink"
+        )
+    }
+
+    @Test func `the repo's bakery menu offers it`() throws {
+        // `baguette plugin install tddworks/baguette/deeplink` resolves
+        // through this file. A plugin the menu doesn't name is
+        // unreachable however good its manifest is.
+        let menu = try BakeryMenu.parsing(json: try Data(
+            contentsOf: Self.repoRoot.appendingPathComponent("baguette.json")
+        ))
+        let entry = try #require(menu.entry(named: "deeplink"))
+        #expect(entry.path == "plugins/deeplink")
+    }
+
+    @Test func `it is not one of the plugins baguette ships bundled`() throws {
+        // The whole point: official, and still installed on purpose. If
+        // this directory ever appears, the plugin starts arriving with
+        // every build and the distinction is gone.
+        let bundled = Self.repoRoot
+            .appendingPathComponent(PluginRoot.sourceTreePath)
+            .appendingPathComponent("deeplink")
+        #expect(!FileManager.default.fileExists(atPath: bundled.path))
+    }
+}

--- a/Tests/BaguetteTests/Plugin/PanelControlTests.swift
+++ b/Tests/BaguetteTests/Plugin/PanelControlTests.swift
@@ -1,0 +1,168 @@
+import Testing
+import Foundation
+import Mockable
+@testable import Baguette
+
+/// Tickable rows — switches, checkboxes and radios.
+///
+/// The behaviour this replaces is `display.py` writing `"● Light"` /
+/// `"○ Dark"` into row *titles*: a plugin drawing a control glyph inside
+/// a string, in a page whose premise is that the host owns every pixel.
+/// It was safe (everything is escaped) but not right — the host couldn't
+/// style it, a screen reader read a bullet, and "which one is on" was
+/// legible only to a human eye.
+///
+/// So the row says what's *on* and the manifest says what *on looks
+/// like*. Ticking is local and batched: the panel accumulates ticks and
+/// submits them together, which buys one subprocess per batch instead of
+/// one per tick, at the cost of rows briefly showing unconfirmed state.
+@Suite("PanelControl")
+struct PanelControlTests {
+
+    private func body(_ json: String, commands: Set<String> = ["flags"]) throws -> ListBody {
+        try ListBody.parsing(
+            dict: JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any] ?? [:],
+            declaredCommands: commands
+        )
+    }
+
+    private func row(_ json: String) throws -> ResultRow {
+        try ResultRow.parsing(
+            dict: JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any] ?? [:],
+            index: 0
+        )
+    }
+
+    // MARK: - the manifest side
+
+    @Test func `a panel can declare tickable rows`() throws {
+        let parsed = try body("""
+        {"kind":"list","source":"flags",
+         "control":{"kind":"checkbox","arg":"enabled","submit":"Apply"}}
+        """)
+        #expect(parsed.control == PanelControl(kind: .checkbox, arg: "enabled", submit: "Apply"))
+    }
+
+    @Test func `all three control families are offered`() throws {
+        for kind in ["switch", "checkbox", "radio"] {
+            let parsed = try body(#"{"kind":"list","source":"flags","control":{"kind":"\#(kind)","arg":"e"}}"#)
+            #expect(parsed.control?.kind.rawValue == kind)
+        }
+    }
+
+    @Test func `a control that names no button label gets a plain one`() throws {
+        #expect(try body(#"{"kind":"list","source":"flags","control":{"kind":"switch","arg":"e"}}"#)
+            .control?.submit == "Apply")
+    }
+
+    @Test func `an unknown control family is refused rather than drawn as the nearest one`() throws {
+        // Unlike an icon, this doesn't degrade. A checkbox silently drawn
+        // as a switch would misrepresent whether ticking two at once is
+        // allowed — a lie about behaviour, not a substituted picture.
+        #expect(throws: PluginManifestError.unknownRowControl(name: "dial")) {
+            _ = try body(#"{"kind":"list","source":"flags","control":{"kind":"dial","arg":"e"}}"#)
+        }
+    }
+
+    @Test func `a control with no arg is refused, because ticks could not be submitted`() throws {
+        #expect(throws: PluginManifestError.missingControlArg) {
+            _ = try body(#"{"kind":"list","source":"flags","control":{"kind":"switch"}}"#)
+        }
+        #expect(throws: PluginManifestError.missingControlArg) {
+            _ = try body(#"{"kind":"list","source":"flags","control":{"kind":"switch","arg":""}}"#)
+        }
+    }
+
+    @Test func `a panel without a control is a plain list, exactly as before`() throws {
+        #expect(try body(#"{"kind":"list","source":"flags"}"#).control == nil)
+    }
+
+    // MARK: - the row side
+
+    @Test func `a row reports whether it is on`() throws {
+        #expect(try row(#"{"title":"Dark Mode","value":"dark","state":"on"}"#).state == .on)
+        #expect(try row(#"{"title":"Bold Text","value":"bold","state":"off"}"#).state == .off)
+    }
+
+    @Test func `a row carries the value its tick submits`() throws {
+        #expect(try row(#"{"title":"Camera","value":"camera","state":"on"}"#).value == "camera")
+    }
+
+    @Test func `a row names the group its radio is exclusive within`() throws {
+        // A settings panel is several independent questions at once —
+        // display.py has appearance, contrast and text size. Without
+        // groups a radio panel could only ever ask one, because picking
+        // "Dark" would unpick the text size.
+        let row = try row(#"{"title":"Dark","value":"appearance:dark","state":"off","group":"appearance"}"#)
+        #expect(row.group == "appearance")
+    }
+
+    @Test func `rows naming no group share one, which is the single-question panel`() throws {
+        #expect(try row(#"{"title":"Camera","value":"camera","state":"on"}"#).group == nil)
+    }
+
+    @Test func `a row with no state is not a control, so headers still work`() throws {
+        // `display.py` opens each group with a title-only row. Those must
+        // keep rendering as plain rows inside a control panel, not turn
+        // into unticked checkboxes.
+        let plain = try row(#"{"title":"Appearance"}"#)
+        #expect(plain.state == nil)
+        #expect(plain.value == nil)
+    }
+
+    @Test func `an unknown state is refused rather than read as off`() throws {
+        // Defaulting to "off" would render a switch that says the feature
+        // is disabled when the plugin never claimed that.
+        #expect(throws: PluginResultError.unknownRowState(name: "maybe", index: 0)) {
+            _ = try row(#"{"title":"X","value":"x","state":"maybe"}"#)
+        }
+    }
+
+    @Test func `a state with no value is refused, because a tick would submit nothing`() throws {
+        #expect(throws: PluginResultError.stateWithoutValue(index: 0)) {
+            _ = try row(#"{"title":"Dark Mode","state":"on"}"#)
+        }
+    }
+
+    // MARK: - what the browser receives
+
+    @Test func `the browser is told how to draw the control and where to post it`() throws {
+        let manifest = try PluginManifest.parsing(json: Data("""
+        {"name":"flags","version":"1.0.0",
+         "contributes":{
+           "commands":[{"id":"flags","title":"Flags","run":["node","x.js"]}],
+           "panels":[{"id":"flags","title":"Flags","icon":"wrench",
+             "body":{"kind":"list","source":"flags",
+                     "control":{"kind":"radio","arg":"appearance","submit":"Set"}}}]}}
+        """.utf8))
+        let plugins = MockPlugins()
+        given(plugins).all().willReturn([
+            Plugin(root: URL(fileURLWithPath: "/tmp/flags"), manifest: manifest)
+        ])
+
+        let root = try #require(
+            JSONSerialization.jsonObject(with: Data(try plugins.listJSON.utf8)) as? [String: Any]
+        )
+        let panels = ((root["plugins"] as? [[String: Any]])?.first?["panels"] as? [[String: Any]]) ?? []
+        let control = (panels.first?["body"] as? [String: Any])?["control"] as? [String: Any]
+
+        #expect(control?["kind"] as? String == "radio")
+        #expect(control?["arg"] as? String == "appearance")
+        #expect(control?["submit"] as? String == "Set")
+    }
+
+    @Test func `a row's state, value and group reach the browser`() throws {
+        let dict = try row("""
+        {"title":"Dark","value":"appearance:dark","state":"on","group":"appearance"}
+        """).dictionary
+        #expect(dict["state"] as? String == "on")
+        #expect(dict["value"] as? String == "appearance:dark")
+        #expect(dict["group"] as? String == "appearance")
+    }
+
+    @Test func `a plain row projects neither, so old panels are byte-identical`() throws {
+        let dict = try row(#"{"title":"Button has no label"}"#).dictionary
+        #expect(dict["state"] == nil)
+        #expect(dict["value"] == nil)
+    }
+}

--- a/Tests/BaguetteTests/Plugin/PanelPromptTests.swift
+++ b/Tests/BaguetteTests/Plugin/PanelPromptTests.swift
@@ -1,0 +1,141 @@
+import Testing
+import Foundation
+import Mockable
+@testable import Baguette
+
+/// A panel that accepts typed input.
+///
+/// Every panel before this one was a *report*: the host ran a command
+/// and drew what came back. A deep-link bar can't work that way — the
+/// interesting value is the one nobody has typed yet — so the list body
+/// gains an optional `prompt`, and submitting it invokes the panel's own
+/// `source` with the typed text as `args`. That's deliberately the same
+/// path `rowAction: "run"` already takes, so no plugin code runs in the
+/// page and there's no second command endpoint.
+///
+/// `prompt` is **additive**: a manifest that omits it parses exactly as
+/// before, and an older baguette reading a manifest that has it ignores
+/// the key and renders the plain list. That's why `apiVersion` stays 1.
+@Suite("PanelPrompt")
+struct PanelPromptTests {
+
+    private func body(_ json: String, commands: Set<String> = ["open"]) throws -> PanelBody {
+        try PanelBody.parsing(
+            dict: JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any] ?? [:],
+            declaredCommands: commands
+        )
+    }
+
+    @Test func `a panel can ask for typed input`() throws {
+        let parsed = try body("""
+        {"kind":"list","source":"open","rowAction":"run",
+         "prompt":{"arg":"url","placeholder":"myapp://path","submit":"Open","filter":true}}
+        """)
+        #expect(parsed == .list(ListBody(
+            source: "open",
+            rowAction: .run,
+            prompt: PanelPrompt(arg: "url", placeholder: "myapp://path", submit: "Open", filter: true)
+        )))
+    }
+
+    @Test func `a prompt that names no button label offers a plain one`() throws {
+        // The label is chrome, not meaning — a manifest shouldn't have
+        // to spell it out to get a usable button.
+        let parsed = try body(#"{"kind":"list","source":"open","prompt":{"arg":"url"}}"#)
+        guard case .list(let list) = parsed else {
+            Issue.record("expected a list body"); return
+        }
+        #expect(list.prompt?.submit == "Run")
+        #expect(list.prompt?.placeholder == nil)
+        #expect(list.prompt?.filter == false)
+    }
+
+    @Test func `a prompt with no arg is refused, because nothing could carry the value`() throws {
+        // The arg names the key the typed text arrives under. Without it
+        // the field would render and submit into nowhere, which is worse
+        // than refusing the manifest — so this is an error at
+        // `plugin validate` time, like an undeclared command source.
+        #expect(throws: PluginManifestError.missingPromptArg) {
+            _ = try body(#"{"kind":"list","source":"open","prompt":{"placeholder":"x"}}"#)
+        }
+        #expect(throws: PluginManifestError.missingPromptArg) {
+            _ = try body(#"{"kind":"list","source":"open","prompt":{"arg":""}}"#)
+        }
+    }
+
+    @Test func `a prompt can complete inline and remember what was submitted`() throws {
+        // The two affordances that make a field feel like a URL bar
+        // rather than a text box: it finishes the word, and it recalls
+        // what you opened last time. Separate flags, because a settings
+        // field wants neither and a search field may want only the first.
+        let parsed = try body("""
+        {"kind":"list","source":"open",
+         "prompt":{"arg":"url","complete":true,"history":true}}
+        """)
+        guard case .list(let list) = parsed else {
+            Issue.record("expected a list body"); return
+        }
+        #expect(list.prompt?.complete == true)
+        #expect(list.prompt?.history == true)
+    }
+
+    @Test func `a prompt neither completes nor remembers unless it says so`() throws {
+        let parsed = try body(#"{"kind":"list","source":"open","prompt":{"arg":"url"}}"#)
+        guard case .list(let list) = parsed else {
+            Issue.record("expected a list body"); return
+        }
+        #expect(list.prompt?.complete == false)
+        #expect(list.prompt?.history == false)
+    }
+
+    @Test func `a panel without a prompt is unchanged`() throws {
+        let parsed = try body(#"{"kind":"list","source":"open","rowAction":"highlight"}"#)
+        #expect(parsed == .list(ListBody(source: "open", rowAction: .highlight)))
+    }
+
+    @Test func `the browser is told what to draw and which key to submit under`() throws {
+        // The page renders the field from this, and posts the typed text
+        // as `args[arg]` — so all four have to survive the projection.
+        let manifest = try PluginManifest.parsing(json: Data("""
+        {"name":"deeplink","version":"1.0.0",
+         "contributes":{
+           "commands":[{"id":"open","title":"Open","run":["node","bin/x.js"]}],
+           "panels":[{"id":"open","title":"Deep Links","icon":"link",
+             "body":{"kind":"list","source":"open","rowAction":"run",
+                     "prompt":{"arg":"url","placeholder":"myapp://path",
+                               "submit":"Open","filter":true}}}]}}
+        """.utf8))
+        let plugins = MockPlugins()
+        given(plugins).all().willReturn([
+            Plugin(root: URL(fileURLWithPath: "/tmp/deeplink"), manifest: manifest)
+        ])
+
+        let json = try plugins.listJSON
+        let root = try #require(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        let panels = ((root["plugins"] as? [[String: Any]])?.first?["panels"] as? [[String: Any]]) ?? []
+        let prompt = (panels.first?["body"] as? [String: Any])?["prompt"] as? [String: Any]
+
+        #expect(prompt?["arg"] as? String == "url")
+        #expect(prompt?["placeholder"] as? String == "myapp://path")
+        #expect(prompt?["submit"] as? String == "Open")
+        #expect(prompt?["filter"] as? Bool == true)
+    }
+
+    @Test func `a panel with no prompt projects none, so old panels are byte-identical`() throws {
+        let manifest = try PluginManifest.parsing(json: Data("""
+        {"name":"a11y","version":"1.0.0",
+         "contributes":{
+           "commands":[{"id":"audit","title":"Audit","run":["node","bin/x.js"]}],
+           "panels":[{"id":"audit","title":"Audit","icon":"accessibility",
+             "body":{"kind":"list","source":"audit","rowAction":"highlight"}}]}}
+        """.utf8))
+        let plugins = MockPlugins()
+        given(plugins).all().willReturn([
+            Plugin(root: URL(fileURLWithPath: "/tmp/a11y"), manifest: manifest)
+        ])
+
+        #expect(!(try plugins.listJSON).contains("prompt"))
+    }
+}

--- a/Tests/BaguetteTests/Plugin/PluginAccessTests.swift
+++ b/Tests/BaguetteTests/Plugin/PluginAccessTests.swift
@@ -40,7 +40,8 @@ struct PluginAccessTests {
         let grants = PluginGrants()
         let token = grants.issue(plugin: "a11y", capabilities: [.describeUI])
         for path in ["/simulators/U/screenshot.jpg", "/simulators/U/apps",
-                     "/simulators/U/media", "/simulators.json"] {
+                     "/simulators/U/media", "/simulators.json",
+                     "/simulators/U/openurl", "/simulators/U/schemes.json"] {
             guard case .refused = PluginAccess.decide(token: token, path: path, grants: grants) else {
                 Issue.record("\(path) should be refused"); return
             }
@@ -69,6 +70,26 @@ struct PluginAccessTests {
             }
             #expect(message.contains("no capability"))
         }
+    }
+
+    @Test func `a deep-link plugin reaches both its routes and nothing else`() {
+        // `open-url` is one capability over one surface: see what's
+        // registered, open one. It must not carry the authority to
+        // install an app, which is the neighbouring `apps` power.
+        let grants = PluginGrants()
+        let token = grants.issue(plugin: "deeplink", capabilities: [.openURL])
+        for path in ["/simulators/U/openurl", "/simulators/U/schemes.json"] {
+            #expect(
+                PluginAccess.decide(token: token, path: path, grants: grants) == .granted,
+                "\(path) should be granted"
+            )
+        }
+        guard case .refused(let message) = PluginAccess.decide(
+            token: token, path: "/simulators/U/apps", grants: grants
+        ) else {
+            Issue.record("open-url must not reach the app-install route"); return
+        }
+        #expect(message == #"this plugin did not declare the "apps" capability"#)
     }
 
     // MARK: - callers that aren't plugins

--- a/Tests/BaguetteTests/Plugin/PluginIconParityTests.swift
+++ b/Tests/BaguetteTests/Plugin/PluginIconParityTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// The icon set exists twice — `PluginIcon` here, the `ICONS` map in
+/// `sim-plugins.js` — and until this suite nothing checked they agreed.
+///
+/// The duplication is deliberate and not removable: the Swift side is
+/// the parse boundary that stops manifest text reaching the DOM, and the
+/// JS side holds the actual SVG paths, which have no business in a Swift
+/// enum. What *was* removable is the failure mode. The two files carried
+/// a comment asking a human to keep them in sync, and a comment is not a
+/// mechanism: adding a case to one and forgetting the other ships a
+/// plugin that passes `baguette plugin validate` and then draws the
+/// wrong glyph, which nothing would have caught.
+///
+/// Reading in this direction on purpose — `allCases` is exact, so only
+/// the JS half needs parsing, and a regex is applied to the file that
+/// can afford one.
+@Suite("PluginIcon parity")
+struct PluginIconParityTests {
+
+    private static var simPluginsJS: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // …/Plugin
+            .deletingLastPathComponent()   // …/BaguetteTests
+            .deletingLastPathComponent()   // …/Tests
+            .deletingLastPathComponent()   // repo root
+            .appendingPathComponent("Sources/Baguette/Resources/Web/sim-plugins.js")
+    }
+
+    /// The keys of the `ICONS` object literal in `sim-plugins.js`.
+    static func iconsDeclaredInJS() throws -> Set<String> {
+        let source = try String(contentsOf: simPluginsJS, encoding: .utf8)
+        guard let start = source.range(of: "const ICONS = {"),
+              let end = source.range(of: "\n  };", range: start.upperBound..<source.endIndex)
+        else {
+            Issue.record("could not find the ICONS literal in sim-plugins.js")
+            return []
+        }
+
+        let block = source[start.upperBound..<end.lowerBound]
+        var names: Set<String> = []
+        for line in block.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            // `name: '<svg paths>',` — skip comment lines and blanks.
+            guard !trimmed.hasPrefix("//"), let colon = trimmed.firstIndex(of: ":") else { continue }
+            let name = trimmed[trimmed.startIndex..<colon].trimmingCharacters(in: .whitespaces)
+            if !name.isEmpty { names.insert(name) }
+        }
+        return names
+    }
+
+    @Test func `every glyph the host parses is one the page can draw`() throws {
+        // The direction that actually breaks a user: a manifest names an
+        // icon, Swift accepts it as known, and the browser has no path
+        // for it — so `iconSVG` silently falls back to `list` and the
+        // plugin wears the wrong face with no warning anywhere.
+        let swift = Set(PluginIcon.allCases.map(\.rawValue))
+        let js = try Self.iconsDeclaredInJS()
+
+        #expect(
+            swift.subtracting(js).isEmpty,
+            "PluginIcon has cases sim-plugins.js can't draw: \(swift.subtracting(js).sorted())"
+        )
+    }
+
+    @Test func `the page draws no glyph the host would refuse to parse`() throws {
+        // The other direction is dead weight rather than breakage, but it
+        // means a plugin naming that icon gets `puzzle` plus a validate
+        // warning while the artwork sits right there unused.
+        let swift = Set(PluginIcon.allCases.map(\.rawValue))
+        let js = try Self.iconsDeclaredInJS()
+
+        #expect(
+            js.subtracting(swift).isEmpty,
+            "sim-plugins.js draws glyphs PluginIcon doesn't name: \(js.subtracting(swift).sorted())"
+        )
+    }
+
+    @Test func `the parse actually found the icon set, rather than agreeing about nothing`() throws {
+        // Two empty sets are equal. If the regex ever stops matching —
+        // the literal is reformatted, renamed, moved — both tests above
+        // would pass vacuously and go on passing forever.
+        let js = try Self.iconsDeclaredInJS()
+        #expect(js.count == PluginIcon.allCases.count)
+        #expect(js.contains("puzzle"), "expected the fallback glyph among the parsed names")
+    }
+}

--- a/Tests/BaguetteTests/Plugin/PluginManifestTests.swift
+++ b/Tests/BaguetteTests/Plugin/PluginManifestTests.swift
@@ -119,13 +119,13 @@ struct PluginManifestTests {
     @Test func `parsing reads a list body bound to a contributed command`() throws {
         let manifest = try PluginManifest.parsing(json: Self.fixturePanel)
         let panel = try #require(manifest.panels.first)
-        #expect(panel.body == .list(source: "audit", rowAction: .highlight))
+        #expect(panel.body == .list(ListBody(source: "audit", rowAction: .highlight)))
     }
 
     @Test func `a panel's rowAction is nil when the manifest omits it`() throws {
         let manifest = try PluginManifest.parsing(json: Self.fixturePanelNoRowAction)
         let panel = try #require(manifest.panels.first)
-        #expect(panel.body == .list(source: "audit", rowAction: nil))
+        #expect(panel.body == .list(ListBody(source: "audit")))
     }
 
     @Test func `parsing reads a panel's when condition`() throws {

--- a/Tests/BaguetteTests/Plugin/PluginRouteTests.swift
+++ b/Tests/BaguetteTests/Plugin/PluginRouteTests.swift
@@ -67,6 +67,22 @@ struct PluginRouteTests {
         #expect(PluginRoute.capability(path: "/simulators/U/interface.json") == .interface)
     }
 
+    @Test func `opening a link and listing schemes demand open-url`() {
+        // One capability for the pair, on the `interface` precedent: a
+        // plugin that can open *any* URL is not meaningfully restrained
+        // by hiding the list of which ones an app registered.
+        #expect(PluginRoute.capability(path: "/simulators/U/openurl") == .openURL)
+        #expect(PluginRoute.capability(path: "/simulators/U/schemes.json") == .openURL)
+    }
+
+    @Test func `opening a link is not covered by the app-install capability`() {
+        // `apps` puts an executable on the device; `open-url` launches
+        // one that's already there. A plugin that only wants to fire a
+        // deep link must not have to be trusted to install software.
+        #expect(PluginCapability.openURL != .apps)
+        #expect(PluginRoute.capability(path: "/simulators/U/openurl") != .apps)
+    }
+
     @Test func `a real udid is carried in the path like any other segment`() {
         #expect(
             PluginRoute.capability(path: "/simulators/AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/input")

--- a/Tests/BaguetteTests/Plugin/PluginRunActionTests.swift
+++ b/Tests/BaguetteTests/Plugin/PluginRunActionTests.swift
@@ -24,7 +24,7 @@ struct PluginRunActionTests {
             dict: ["kind": "list", "source": "settings", "rowAction": "run"],
             declaredCommands: ["settings"]
         )
-        #expect(body == .list(source: "settings", rowAction: .run))
+        #expect(body == .list(ListBody(source: "settings", rowAction: .run)))
     }
 
     @Test func `an unknown row action is still refused`() {

--- a/Tests/BaguetteTests/Plugin/PluginTests.swift
+++ b/Tests/BaguetteTests/Plugin/PluginTests.swift
@@ -134,7 +134,7 @@ struct PluginTests {
                         id: "panel\(index)",
                         title: "Panel \(index)",
                         icon: panelIcon,
-                        body: .list(source: commandIDs.first ?? "", rowAction: nil)
+                        body: .list(ListBody(source: commandIDs.first ?? ""))
                     )
                 }
             )

--- a/Tests/BaguetteTests/Plugin/RowActionFillTests.swift
+++ b/Tests/BaguetteTests/Plugin/RowActionFillTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import Baguette
+
+/// `rowAction: "fill"` — a row that puts its text into the panel's own
+/// prompt instead of doing something with it.
+///
+/// The other four actions all *act*: box a frame, tap it, copy it, run a
+/// command. This one hands the row to the field above it, which is what
+/// a list of suggestions under a text box has always meant. The
+/// deep-link panel is the case that named it: clicking `account://` was
+/// opening a bare scheme with no path, when what anyone wants is that
+/// scheme in the box with the caret after it, ready for the rest of the
+/// URL.
+///
+/// So the list stops being a launcher and becomes what it looks like —
+/// completion.
+@Suite("Row action fill")
+struct RowActionFillTests {
+
+    private func row(_ json: String) throws -> ResultRow {
+        try ResultRow.parsing(
+            dict: JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any] ?? [:],
+            index: 0
+        )
+    }
+
+    @Test func `a panel may declare the fill row action`() throws {
+        let body = try PanelBody.parsing(
+            dict: ["kind": "list", "source": "open", "rowAction": "fill"],
+            declaredCommands: ["open"]
+        )
+        #expect(body == .list(ListBody(source: "open", rowAction: .fill)))
+    }
+
+    @Test func `a row carries the text it fills the field with`() throws {
+        #expect(try row(#"{"title":"account://","fill":"account://"}"#).fill == "account://")
+    }
+
+    @Test func `what a row fills with is separate from what it displays`() throws {
+        // The title is display text — it may be truncated, decorated or
+        // translated. Reusing it as the value would make every one of
+        // those a silent change to what gets typed into the box.
+        let row = try row(#"{"title":"Account (SpringBoard)","fill":"account://"}"#)
+        #expect(row.title == "Account (SpringBoard)")
+        #expect(row.fill == "account://")
+    }
+
+    @Test func `a row that fills nothing is not a fill row`() throws {
+        #expect(try row(#"{"title":"Nothing here"}"#).fill == nil)
+    }
+
+    @Test func `fill reaches the browser, and is absent when unused`() throws {
+        #expect(try row(#"{"title":"a","fill":"account://"}"#).dictionary["fill"] as? String
+                == "account://")
+        #expect(try row(#"{"title":"a"}"#).dictionary["fill"] == nil)
+    }
+
+    @Test func `fill joins the actions a manifest may name`() {
+        // The set is closed and the error message lists it, so a new
+        // member has to show up there or authors can't discover it.
+        #expect(RowAction.allCases.contains(.fill))
+        #expect(
+            PluginManifestError.unknownRowAction(name: "x").description.contains("fill")
+        )
+    }
+}

--- a/Tests/BaguetteTests/Server/DeepLinkRoutesTests.swift
+++ b/Tests/BaguetteTests/Server/DeepLinkRoutesTests.swift
@@ -1,0 +1,160 @@
+import Testing
+import Foundation
+import Mockable
+@testable import Baguette
+
+/// Handler-level coverage for the console's two routes. We drive the
+/// pure dispatch helpers rather than the Hummingbird `Response`
+/// wrappers, with `MockSimulators` + `MockApps`.
+///
+/// `openURL` reports *where the link went*, not just whether dispatch
+/// succeeded — an https link dispatches perfectly happily and then lands
+/// in Safari, so "ok" alone would be a lie the URL bar repeats to the
+/// developer. `schemes` answers the completion inventory, ranked
+/// server-side so the browser never has to re-implement the ordering.
+@Suite("Server deep-link routes")
+struct DeepLinkRoutesTests {
+
+    private func host(
+        installed: [InstalledApp] = [],
+        openSucceeds: Bool = true,
+        listSucceeds: Bool = true
+    ) -> (MockSimulators, MockApps) {
+        let simulators = MockSimulators()
+        let sim = MockSimulator()
+        let apps = MockApps()
+        given(simulators).find(udid: .value("U")).willReturn(sim)
+        given(simulators).find(udid: .value("nope")).willReturn(nil)
+        given(sim).apps().willReturn(apps)
+
+        if openSucceeds {
+            given(apps).open(.any).willReturn(())
+        } else {
+            given(apps).open(.any).willThrow(AppsError.openFailed(status: 1))
+        }
+        if listSucceeds {
+            given(apps).installed().willReturn(installed)
+        } else {
+            given(apps).installed().willThrow(AppsError.listFailed(status: 1))
+        }
+        return (simulators, apps)
+    }
+
+    private static let myApp = InstalledApp(
+        bundleIdentifier: "com.example.MyApp",
+        name: "My App",
+        schemes: ["myapp", "com.example.myapp"]
+    )
+
+    // MARK: - openurl
+
+    @Test func `opening a custom scheme reports it reached the app`() async {
+        let (simulators, apps) = host()
+        let outcome = await Server.openURL(udid: "U", url: "myapp://profile", simulators: simulators)
+
+        #expect(outcome == .opened(routing: .app))
+        verify(apps).open(.value(DeepLink.from("myapp://profile")!)).called(1)
+    }
+
+    @Test func `opening an https link reports it went to the browser`() async {
+        // Dispatch succeeds; the link still lands in Safari. The URL bar
+        // needs to say so, so the outcome carries the routing.
+        let (simulators, _) = host()
+        let outcome = await Server.openURL(
+            udid: "U", url: "https://example.com/x", simulators: simulators
+        )
+        #expect(outcome == .opened(routing: .browser))
+    }
+
+    @Test func `a bare word is refused as not a URL`() async {
+        let (simulators, apps) = host()
+        let outcome = await Server.openURL(udid: "U", url: "profile", simulators: simulators)
+
+        #expect(outcome == .notAURL)
+        verify(apps).open(.any).called(0)
+    }
+
+    @Test func `opening against an unknown device is reported`() async {
+        let (simulators, _) = host()
+        let outcome = await Server.openURL(udid: "nope", url: "myapp://x", simulators: simulators)
+        #expect(outcome == .unknownDevice)
+    }
+
+    @Test func `a failed dispatch is reported`() async {
+        let (simulators, _) = host(openSucceeds: false)
+        let outcome = await Server.openURL(udid: "U", url: "myapp://x", simulators: simulators)
+        #expect(outcome == .dispatchFailed)
+    }
+
+    // MARK: - schemes
+
+    @Test func `the schemes route answers the ranked inventory`() async {
+        let (simulators, _) = host(installed: [Self.myApp])
+        let outcome = await Server.schemes(udid: "U", query: "", simulators: simulators)
+
+        #expect(outcome == .ok([
+            SchemeSuggestion(scheme: "myapp", appName: "My App", bundleIdentifier: "com.example.MyApp"),
+            SchemeSuggestion(scheme: "com.example.myapp", appName: "My App", bundleIdentifier: "com.example.MyApp"),
+        ]))
+    }
+
+    @Test func `the schemes route ranks against the typed query`() async {
+        // Ranking is server-side so the browser never re-implements it.
+        let (simulators, _) = host(installed: [
+            InstalledApp(bundleIdentifier: "a", name: "A", schemes: ["superapp"]),
+            InstalledApp(bundleIdentifier: "b", name: "B", schemes: ["app"]),
+        ])
+        let outcome = await Server.schemes(udid: "U", query: "app", simulators: simulators)
+
+        guard case .ok(let suggestions) = outcome else { return #expect(Bool(false)) }
+        #expect(suggestions.map(\.scheme) == ["app", "superapp"])
+    }
+
+    @Test func `listing against an unknown device is reported`() async {
+        let (simulators, _) = host()
+        #expect(await Server.schemes(udid: "nope", query: "", simulators: simulators) == .unknownDevice)
+    }
+
+    @Test func `a failed listing is reported`() async {
+        let (simulators, _) = host(listSucceeds: false)
+        #expect(await Server.schemes(udid: "U", query: "", simulators: simulators) == .listFailed)
+    }
+
+    // MARK: - what the browser actually receives
+
+    private func object(_ json: String) -> [String: Any] {
+        (try? JSONSerialization.jsonObject(with: Data(json.utf8))) as? [String: Any] ?? [:]
+    }
+
+    @Test func `an opened custom scheme serialises as having reached the app`() {
+        let body = object(Server.openedJSONString(routing: .app))
+        #expect(body["routing"] as? String == "app")
+        #expect(body["warning"] == nil)
+    }
+
+    @Test func `an opened https link serialises with the warning attached`() {
+        // The copy lives server-side so the URL bar renders it rather
+        // than keeping its own duplicate of the explanation.
+        let body = object(Server.openedJSONString(routing: .browser))
+        #expect(body["routing"] as? String == "browser")
+        let warning = body["warning"] as? String
+        #expect(warning?.contains("Safari") == true)
+    }
+
+    @Test func `suggestions serialise with what the bar needs to render a row`() {
+        let json = Server.schemesJSONString([
+            SchemeSuggestion(scheme: "myapp", appName: "My App", bundleIdentifier: "com.example.MyApp"),
+        ])
+        let rows = (object(json)["schemes"] as? [[String: Any]]) ?? []
+
+        #expect(rows.count == 1)
+        #expect(rows.first?["scheme"] as? String == "myapp")
+        #expect(rows.first?["completion"] as? String == "myapp://")
+        #expect(rows.first?["app"] as? String == "My App")
+        #expect(rows.first?["bundleId"] as? String == "com.example.MyApp")
+    }
+
+    @Test func `an empty inventory serialises as an empty list`() {
+        #expect((object(Server.schemesJSONString([]))["schemes"] as? [[String: Any]])?.isEmpty == true)
+    }
+}

--- a/Tests/Web/plugin-control.test.js
+++ b/Tests/Web/plugin-control.test.js
@@ -208,3 +208,26 @@ test('the glyph family is reported for the host to draw', () => {
   assert.equal(new Control(CHECKBOX).kind, 'checkbox');
   assert.equal(new Control(RADIO).kind, 'radio');
 });
+
+test('a control kind the page cannot draw is refused, not passed through', () => {
+  // `kind` is interpolated straight into `data-control` and `role`
+  // attributes. The Swift parser restricts it to three values, but this
+  // file must not depend on that: /plugins.json is the same untrusted
+  // manifest text every other string here is escaped for, and one
+  // malformed value would otherwise close the attribute and open a new
+  // one. Same closed-set treatment `SEVERITIES` already gets.
+  const Control = PluginControl();
+  assert.equal(new Control({ kind: 'dial', arg: 'e' }).present, false);
+  assert.equal(new Control({ kind: 'radio" data-x="injected', arg: 'e' }).present, false);
+  assert.equal(new Control({ kind: 'dial', arg: 'e' }).kind, null);
+});
+
+test('a refused control kind ticks nothing and submits nothing', () => {
+  // Refusing must be inert all the way through, not just at `kind` —
+  // otherwise the rows would still tick while drawing no glyph.
+  const Control = PluginControl();
+  const control = new Control({ kind: 'dial', arg: 'e' });
+  assert.equal(control.isControlRow({ state: 'on', value: 'x' }), false);
+  assert.deepEqual(control.initialTicks(ROWS), {});
+  assert.equal(control.args({}, ROWS), null);
+});

--- a/Tests/Web/plugin-control.test.js
+++ b/Tests/Web/plugin-control.test.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { loadBrowserModule } = require('./helpers/load-browser-module.js');
+
+const MODULE_PATH = path.join(
+  __dirname, '..', '..', 'Sources', 'Baguette', 'Resources', 'Web',
+  'plugin-control.js'
+);
+
+function PluginControl() {
+  return loadBrowserModule(MODULE_PATH).Baguette._PluginControl;
+}
+
+const CHECKBOX = { kind: 'checkbox', arg: 'enabled', submit: 'Apply' };
+const RADIO = { kind: 'radio', arg: 'appearance', submit: 'Set' };
+
+// A panel mixing controls with a plain header row, which is the shape
+// display.py actually returns.
+const ROWS = [
+  { title: 'Permissions' },
+  { title: 'Camera', value: 'camera', state: 'on' },
+  { title: 'Microphone', value: 'mic', state: 'off' },
+  { title: 'Location', value: 'location', state: 'off' },
+];
+
+test('a panel with no control declares no ticks', () => {
+  const Control = PluginControl();
+  assert.equal(new Control(undefined).present, false);
+  assert.equal(new Control({ kind: 'switch' }).present, false); // no arg
+});
+
+test('ticks start from what the device reported, not from empty', () => {
+  // The panel opens showing the machine's actual state. Starting blank
+  // would show every setting off and invite you to "fix" it.
+  const Control = PluginControl();
+  assert.deepEqual(new Control(CHECKBOX).initialTicks(ROWS), {
+    camera: true, mic: false, location: false,
+  });
+});
+
+test('a row with no state is not a control, so headers stay headers', () => {
+  const Control = PluginControl();
+  const control = new Control(CHECKBOX);
+  assert.equal(control.isControlRow(ROWS[0]), false);
+  assert.equal(control.isControlRow(ROWS[1]), true);
+  assert.equal(Object.hasOwn(control.initialTicks(ROWS), 'Permissions'), false);
+});
+
+test('ticking a checkbox flips only that row', () => {
+  const Control = PluginControl();
+  const control = new Control(CHECKBOX);
+  const next = control.toggle(control.initialTicks(ROWS), ROWS[2], ROWS);
+  assert.deepEqual(next, { camera: true, mic: true, location: false });
+});
+
+test('ticking does not mutate the ticks it was given', () => {
+  // The renderer holds the previous set while painting; mutating in
+  // place would make "what changed" unanswerable.
+  const Control = PluginControl();
+  const control = new Control(CHECKBOX);
+  const before = control.initialTicks(ROWS);
+  control.toggle(before, ROWS[2], ROWS);
+  assert.deepEqual(before, { camera: true, mic: false, location: false });
+});
+
+test('a radio turns its siblings off, and cannot be turned off by re-clicking', () => {
+  // One-of-many: clicking the selected option again must leave it
+  // selected rather than dropping the panel into "nothing chosen",
+  // which is a state the device can't be in.
+  const Control = PluginControl();
+  const control = new Control(RADIO);
+  const start = control.initialTicks(ROWS);
+  assert.deepEqual(control.toggle(start, ROWS[2], ROWS), {
+    camera: false, mic: true, location: false,
+  });
+  assert.deepEqual(control.toggle(start, ROWS[1], ROWS), {
+    camera: true, mic: false, location: false,
+  });
+});
+
+// A settings panel is normally several independent choices at once —
+// display.py alone has appearance, contrast and text size. Without
+// groups, one radio panel could only ever offer a single question, and
+// picking "Dark" would silently unpick the text size.
+const GROUPED = [
+  { title: 'Appearance' },
+  { title: 'Light', value: 'appearance:light', state: 'on', group: 'appearance' },
+  { title: 'Dark', value: 'appearance:dark', state: 'off', group: 'appearance' },
+  { title: 'Text size' },
+  { title: 'Default', value: 'size:large', state: 'on', group: 'size' },
+  { title: 'Largest', value: 'size:xxxl', state: 'off', group: 'size' },
+];
+
+test('a radio only unpicks its own group', () => {
+  const Control = PluginControl();
+  const control = new Control(RADIO);
+  const next = control.toggle(control.initialTicks(GROUPED), GROUPED[2], GROUPED);
+
+  assert.equal(next['appearance:dark'], true);
+  assert.equal(next['appearance:light'], false);
+  // The other question is untouched.
+  assert.equal(next['size:large'], true);
+  assert.equal(next['size:xxxl'], false);
+});
+
+test('picking in one group leaves the other groups unpending', () => {
+  const Control = PluginControl();
+  const control = new Control(RADIO);
+  const next = control.toggle(control.initialTicks(GROUPED), GROUPED[5], GROUPED);
+  assert.deepEqual(control.pending(next, GROUPED), ['size:large', 'size:xxxl']);
+});
+
+test('ungrouped radio rows behave as one group, as before', () => {
+  const Control = PluginControl();
+  const control = new Control(RADIO);
+  const next = control.toggle(control.initialTicks(ROWS), ROWS[2], ROWS);
+  assert.deepEqual(next, { camera: false, mic: true, location: false });
+});
+
+test('a checkbox ignores groups — ticking one leaves the rest alone', () => {
+  // Grouping is a radio concept: it says which options are mutually
+  // exclusive. Many-of-many has no such constraint to express.
+  const Control = PluginControl();
+  const control = new Control(CHECKBOX);
+  const next = control.toggle(control.initialTicks(GROUPED), GROUPED[2], GROUPED);
+  assert.equal(next['appearance:dark'], true);
+  assert.equal(next['appearance:light'], true);
+});
+
+test('a row whose tick disagrees with the device is pending', () => {
+  // This is the whole cost of batching, made visible: until Apply
+  // returns, these rows show something the device has not confirmed.
+  const Control = PluginControl();
+  const control = new Control(CHECKBOX);
+  const ticks = control.toggle(control.initialTicks(ROWS), ROWS[2], ROWS);
+  assert.deepEqual(control.pending(ticks, ROWS), ['mic']);
+});
+
+test('nothing is pending before anything is ticked', () => {
+  const Control = PluginControl();
+  const control = new Control(CHECKBOX);
+  const ticks = control.initialTicks(ROWS);
+  assert.deepEqual(control.pending(ticks, ROWS), []);
+  assert.equal(control.changed(ticks, ROWS), false);
+});
+
+test('ticking a row and ticking it back is not a change', () => {
+  const Control = PluginControl();
+  const control = new Control(CHECKBOX);
+  let ticks = control.initialTicks(ROWS);
+  ticks = control.toggle(ticks, ROWS[2], ROWS);
+  ticks = control.toggle(ticks, ROWS[2], ROWS);
+  assert.equal(control.changed(ticks, ROWS), false);
+});
+
+test('submitting sends every ticked value under the manifest key', () => {
+  const Control = PluginControl();
+  const control = new Control(CHECKBOX);
+  const ticks = control.toggle(control.initialTicks(ROWS), ROWS[3], ROWS);
+  assert.deepEqual(control.args(ticks, ROWS), { enabled: ['camera', 'location'] });
+});
+
+test('submitting sends an array even for a radio, so plugins have one shape', () => {
+  const Control = PluginControl();
+  const control = new Control(RADIO);
+  const ticks = control.toggle(control.initialTicks(ROWS), ROWS[2], ROWS);
+  assert.deepEqual(control.args(ticks, ROWS), { appearance: ['mic'] });
+});
+
+test('unticking everything submits an empty array, not nothing', () => {
+  // "Turn all of these off" is a real instruction. Collapsing it to a
+  // no-op would make the panel refuse the one edit it should accept.
+  const Control = PluginControl();
+  const control = new Control(CHECKBOX);
+  const ticks = control.toggle(control.initialTicks(ROWS), ROWS[1], ROWS);
+  assert.deepEqual(control.args(ticks, ROWS), { enabled: [] });
+  assert.equal(control.changed(ticks, ROWS), true);
+});
+
+test('submitted values follow row order, so the plugin sees a stable list', () => {
+  const Control = PluginControl();
+  const control = new Control(CHECKBOX);
+  let ticks = control.initialTicks(ROWS);
+  ticks = control.toggle(ticks, ROWS[3], ROWS);
+  ticks = control.toggle(ticks, ROWS[2], ROWS);
+  assert.deepEqual(control.args(ticks, ROWS), { enabled: ['camera', 'mic', 'location'] });
+});
+
+test('a panel with no control submits nothing at all', () => {
+  const Control = PluginControl();
+  const control = new Control(undefined);
+  assert.equal(control.args({}, ROWS), null);
+  assert.deepEqual(control.initialTicks(ROWS), {});
+  assert.equal(control.changed({}, ROWS), false);
+});
+
+test('the button label falls back when the manifest names none', () => {
+  const Control = PluginControl();
+  assert.equal(new Control({ kind: 'switch', arg: 'e' }).submitLabel, 'Apply');
+  assert.equal(new Control(RADIO).submitLabel, 'Set');
+});
+
+test('the glyph family is reported for the host to draw', () => {
+  const Control = PluginControl();
+  assert.equal(new Control(CHECKBOX).kind, 'checkbox');
+  assert.equal(new Control(RADIO).kind, 'radio');
+});

--- a/Tests/Web/plugin-prompt.test.js
+++ b/Tests/Web/plugin-prompt.test.js
@@ -92,6 +92,19 @@ test('a suggestion stays visible once you have typed past it', () => {
   assert.equal(prompt.matches({ title: 'myapp://' }, 'account://settings'), false);
 });
 
+test('a row is matched on the text it would fill in, not only on its label', () => {
+  // `fill` is what actually goes into the field; `title` is display text
+  // and may be decorated or translated. Searching only the label hides
+  // the completion whenever the two differ — type `://` against a row
+  // labelled "Account (SpringBoard)" and it disappears.
+  const Prompt = PluginPrompt();
+  const prompt = new Prompt(SPEC);
+  const row = { title: 'Account (SpringBoard)', fill: 'account://' };
+  assert.equal(prompt.matches(row, 'account'), true);
+  assert.equal(prompt.matches(row, '://'), true);
+  assert.equal(prompt.matches(row, 'zzz'), false);
+});
+
 test('typing past a suggestion is matched on the fill text when there is one', () => {
   const Prompt = PluginPrompt();
   const prompt = new Prompt(SPEC);

--- a/Tests/Web/plugin-prompt.test.js
+++ b/Tests/Web/plugin-prompt.test.js
@@ -1,0 +1,229 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { loadBrowserModule } = require('./helpers/load-browser-module.js');
+
+const MODULE_PATH = path.join(
+  __dirname, '..', '..', 'Sources', 'Baguette', 'Resources', 'Web',
+  'plugin-prompt.js'
+);
+
+function PluginPrompt() {
+  return loadBrowserModule(MODULE_PATH).Baguette._PluginPrompt;
+}
+
+const SPEC = { arg: 'url', placeholder: 'myapp://path', submit: 'Open', filter: true };
+
+test('a panel with no prompt draws no field', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt(undefined).present, false);
+  assert.equal(new Prompt(null).present, false);
+});
+
+test('a prompt naming no arg is not drawn', () => {
+  // The host refuses such a manifest, but the page must not depend on
+  // that: a field submitting into nowhere looks like a working control.
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt({ placeholder: 'x' }).present, false);
+  assert.equal(new Prompt({ arg: '' }).present, false);
+});
+
+test('what was typed is submitted under the key the manifest named', () => {
+  const Prompt = PluginPrompt();
+  assert.deepEqual(new Prompt(SPEC).args('myapp://profile/42'), { url: 'myapp://profile/42' });
+});
+
+test('a pasted value is trimmed before it is submitted', () => {
+  // Pasting a link routinely brings a trailing newline; the host would
+  // trim it anyway, and sending it untrimmed makes the echo look wrong.
+  const Prompt = PluginPrompt();
+  assert.deepEqual(new Prompt(SPEC).args('  myapp://x\n'), { url: 'myapp://x' });
+});
+
+test('submitting an empty field does nothing rather than running the command', () => {
+  // A blank submit would spawn a subprocess to be told nothing was
+  // typed. The button is inert until there is something to send.
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt(SPEC).args(''), null);
+  assert.equal(new Prompt(SPEC).args('   '), null);
+  assert.equal(new Prompt(SPEC).args(undefined), null);
+});
+
+test('a panel without a prompt never produces args', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt(undefined).args('myapp://x'), null);
+});
+
+test('a prompt that named no label gets a plain one', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt({ arg: 'url' }).submitLabel, 'Run');
+  assert.equal(new Prompt(SPEC).submitLabel, 'Open');
+});
+
+test('a prompt that named no placeholder leaves the field blank', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt({ arg: 'url' }).placeholder, '');
+  assert.equal(new Prompt(SPEC).placeholder, 'myapp://path');
+});
+
+test('filtering narrows the rows already on screen, over title and subtitle', () => {
+  // The rows came back from one subprocess run. Narrowing them locally
+  // is what gives completion its feel without re-running the command.
+  const Prompt = PluginPrompt();
+  const prompt = new Prompt(SPEC);
+  assert.equal(prompt.matches({ title: 'myapp://', subtitle: 'My App' }, 'myap'), true);
+  assert.equal(prompt.matches({ title: 'myapp://', subtitle: 'My App' }, 'my app'), true);
+  assert.equal(prompt.matches({ title: 'other://', subtitle: 'Other' }, 'myap'), false);
+});
+
+test('a suggestion stays visible once you have typed past it', () => {
+  // Picking `account://` fills the box, and then you type the path. If
+  // the filter only matched substrings, the row you just picked would
+  // vanish the moment you added a character and the list would read
+  // "Nothing matches" for the rest of the URL — the list would fight the
+  // thing it exists to help with.
+  const Prompt = PluginPrompt();
+  const prompt = new Prompt(SPEC);
+  assert.equal(prompt.matches({ title: 'account://' }, 'account://'), true);
+  assert.equal(prompt.matches({ title: 'account://' }, 'account://settings/1'), true);
+  // An unrelated scheme still drops out.
+  assert.equal(prompt.matches({ title: 'myapp://' }, 'account://settings'), false);
+});
+
+test('typing past a suggestion is matched on the fill text when there is one', () => {
+  const Prompt = PluginPrompt();
+  const prompt = new Prompt(SPEC);
+  const row = { title: 'Account (SpringBoard)', fill: 'account://' };
+  assert.equal(prompt.matches(row, 'account://settings'), true);
+});
+
+test('filtering ignores case, so typing MYAPP still finds myapp', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt(SPEC).matches({ title: 'myapp://' }, 'MYAPP'), true);
+});
+
+test('an empty field hides nothing', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt(SPEC).matches({ title: 'myapp://' }, ''), true);
+  assert.equal(new Prompt(SPEC).matches({ title: 'myapp://' }, '   '), true);
+});
+
+test('a panel that did not ask for filtering keeps every row visible', () => {
+  // Otherwise typing a full URL into a deep-link bar would empty the
+  // list of schemes underneath it — the list is a reference, not a
+  // search result, unless the manifest says so.
+  const Prompt = PluginPrompt();
+  const unfiltered = new Prompt({ arg: 'url' });
+  assert.equal(unfiltered.matches({ title: 'myapp://' }, 'zzz'), true);
+  assert.equal(new Prompt(undefined).matches({ title: 'myapp://' }, 'zzz'), true);
+});
+
+// --- inline completion + history -------------------------------------
+//
+// A suggestion list you have to point at is slower than a bar that
+// finishes your sentence. These are the affordances that make the field
+// feel like a URL bar rather than a text box with a list under it.
+
+const BAR = { ...SPEC, complete: true, history: true };
+
+const SCHEME_ROWS = [
+  { title: 'account://', subtitle: 'SpringBoard', fill: 'account://' },
+  { title: 'activitysharing://', subtitle: 'Fitness', fill: 'activitysharing://' },
+];
+
+test('a panel opts into completion and history separately', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt(SPEC).completes, false);
+  assert.equal(new Prompt(SPEC).remembers, false);
+  assert.equal(new Prompt(BAR).completes, true);
+  assert.equal(new Prompt(BAR).remembers, true);
+});
+
+test('what you have used before is offered ahead of what is merely installed', () => {
+  // `account://hello` is a thing you actually did; `account://` is a
+  // scheme that happens to exist. The first is the better guess.
+  const Prompt = PluginPrompt();
+  const candidates = new Prompt(BAR).candidates(SCHEME_ROWS, ['account://hello']);
+  assert.deepEqual(candidates, ['account://hello', 'account://', 'activitysharing://']);
+});
+
+test('a candidate is not offered twice when history repeats a row', () => {
+  const Prompt = PluginPrompt();
+  const candidates = new Prompt(BAR).candidates(SCHEME_ROWS, ['account://']);
+  assert.deepEqual(candidates, ['account://', 'activitysharing://']);
+});
+
+test('the ghost is only the part you have not typed', () => {
+  const Prompt = PluginPrompt();
+  const prompt = new Prompt(BAR);
+  assert.equal(prompt.ghost('acc', ['account://hello']), 'ount://hello');
+  assert.equal(prompt.ghost('account://hello', ['account://hello']), '');
+});
+
+test('completing keeps the case you typed rather than rewriting it', () => {
+  // Typing ACC and having the field snap to lowercase mid-word is the
+  // kind of thing that makes a bar feel like it is fighting you.
+  const Prompt = PluginPrompt();
+  const prompt = new Prompt(BAR);
+  assert.equal(prompt.ghost('ACC', ['account://hello']), 'ount://hello');
+  assert.equal(prompt.accepted('ACC', ['account://hello']), 'ACCount://hello');
+});
+
+test('nothing is ghosted when nothing starts with what you typed', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt(BAR).ghost('zzz', ['account://']), '');
+  assert.equal(new Prompt(BAR).accepted('zzz', ['account://']), 'zzz');
+});
+
+test('an empty field ghosts nothing, so the bar is quiet until you type', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt(BAR).ghost('', ['account://']), '');
+});
+
+test('a panel that did not ask for completion never ghosts', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt(SPEC).ghost('acc', ['account://']), '');
+  assert.equal(new Prompt(SPEC).accepted('acc', ['account://']), 'acc');
+});
+
+test('what you open is remembered, most recent first', () => {
+  const Prompt = PluginPrompt();
+  const prompt = new Prompt(BAR);
+  let history = prompt.remember([], 'account://hello');
+  history = prompt.remember(history, 'myapp://x');
+  assert.deepEqual(history, ['myapp://x', 'account://hello']);
+});
+
+test('re-opening a link moves it to the front rather than duplicating it', () => {
+  const Prompt = PluginPrompt();
+  const prompt = new Prompt(BAR);
+  let history = prompt.remember(['a://', 'b://'], 'b://');
+  assert.deepEqual(history, ['b://', 'a://']);
+});
+
+test('history is capped, so it stays a shortlist rather than a log', () => {
+  const Prompt = PluginPrompt();
+  const prompt = new Prompt(BAR);
+  let history = [];
+  for (let i = 0; i < 40; i += 1) history = prompt.remember(history, `x://${i}`);
+  assert.equal(history.length, 25);
+  assert.equal(history[0], 'x://39');
+});
+
+test('a panel that does not remember keeps no history', () => {
+  const Prompt = PluginPrompt();
+  assert.deepEqual(new Prompt(SPEC).remember(['a://'], 'b://'), ['a://']);
+});
+
+test('blank submissions are not remembered', () => {
+  const Prompt = PluginPrompt();
+  assert.deepEqual(new Prompt(BAR).remember(['a://'], '   '), ['a://']);
+});
+
+test('a row carrying no text is filtered out rather than crashing', () => {
+  const Prompt = PluginPrompt();
+  assert.equal(new Prompt(SPEC).matches({}, 'myap'), false);
+  assert.equal(new Prompt(SPEC).matches(null, 'myap'), false);
+});

--- a/Tests/Web/plugin-row-action.test.js
+++ b/Tests/Web/plugin-row-action.test.js
@@ -64,6 +64,32 @@ test('a run row without args still invokes its command', () => {
   );
 });
 
+test('a fill row hands its text to the panel prompt', () => {
+  // The other actions do something *with* a row. This one types it into
+  // the field above, which is what a list under a text box means: the
+  // deep-link panel used to open a bare `account://` on click, when what
+  // you want is that scheme in the box ready for the rest of the path.
+  const Action = PluginRowAction();
+  assert.deepEqual(
+    new Action('fill').intent({ title: 'account://', fill: 'account://' }),
+    { kind: 'fill', text: 'account://' }
+  );
+});
+
+test('a fill row uses its own text, not the label it displays', () => {
+  const Action = PluginRowAction();
+  assert.deepEqual(
+    new Action('fill').intent({ title: 'Account (SpringBoard)', fill: 'account://' }),
+    { kind: 'fill', text: 'account://' }
+  );
+});
+
+test('a row with nothing to fill is inert', () => {
+  const Action = PluginRowAction();
+  assert.equal(new Action('fill').intent({ title: 'Nothing to report' }), null);
+  assert.equal(new Action('fill').actionable({ title: 'Nothing to report' }), false);
+});
+
 test('a run row naming no command is inert', () => {
   const Action = PluginRowAction();
   assert.equal(new Action('run').intent({ title: 'Dark' }), null);

--- a/baguette.json
+++ b/baguette.json
@@ -1,0 +1,7 @@
+{
+  "name": "tddworks/baguette",
+  "description": "Official baguette plugins",
+  "plugins": [
+    { "name": "deeplink", "path": "plugins/deeplink" }
+  ]
+}

--- a/docs/features/deep-links.md
+++ b/docs/features/deep-links.md
@@ -1,0 +1,151 @@
+# Deep links
+
+Open a URL on a booted simulator and watch it land in your app, plus the
+inventory of what's openable there in the first place.
+
+```bash
+baguette openurl --udid <UDID> 'myapp://profile/42'
+baguette schemes --udid <UDID>
+```
+
+The browser gets the same thing as a plugin panel — see
+[the plugin](#the-plugin) below. It isn't in the toolbar, because it
+isn't part of baguette's own surface: install it.
+
+---
+
+## The `https://` trap
+
+This is the one thing baguette says that `simctl openurl`, `idb open`
+and Maestro's `openLink` don't.
+
+A custom scheme (`myapp://…`) is dispatched to the app that registered
+it. An `https://` **universal link is not**. The simulator hands it to
+Safari rather than resolving the associated domain to an installed app,
+so the dispatch succeeds and your app never opens:
+
+```console
+$ baguette openurl --udid <UDID> 'https://example.com/profile/42'
+[baguette] Warning: https:// lands in Safari on the simulator, not your app.
+If an app claims the domain, iOS then shows an "Open in …?" dialog that needs a
+tap, so this never completes unattended. For an automated check, use the app's
+custom scheme — `baguette schemes` lists them.
+[baguette] Opened https://example.com/profile/42 on iPhone 17 Pro
+```
+
+Every other tool performs that silently, which leaves you to guess
+whether your entitlement, your `apple-app-site-association` file or the
+simulator is at fault. `DeepLink.routing` names the case, so both the
+CLI and the panel can say it out loud before anyone starts debugging the
+wrong thing.
+
+Nothing here *blocks* the https link — it's still the right thing to
+open when you're testing what a person sees. It just isn't a check that
+can run unattended, because the "Open in …?" dialog needs a tap.
+
+## `baguette schemes`
+
+```console
+$ baguette schemes --udid <UDID>
+myapp://                 My App
+com.example.myapp://     My App
+exp+myapp://             My App
+calshow://               Calendar
+
+$ baguette schemes --udid <UDID> --json
+[ { "app": "My App", "bundleId": "com.example.MyApp",
+    "scheme": "myapp", "url": "myapp://" } ]
+```
+
+Ordering is a specified behaviour, not dictionary iteration. One app
+routinely registers three schemes — a readable one, a reverse-DNS alias,
+and a dev-client scheme injected by tooling (`exp+…`) — and only the
+first is what anyone means to type. So matches are ranked: schemes
+*starting* with what was typed before ones merely containing it, then an
+app's own scheme before its aliases, then alphabetically, so the list
+never reshuffles between keystrokes.
+
+### How the schemes are found
+
+Two reads, no private API, because neither source has the whole picture:
+
+1. `xcrun simctl listapps <udid>` — the authoritative roster: which apps
+   are installed, what they're called, and each one's real `Path` on
+   disk. It reports a curated metadata subset that **does not include
+   `CFBundleURLTypes`** (verified against Xcode 26), so it cannot answer
+   the question on its own.
+2. `<Path>/Info.plist` — the schemes, from the key the app declared them
+   under, unioned across every `CFBundleURLTypes` entry.
+
+Taking the path from step 1 is what makes step 2 safe. Reading
+`Info.plist` means touching CoreSimulator's container layout, whose
+`…/Containers/Bundle/Application/<uuid>/` shape is undocumented and
+whose UUID changes on every reinstall — but it never has to be
+*guessed*, because `listapps` just reported it. An app whose bundle has
+vanished keeps its roster entry and simply contributes no schemes.
+
+Both parses are pure (`InstalledApp.all(fromListApps:)` /
+`InstalledApp.schemes(inInfoPlist:)`); `SimctlApps` runs the child,
+reads the file, and composes them.
+
+## Routes
+
+| Route | Answers |
+|---|---|
+| `POST /simulators/:udid/openurl?url=<encoded>` | `{"ok":true,"routing":"app"}`, or `"browser"` with a `warning` |
+| `GET /simulators/:udid/schemes.json[?q=…]` | `{"schemes":[{"scheme","completion","app","bundleId"}]}` |
+
+Ranking happens server-side so there is one ordering rule, tested once,
+rather than a copy in every client that drifts. `?q=` narrows and ranks
+against what's been typed; omit it for the whole inventory.
+
+Both are reachable by a plugin holding the `open-url` capability, and by
+a trusted browser. Failures answer `{"ok":false,"error":…}` — `400` for
+something that isn't a URL, `404` for an unknown udid, `500` when simctl
+itself failed.
+
+## The plugin
+
+The UI is a plugin, not part of focus mode's toolbar. baguette ships the
+toolbar; a deep-link bar is a thing you choose to install:
+
+```bash
+baguette bakery add tddworks/baguette
+baguette plugin install deeplink
+```
+
+It declares one capability, `open-url`, which `baguette plugin show
+deeplink` prints before you install anything.
+
+Its panel opens with every scheme on the device listed, so "what can I
+even open here?" is answered before you type. The list is **completion,
+not a launcher**: clicking `account://` puts it in the field with the
+caret after it, ready for the path — a bare scheme with no path is
+almost never what anyone means to open. Typing narrows the list, and a
+suggestion you've typed past stays visible so it doesn't disappear
+mid-URL. Enter (or **Open**) is what actually opens.
+
+The field completes as you type: the rest of the best match is drawn
+greyed after the caret, and `Tab` (or `→` at the end) accepts it. Links
+you've opened before come first — having used `account://hello`, typing
+`acc` offers that back rather than the bare scheme, and `↑` / `↓` walks
+the last 25. That history lives in the browser: the plugin never sees
+what you typed before, only what you submit. See
+[`plugins.md`](plugins.md) for the manifest.
+
+Being separate from `apps` is deliberate. That capability installs
+software; this one only launches what is already there, and a plugin
+that wants to fire a deep link shouldn't have to be trusted to put an
+executable on the device.
+
+## Limits
+
+- **`https://` never reaches your app on the simulator.** See above.
+  This is simulator behaviour, not something baguette can route around.
+- **No live server-side completion in the panel.** A plugin command is a
+  subprocess with a ten-second budget, so re-running it per keystroke is
+  the wrong shape. The panel fetches the inventory once when it opens
+  and filters those rows in the page as you type.
+- **A scheme is not a guarantee.** `listapps` reports what an app
+  *registered*; whether it does anything useful with a given path is the
+  app's business.

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -84,7 +84,7 @@ A plugin is a directory containing `baguette-plugin.json`:
   `fill` for `fill`. An unknown `rowAction` is inert rather than
   resolved to the nearest match.
 - **`body.prompt`** adds a text field above the rows — see
-  [Panels you can type into](#panels-you-can-type-into).
+  [Panels you can type into](#panels-you-can-type-into--bodyprompt).
 - **`body.control`** makes rows tickable — see
   [Panels you can tick](#panels-you-can-tick--bodycontrol).
 

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -73,10 +73,20 @@ A plugin is a directory containing `baguette-plugin.json`:
   - `copy` — put the row's `copy` string on the clipboard
   - `run` — invoke the command named by the row's `run`, passing its
     `args`, and re-render the panel from the answer
+  - `fill` — put the row's `fill` text into the panel's own `prompt`,
+    focus it, and leave the caret at the end. The list becomes
+    completion rather than a launcher: clicking `account://` gives you
+    that scheme in the box ready for the path, instead of opening a bare
+    scheme nobody meant. It deliberately does **not** submit
 
   A row missing what the action needs isn't clickable: no `frame` for
-  `highlight` / `tap`, no `copy` for `copy`, no `run` for `run`. An
-  unknown `rowAction` is inert rather than resolved to the nearest match.
+  `highlight` / `tap`, no `copy` for `copy`, no `run` for `run`, no
+  `fill` for `fill`. An unknown `rowAction` is inert rather than
+  resolved to the nearest match.
+- **`body.prompt`** adds a text field above the rows — see
+  [Panels you can type into](#panels-you-can-type-into).
+- **`body.control`** makes rows tickable — see
+  [Panels you can tick](#panels-you-can-tick--bodycontrol).
 
 Contributions are namespaced by plugin: `a11y:audit`. Two plugins can
 both ship a `reload`.
@@ -117,6 +127,14 @@ The command prints **one JSON object** on stdout and exits:
   its centre with no conversion. Omit the frame and a `highlight` /
   `tap` row isn't clickable.
 - `copy` is the string a `rowAction: "copy"` row puts on the clipboard.
+- `fill` is the string a `rowAction: "fill"` row types into the panel's
+  `prompt`. Kept separate from `title` because a title is display text —
+  truncating, decorating or translating it would otherwise silently
+  change what gets typed.
+- `state` / `value` / `group` make a row a **tickable control** — see
+  [Panels you can tick](#panels-you-can-tick--bodycontrol). A row with no
+  `state` is an ordinary row, which is how headings survive in a panel
+  full of switches.
 - `run` names one of *this plugin's* command ids, and `args` is an
   object handed to it — see below. `args` without `run` is an error, not
   a silently-inert row.
@@ -177,6 +195,156 @@ from the panel's own `source`, never from the row — and this is still an
 HTTP call to the same command endpoint the panel opens with. No plugin
 code runs in the page.
 
+## Panels you can type into — `body.prompt`
+
+Every panel above is a *report*: the host runs a command and draws what
+comes back. Some tools need the other direction — a deep link is
+interesting precisely because nobody has typed it yet, and a list of
+rows has nowhere to put a value that doesn't exist.
+
+```jsonc
+{ "id": "open", "title": "Deep Links", "icon": "link",
+  "body": { "kind": "list", "source": "open", "rowAction": "fill",
+            "prompt": { "arg": "url", "placeholder": "myapp://path",
+                        "submit": "Open", "filter": true,
+                        "complete": true, "history": true } } }
+```
+
+Submitting invokes the panel's **own** `source` command with what was
+typed, under the key `arg` names:
+
+```json
+{ "command": "deeplink:open", "url": "…", "token": "…", "udid": "…",
+  "args": { "url": "myapp://profile/42" } }
+```
+
+That is exactly the path `rowAction: "run"` already takes — same body,
+same endpoint — so this adds a widget, not an execution model. Still one
+command per panel, still no plugin code in the page. The command tells
+the two cases apart by whether `args` arrived: absent means "just show
+me what's there".
+
+- **`arg`** is required. A field that submitted into nowhere would look
+  like a working control and do nothing, so a manifest without it is
+  refused at `baguette plugin validate` rather than drawn.
+- **`submit`** is the button's label; it defaults to `Run`.
+- **`placeholder`** is the greyed hint. Both are manifest text, so the
+  host sets them with `setAttribute` / `textContent` — a plugin still
+  supplies no markup.
+- **`filter`** narrows the rows already on screen as you type, matching
+  over `title` and `subtitle`. It does **not** re-run the command: a
+  command is a subprocess with a ten-second budget, so per-keystroke
+  invocations are the wrong shape, but the rows it already returned are
+  right there. Omit it and the list stays a fixed reference.
+
+  A row you have typed *past* stays visible — once the field starts with
+  a row's own text, that row keeps matching. Otherwise picking
+  `account://` and then typing the path would make the suggestion vanish
+  at the next character and leave the list reading "Nothing matches" for
+  the rest of the URL, fighting the thing it exists to help with.
+- **`complete`** finishes the word: the rest of the best candidate is
+  drawn greyed after the caret, and `Tab` — or `→` at the end of the
+  field — accepts it. A list you have to point at is slower than a bar
+  that completes. `Esc` dismisses the suggestion without clearing what
+  you typed.
+
+  Completion appends to what you typed rather than swapping the
+  candidate in, so `ACC` completes to `ACCount://hello`: the bar
+  finishes your word instead of rewriting it under the caret.
+- **`history`** remembers what you submit and puts it on `↑` / `↓`.
+  It is also the *first* completion source, ahead of the rows — having
+  opened `account://hello`, typing `acc` offers that back rather than the
+  bare `account://` scheme, because a link you actually used is a better
+  guess than one that merely exists.
+
+  Kept by the browser in `localStorage`, per panel, capped at 25. It is a
+  convenience for the person typing, not state the plugin owns: it never
+  rides the wire, and **a plugin never sees what you typed before** — only
+  what you submit to it.
+
+An empty field submits nothing rather than spending a subprocess to be
+told it was empty. What you typed survives the re-render, so tweaking a
+path and firing again doesn't mean retyping the URL.
+
+`prompt` is **additive**, which is why `apiVersion` stays 1: a baguette
+that predates it ignores the key and renders the plain list. For a
+well-written plugin that's a working panel with one affordance missing,
+not a broken one — so keep the rows useful on their own.
+
+## Panels you can tick — `body.control`
+
+A settings list needs rows that are *on* or *off*. Before this, a plugin
+wrote that into the row title — `display.py` shipped `"● Light"` /
+`"○ Dark"` — which is a plugin drawing a control glyph inside a string,
+in a page whose whole premise is that the host owns every pixel. Escaping
+made it safe, not right: the host couldn't style it, a screen reader read
+a bullet, and "which one is on" was legible only to a human eye.
+
+So the row says what's on, and the manifest says what on looks like:
+
+```jsonc
+{ "id": "display", "title": "Display & Text Size", "icon": "wrench",
+  "body": { "kind": "list", "source": "display",
+            "control": { "kind": "radio", "arg": "settings", "submit": "Apply" } } }
+```
+
+```json
+{ "ok": true, "rows": [
+  { "title": "Appearance" },
+  { "title": "Light", "state": "on",  "value": "appearance:light", "group": "appearance" },
+  { "title": "Dark",  "state": "off", "value": "appearance:dark",  "group": "appearance" }
+] }
+```
+
+- **`control.kind`** is `switch` | `checkbox` | `radio`. Purely
+  cosmetic — grouping is yours, since the panel re-renders from your own
+  answer after every submit. An unknown kind is a **parse error**, not a
+  fallback: a checkbox silently drawn as a switch would misrepresent
+  whether ticking two at once is allowed, and that's a lie about
+  behaviour rather than a substituted picture.
+- **`control.arg`** is required, and is the key the ticked values arrive
+  under.
+- **`state`** is `on` | `off`, and is what the **device** last reported —
+  never what the user has clicked since.
+- **`value`** is what a ticked row submits. Required alongside `state`;
+  a tick carrying nothing is a control you can't act on.
+- **`group`** says which options a `radio` is exclusive within. This is
+  what lets one panel ask more than one question: without it, picking
+  "Dark" would unpick the text size. Rows naming no group share one
+  implicit group. Meaningless for `switch` / `checkbox`.
+- A row with **no `state`** isn't a control — so section headings and
+  plain notes keep rendering as themselves, and an ordinary
+  `rowAction` row still works beside the ticks.
+
+### Ticking is local; submitting is one call
+
+A tick costs **no subprocess**. The panel accumulates ticks and sends
+them together when the submit button is pressed:
+
+```json
+{ "command": "a11y:display", "args": { "settings": ["appearance:dark", "contentSize:large"] } }
+```
+
+**Always an array**, including for `radio`, which yields one element —
+one shape means you write one branch rather than discovering a scalar
+case by reading this page twice. An empty array is a real instruction
+("turn all of these off"), not a no-op.
+
+The cost of batching is that between the tick and the answer, a row shows
+state the device hasn't confirmed. The host draws those rows as
+**pending** rather than letting them look settled, and the button counts
+them (`Apply (2)`). When your answer comes back, the panel rebuilds every
+tick from it — so a setting the device refused snaps back to the truth
+instead of staying stuck the way it was clicked.
+
+Relative actions don't belong in a batch. `display.py` keeps *Smaller* /
+*Larger* as `rowAction: "run"` rows, because ticking a relative change
+and applying it later would apply it from wherever the value had got to
+by then, not from where it was when you clicked.
+
+Like `prompt`, `control` is additive, so `apiVersion` stays 1 — an older
+baguette ignores it and renders a plain list.
+
 ## The rail
 
 Plugins live in their own strip on the right edge of focus mode, apart
@@ -209,11 +377,18 @@ closed set, and it is **enforced**, not documentation:
 | `location` | `POST`/`DELETE /simulators/:udid/location` |
 | `apps` | `POST /simulators/:udid/apps` — install an app |
 | `media` | `POST /simulators/:udid/media` — add photos / videos |
+| `open-url` | `POST /simulators/:udid/openurl`, `GET /simulators/:udid/schemes.json` — open a deep link, list registered schemes |
 | `simulators` | `GET /simulators.json` |
 
 `apps` and `media` are deliberately separate: one puts a picture in the
 photo library, the other puts an executable on the device. A plugin that
 seeds test images shouldn't have to be trusted to install software.
+
+`open-url` sits apart from `apps` for the same reason in the other
+direction — it only launches software that is already there. Reading and
+opening are one capability rather than two, on the `interface`
+precedent: a plugin that can open *any* URL isn't meaningfully
+restrained by hiding the list of which ones an app registered.
 
 The browser's drag-and-drop endpoint, `POST /simulators/:udid/files`,
 takes either and works out which from the file — convenient for a person
@@ -315,6 +490,23 @@ adding a `baguette.json` at its root — its *menu*:
 
 `path` is repo-relative and must stay inside the repo. The rest of the
 repo can be anything — a bakery doesn't have to be a dedicated project.
+
+### The official bakery
+
+baguette's own repo is one. Its `baguette.json` offers the plugins that
+are maintained alongside baguette but deliberately **not** bundled with
+it:
+
+```bash
+baguette bakery add tddworks/baguette
+baguette plugin install deeplink
+```
+
+The split is the point. `a11y` ships inside the binary because a fresh
+install should have something in the rail. Everything else — starting
+with [`deeplink`](deep-links.md) — is official, supported, and still
+something you choose. The rail's length stays a count of what you asked
+for.
 
 ### Installing (CLI)
 

--- a/plugins/deeplink/baguette-plugin.json
+++ b/plugins/deeplink/baguette-plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "deeplink",
+  "version": "1.2.0",
+  "apiVersion": 1,
+  "description": "Open deep links on the focused simulator, and list the URL schemes its apps answer to",
+  "icon": "link",
+  "capabilities": ["open-url"],
+  "contributes": {
+    "commands": [
+      { "id": "open", "title": "Open a deep link", "run": ["/usr/bin/python3", "bin/open.py"] }
+    ],
+    "panels": [
+      {
+        "id": "open",
+        "title": "Deep Links",
+        "icon": "link",
+        "when": "simulator.booted",
+        "body": {
+          "kind": "list",
+          "source": "open",
+          "rowAction": "fill",
+          "prompt": {
+            "arg": "url",
+            "placeholder": "myapp://path",
+            "submit": "Open",
+            "filter": true,
+            "complete": true,
+            "history": true
+          }
+        }
+      }
+    ]
+  }
+}

--- a/plugins/deeplink/bin/open.py
+++ b/plugins/deeplink/bin/open.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Deep links — type a URL, watch it land in your app.
+
+Opening the panel lists every URL scheme the device's apps registered,
+so the answer to "what can I even open here?" is on screen before you
+type anything. Each row is a `rowAction: "run"` row, so clicking one
+opens `scheme://` immediately; the field above submits to this same
+command with whatever you typed.
+
+The one thing this says that `xcrun simctl openurl` doesn't: an
+`https://` link dispatches perfectly happily and then opens **Safari**,
+because the simulator doesn't resolve associated domains the way a
+device does. Every tool performs that silently, leaving you to wonder
+whether your entitlement, your apple-app-site-association file or the
+simulator is at fault. The server names the case; this reports it.
+
+  in   BAGUETTE_URL / BAGUETTE_UDID / BAGUETTE_TOKEN in the environment,
+       plus the typed text as {"args": {"url": …}} in the JSON on stdin
+  out  one JSON object on stdout: {"ok": bool, "message"?, "rows": [...]}
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def answer(ok, rows=None, message=None):
+    out = {"ok": ok, "rows": rows or []}
+    if message:
+        out["message"] = message
+    json.dump(out, sys.stdout)
+    sys.stdout.write("\n")
+    sys.exit(0)
+
+
+def call(method, url, token):
+    """One request against the running server. Raises on failure."""
+    request = urllib.request.Request(
+        url, headers={"X-Baguette-Token": token}, method=method
+    )
+    with urllib.request.urlopen(request, timeout=8) as response:
+        return json.load(response)
+
+
+def reason(error):
+    """Why a call failed, in the server's own words where it has any.
+
+    A route that answers `{"ok":false,"error":…}` knows more about the
+    failure than we can infer from a status code — and reporting "the
+    device isn't booted" when the real problem was a typo'd URL sends
+    people looking in the wrong place entirely.
+    """
+    if isinstance(error, urllib.error.HTTPError):
+        body = error.read().decode(errors="replace")
+        try:
+            said = json.loads(body).get("error")
+        except ValueError:
+            said = None
+        if said:
+            return said
+        if error.code == 404:
+            return (
+                "This baguette has no deep-link routes — rebuild it (`make`) "
+                "and restart `baguette serve`."
+            )
+        return f"HTTP {error.code}"
+    return str(error)
+
+
+def scheme_rows(base, udid, token):
+    """One row per registered scheme, already ranked by the server."""
+    url = f"{base}/simulators/{udid}/schemes.json"
+    try:
+        found = call("GET", url, token).get("schemes") or []
+    except Exception as error:  # noqa: BLE001 - surfaced to the user verbatim
+        # The inventory is a convenience, not the feature. If it can't be
+        # read we still want the field above it to work, so this degrades
+        # to a note rather than failing the whole panel.
+        return [{
+            "title": "Could not list URL schemes",
+            "subtitle": reason(error),
+            "severity": "warn",
+        }]
+
+    if not found:
+        return [{
+            "title": "No app here registers a URL scheme",
+            "subtitle": "http:// and https:// still work — they open Safari",
+            "severity": "info",
+        }]
+
+    # Each row *fills the field* rather than opening. A bare `account://`
+    # with no path is almost never what anyone means to open — the list
+    # is a completion source, so picking one puts it in the box with the
+    # caret after it, ready for the rest of the URL.
+    return [{
+        "title": row.get("completion", ""),
+        "subtitle": row.get("app", ""),
+        "severity": "info",
+        "fill": row.get("completion", ""),
+    } for row in found]
+
+
+def opened_row(url, answered):
+    """What happened to the link we just dispatched."""
+    if answered.get("routing") == "browser":
+        return {
+            "title": f"Opened {url} in Safari",
+            "subtitle": answered.get(
+                "warning", "This lands in Safari on the simulator, not your app."
+            ),
+            "severity": "warn",
+        }
+    return {
+        "title": f"Opened {url}",
+        "subtitle": "the app that registered this scheme came to the foreground",
+        "severity": "info",
+    }
+
+
+def main():
+    base = os.environ.get("BAGUETTE_URL")
+    udid = os.environ.get("BAGUETTE_UDID")
+    token = os.environ.get("BAGUETTE_TOKEN", "")
+    if not base or not udid:
+        answer(False, message="No device focused")
+
+    # The typed text, when something was typed. Opening the panel sends
+    # none, which means "just show me what's openable".
+    try:
+        context = json.load(sys.stdin)
+    except Exception:  # noqa: BLE001 - stdin is optional
+        context = {}
+    url = ((context.get("args") or {}).get("url") or "").strip()
+
+    if not url:
+        answer(True, rows=scheme_rows(base, udid, token))
+
+    target = (
+        f"{base}/simulators/{udid}/openurl?url="
+        + urllib.parse.quote(url, safe="")
+    )
+    try:
+        answered = call("POST", target, token)
+    except Exception as error:  # noqa: BLE001 - surfaced to the user verbatim
+        answer(False, message=f"Could not open {url}: {reason(error)}")
+
+    # The result first, then the inventory again — the panel stays a
+    # control surface rather than becoming a one-line receipt.
+    answer(True, rows=[opened_row(url, answered)] + scheme_rows(base, udid, token))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/deeplink/bin/open.py
+++ b/plugins/deeplink/bin/open.py
@@ -3,9 +3,11 @@
 
 Opening the panel lists every URL scheme the device's apps registered,
 so the answer to "what can I even open here?" is on screen before you
-type anything. Each row is a `rowAction: "run"` row, so clicking one
-opens `scheme://` immediately; the field above submits to this same
-command with whatever you typed.
+type anything. Each row is a `rowAction: "fill"` row: clicking one puts
+that scheme in the field with the caret after it, ready for the path,
+rather than opening a bare scheme nobody meant. Submitting the field is
+what actually opens, and comes back to this same command as
+`args.url`.
 
 The one thing this says that `xcrun simctl openurl` doesn't: an
 `https://` link dispatches perfectly happily and then opens **Safari**,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simulator deep-link support through CLI commands, web routes, and an official deep-link plugin.
  * Added URL-scheme discovery with ranked autocomplete suggestions.
  * Expanded plugin panels with prompts, filtering, completion, history, and fill actions.
  * Added checkbox, switch, and radio controls with batched apply behavior.
* **Documentation**
  * Documented deep-link workflows, URL schemes, plugin installation, panel prompts, and controls.
* **Improvements**
  * Updated the accessibility panel to use the new control interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->