### PR TITLE
feat: size-aware stills in CaptureGallery

### DIFF
--- a/Sources/Baguette/Resources/Web/capture-gallery.js
+++ b/Sources/Baguette/Resources/Web/capture-gallery.js
@@ -266,10 +266,13 @@
       return parts.join(' · ');
     }
 
+    /** `capture-3-appstore-6.9-1290x2796.png` — the slug arrives from
+     *  CaptureSettings already filename-safe, so screenshots and
+     *  recordings can't drift apart on how they name a `16:9` file. */
     _download(entry, index) {
       const a = root.document.createElement('a');
       a.href = entry.dataUrl;
-      a.download = `capture-${index + 1}-${filenameSafe(entry.slug)}.png`;
+      a.download = `capture-${index + 1}-${entry.slug}.png`;
       a.click();
     }
   }
@@ -312,15 +315,6 @@
     return plan.drawX === 0 && plan.drawY === 0
       && plan.drawW === plan.width && plan.drawH === plan.height
       && plan.width === plan.sourceWidth && plan.height === plan.sourceHeight;
-  }
-
-  /**
-   * `16:9` is a legal size spec but an illegal Windows filename, and
-   * Finder renders a `:` in a filename as `/` — so the colon never
-   * reaches the download.
-   */
-  function filenameSafe(slug) {
-    return String(slug).replace(/[^\w.-]+/g, '-');
   }
 
   function blobToDataUrl(win, blob) {

--- a/Sources/Baguette/Resources/Web/capture-gallery.js
+++ b/Sources/Baguette/Resources/Web/capture-gallery.js
@@ -1,136 +1,345 @@
-// CaptureGallery — owns the screenshot list, fetches one-frame
-// snapshots, optionally composites with the bezel, and renders the
-// thumbnail strip. The captures array is mirrored to
-// `window.simCaptures` for any legacy code that still inspects it.
+// CaptureGallery — owns the screenshot list: fetches one-frame
+// snapshots, composites them at the size the user picked (bezel
+// optional), and renders the thumbnail strip. Each entry remembers the
+// pixels it came out at and which preset produced them, so the strip
+// and the download filename can both say so.
+//
+// Collaborators (all from Resources/Web/capture/, loaded by sim.html
+// BEFORE this file):
+//   • CaptureSettings — size + fit + background + withFrame, as one value
+//   • CaptureSize     — via `settings.plan()`; the canvas geometry
+//   • CaptureComposer — the bezel composite and the source→target paint
+//
+// A page that doesn't load them still captures — natively, unframed —
+// rather than throwing on the Screenshot button; see NativeCapture.
 //
 //   const gallery = new CaptureGallery({ udid, screen: def.screen, frameImg });
-//   await gallery.capture({ withFrame: true, naturalSize: { w, h } });
+//   await gallery.capture({ settings });          // a CaptureSettings
+//   await gallery.capture({ withFrame, naturalSize });  // legacy shape
 //   gallery.renderInto(galleryEl, countEl);
 //   gallery.clear();
 //
-// Doesn't know about WebSocket lifetime or sidebar buttons. The
-// orchestrator decides when to call `capture` and when to render.
-(function () {
+// The list is mirrored to `window.simCaptures` for legacy code that
+// still inspects it. Doesn't know about WebSocket lifetime or sidebar
+// buttons — the orchestrator decides when to capture and when to render.
+(function (root) {
   'use strict';
 
-  function CaptureGallery({ udid, screen, frameImg }) {
-    this.udid = udid;
-    this.screen = screen;        // SDK SimulatorDefinition.screen
-    this.frameImg = frameImg;
-    window.simCaptures = window.simCaptures || [];
+  class CaptureGallery {
+    /**
+     * @param {object} opts
+     * @param {string} opts.udid
+     * @param {object|null} opts.screen    SDK SimulatorDefinition.screen
+     * @param {HTMLImageElement|null} opts.frameImg  decoded bezel image
+     */
+    constructor({ udid, screen, frameImg }) {
+      this.udid = udid;
+      this.screen = screen;
+      this.frameImg = frameImg;
+      this.captures = [];
+      this._mirror();
+    }
+
+    /**
+     * Fetch a screenshot, compose it at the settings' size, push it onto
+     * the list. Returns the entry that was pushed.
+     *
+     * @param {object} [options]
+     * @param {object} [options.settings]  a CaptureSettings
+     * @param {boolean} [options.withFrame]        legacy call shape
+     * @param {{w:number,h:number}} [options.naturalSize] legacy call shape
+     */
+    async capture(options = {}) {
+      const settings = this._settingsFrom(options);
+      const withBezel = settings.withFrame && this._hasBezel();
+
+      const shot = await this._fetchScreenshot(settings, withBezel);
+      const natural = this._naturalSize(shot.image, withBezel, options.naturalSize);
+      const plan = settings.plan(natural.width, natural.height);
+      const dataUrl = this._paint(plan, settings, shot, withBezel);
+
+      return this._push({
+        dataUrl,
+        w: plan.width,
+        h: plan.height,
+        withFrame: withBezel,
+        sizeId: settings.size.id,
+        sizeLabel: settings.size.label,
+        slug: settings.slug(plan.width, plan.height),
+      });
+    }
+
+    /** Drop every capture. */
+    clear() {
+      this.captures = [];
+      this._mirror();
+    }
+
+    /** Paint the strip into `galleryEl`, the count into `countEl`. */
+    renderInto(galleryEl, countEl) {
+      if (!galleryEl) return;
+      const items = this.captures;
+      if (countEl) countEl.textContent = items.length ? `(${items.length})` : '';
+
+      galleryEl.innerHTML = '';
+      if (!items.length) {
+        galleryEl.appendChild(this._emptyNote());
+        return;
+      }
+      items.forEach((entry, i) => galleryEl.appendChild(this._thumb(entry, i)));
+    }
+
+    // ── request ────────────────────────────────────────────────
+
+    /**
+     * The screenshot as `{ image, dataUrl }` — decoded and ready to
+     * `drawImage`, plus the bytes the route actually sent, which an
+     * untouched capture can keep verbatim.
+     *
+     * The size vocabulary rides along as `?size=&fit=&background=` — the
+     * same names `baguette screenshot` takes — so a server that resizes
+     * can hand back a finished image. A server that ignores them changes
+     * nothing: the client re-plans the same size below, and re-planning a
+     * size onto an image already at that size is the identity transform.
+     *
+     * The one case that must NOT be resized server-side is a bezel
+     * composite: the screen has to arrive unpadded to paste into the
+     * cutout, and the resize then happens around the whole composite.
+     */
+    async _fetchScreenshot(settings, withBezel) {
+      const query = withBezel ? {} : settings.toQuery();
+      const params = new URLSearchParams({ t: String(Date.now()), ...query });
+      const url = `/simulators/${encodeURIComponent(this.udid)}`
+        + `/screenshot.jpg?${params.toString()}`;
+      const res = await root.fetch(url);
+      // The route answers a bad UDID or a failed grab with a JSON body,
+      // which would otherwise decode-fail as "not an image" and throw the
+      // server's own message away.
+      if (!res.ok) {
+        const detail = res.text ? await res.text().catch(() => '') : '';
+        throw new Error(`screenshot failed (${res.status}) ${detail}`.trim());
+      }
+      const dataUrl = await blobToDataUrl(root, await res.blob());
+      return { image: await decodeImage(root, dataUrl), dataUrl };
+    }
+
+    /** A bezel composite needs both the artwork and the composer. */
+    _hasBezel() {
+      const img = this.frameImg;
+      return !!(img && img.naturalWidth > 0
+        && this.screen && this.screen.viewport && this.screen.rect
+        && composerOrNull());
+    }
+
+    // ── composition ────────────────────────────────────────────
+
+    /** The composite's size before the picked size is applied. */
+    _naturalSize(image, withBezel, legacyNaturalSize) {
+      const composer = composerOrNull();
+      const size = composer
+        ? composer.compositeSize(
+          withBezel ? this.frameImg : null,
+          withBezel ? this.screen : null,
+          image
+        )
+        : { width: image.width || 0, height: image.height || 0 };
+      if (size.width > 0 && size.height > 0) return size;
+      // Defensive: an image that decoded without dimensions would give a
+      // 0 × 0 canvas — fall back to the size the stream last painted at.
+      return {
+        width: legacyNaturalSize ? legacyNaturalSize.w : 0,
+        height: legacyNaturalSize ? legacyNaturalSize.h : 0,
+      };
+    }
+
+    /**
+     * The finished capture as a data URL. A capture that neither wears a
+     * bezel nor changes shape IS the bytes the route sent, so it keeps
+     * them — re-encoding a 1290 × 2796 JPEG as lossless PNG would cost
+     * megabytes per thumbnail for an identical picture.
+     */
+    _paint(plan, settings, shot, withBezel) {
+      if (!withBezel && isIdentity(plan)
+        && settings.effectiveBackground === 'transparent') {
+        return shot.dataUrl;
+      }
+      const composer = composerOrNull();
+      if (!composer) return shot.dataUrl;
+      const canvas = root.document.createElement('canvas');
+      canvas.width = plan.width;
+      canvas.height = plan.height;
+      const ctx = canvas.getContext('2d');
+      composer.compose(ctx, plan, settings.effectiveBackground, (c) => {
+        composer.paintComposite(c, {
+          frameImg: withBezel ? this.frameImg : null,
+          screen: withBezel ? this.screen : null,
+          sourceCanvas: shot.image,
+        });
+      });
+      return canvas.toDataURL('image/png');
+    }
+
+    // ── list ───────────────────────────────────────────────────
+
+    _push(entry) {
+      const stored = { name: `Screen ${this.captures.length + 1}`, ...entry };
+      this.captures.push(stored);
+      this._mirror();
+      return stored;
+    }
+
+    /**
+     * Legacy code reads `window.simCaptures` directly. One gallery owns
+     * the mirror for as long as it lives; a new gallery (a new stream)
+     * starts a fresh strip rather than inheriting the last device's.
+     */
+    _mirror() {
+      root.simCaptures = this.captures;
+    }
+
+    /**
+     * Legacy `{ withFrame, naturalSize }` call shape → a native capture.
+     * `withFrame` defaults to OFF here, the way it always did — the
+     * CaptureSettings default (on) is for the picker, not for a caller
+     * that left the flag out.
+     */
+    _settingsFrom(options) {
+      if (options.settings) return options.settings;
+      const CaptureSettings = root.Baguette && root.Baguette._CaptureSettings;
+      return CaptureSettings
+        ? new CaptureSettings({ withFrame: !!options.withFrame })
+        : new NativeCapture(!!options.withFrame);
+    }
+
+    // ── strip DOM ──────────────────────────────────────────────
+
+    _emptyNote() {
+      const note = root.document.createElement('div');
+      note.style.cssText =
+        'color:var(--text-muted);font-size:11px;padding:8px';
+      note.textContent = 'No captures yet';
+      return note;
+    }
+
+    /**
+     * One thumbnail: the image, a dimensions chip, and the `F` badge when
+     * the bezel was composited in. Clicking downloads it — a real
+     * listener, not an `onclick` attribute with a megabyte-long data URL
+     * interpolated into it.
+     */
+    _thumb(entry, index) {
+      const doc = root.document;
+      const wrap = doc.createElement('div');
+      wrap.style.cssText = 'position:relative;width:56px;cursor:pointer';
+      wrap.title = this._thumbTitle(entry);
+
+      const img = doc.createElement('img');
+      img.src = entry.dataUrl;
+      img.alt = '';
+      img.style.cssText =
+        'width:56px;border-radius:4px;border:1px solid var(--border);display:block';
+      img.addEventListener('click', () => this._download(entry, index));
+      wrap.appendChild(img);
+
+      const dims = doc.createElement('div');
+      dims.style.cssText = 'position:absolute;left:2px;bottom:2px;'
+        + 'background:rgba(0,0,0,.6);color:white;font-size:7px;'
+        + 'padding:1px 3px;border-radius:2px;line-height:1';
+      dims.textContent = `${entry.w}×${entry.h}`;
+      wrap.appendChild(dims);
+
+      if (entry.withFrame) {
+        const badge = doc.createElement('div');
+        badge.style.cssText = 'position:absolute;top:2px;right:2px;'
+          + 'background:var(--accent,#2563EB);color:white;font-size:7px;'
+          + 'padding:1px 3px;border-radius:2px;line-height:1';
+        badge.textContent = 'F';
+        wrap.appendChild(badge);
+      }
+      return wrap;
+    }
+
+    _thumbTitle(entry) {
+      const parts = [`${entry.name} — ${entry.w} × ${entry.h}`];
+      if (entry.sizeId && entry.sizeId !== 'native') parts.push(entry.sizeLabel);
+      if (entry.withFrame) parts.push('with frame');
+      return parts.join(' · ');
+    }
+
+    _download(entry, index) {
+      const a = root.document.createElement('a');
+      a.href = entry.dataUrl;
+      a.download = `capture-${index + 1}-${filenameSafe(entry.slug)}.png`;
+      a.click();
+    }
   }
-
-  /** Fetch a screenshot, optionally composite it onto the bezel,
-   *  push onto the captures array. Returns the entry's metadata. */
-  CaptureGallery.prototype.capture = async function ({ withFrame, naturalSize }) {
-    const url = `/simulators/${encodeURIComponent(this.udid)}/screenshot.jpg?t=${Date.now()}`;
-    const blob = await (await fetch(url)).blob();
-    const screenshotUrl = await blobToDataUrl(blob);
-
-    const fimg = this.frameImg;
-    const wantFrame = withFrame && fimg && fimg.naturalWidth > 0;
-
-    if (wantFrame) {
-      const dataUrl = await composite(screenshotUrl, fimg, this.screen);
-      const fw = fimg.naturalWidth, fh = fimg.naturalHeight;
-      this._push({ dataUrl, w: fw, h: fh, withFrame: true });
-      return { withFrame: true, w: fw, h: fh };
-    }
-
-    this._push({
-      dataUrl: screenshotUrl,
-      w: naturalSize ? naturalSize.w : 0,
-      h: naturalSize ? naturalSize.h : 0,
-      withFrame: false,
-    });
-    return { withFrame: false, w: naturalSize?.w ?? 0, h: naturalSize?.h ?? 0 };
-  };
-
-  CaptureGallery.prototype._push = function (entry) {
-    window.simCaptures.push({
-      name: `Screen ${window.simCaptures.length + 1}`,
-      ...entry,
-    });
-  };
-
-  CaptureGallery.prototype.clear = function () {
-    window.simCaptures = [];
-  };
-
-  CaptureGallery.prototype.renderInto = function (galleryEl, countEl) {
-    if (!galleryEl) return;
-    const items = window.simCaptures;
-    if (countEl) countEl.textContent = items.length ? `(${items.length})` : '';
-
-    if (!items.length) {
-      galleryEl.innerHTML =
-        '<div style="color:var(--text-muted);font-size:11px;padding:8px">No captures yet</div>';
-      return;
-    }
-    galleryEl.innerHTML = items.map((c, i) => `
-      <div style="position:relative;width:56px;cursor:pointer">
-        <img src="${c.dataUrl}" alt=""
-             style="width:56px;border-radius:4px;border:1px solid var(--border);display:block"
-             onclick="(function(){const a=document.createElement('a');a.href='${c.dataUrl}';a.download='capture_${i}.png';a.click()})()">
-        ${c.withFrame
-          ? '<div style="position:absolute;top:2px;right:2px;background:var(--accent,#2563EB);color:white;font-size:7px;padding:1px 3px;border-radius:2px;line-height:1">F</div>'
-          : ''}
-      </div>`).join('');
-  };
 
   // ── helpers ──────────────────────────────────────────────────
 
-  function blobToDataUrl(blob) {
+  /**
+   * The read surface of CaptureSettings for a plain native capture —
+   * what a legacy caller gets when the capture vocabulary
+   * (Resources/Web/capture/*.js) isn't on the page. Native means every
+   * question has a trivial answer, so this stays a handful of lines
+   * rather than a second implementation of the size maths.
+   */
+  class NativeCapture {
+    constructor(withFrame) {
+      this.withFrame = withFrame;
+      this.size = { id: 'native', label: 'Native', spec: 'native', isNative: true };
+      this.effectiveBackground = 'transparent';
+    }
+
+    toQuery() { return {}; }
+
+    plan(width, height) {
+      return {
+        width, height, drawX: 0, drawY: 0, drawW: width, drawH: height,
+        sourceWidth: width, sourceHeight: height,
+      };
+    }
+
+    slug(width, height) {
+      return `${Math.round(width)}x${Math.round(height)}`;
+    }
+  }
+
+  const composerOrNull = () =>
+    (root.Baguette && root.Baguette._CaptureComposer) || null;
+
+  /** True when the plan draws the source unscaled, unmoved, unpadded. */
+  function isIdentity(plan) {
+    return plan.drawX === 0 && plan.drawY === 0
+      && plan.drawW === plan.width && plan.drawH === plan.height
+      && plan.width === plan.sourceWidth && plan.height === plan.sourceHeight;
+  }
+
+  /**
+   * `16:9` is a legal size spec but an illegal Windows filename, and
+   * Finder renders a `:` in a filename as `/` — so the colon never
+   * reaches the download.
+   */
+  function filenameSafe(slug) {
+    return String(slug).replace(/[^\w.-]+/g, '-');
+  }
+
+  function blobToDataUrl(win, blob) {
     return new Promise((resolve) => {
-      const fr = new FileReader();
+      const fr = new win.FileReader();
       fr.onloadend = () => resolve(fr.result);
       fr.readAsDataURL(blob);
     });
   }
 
-  /** Draw the bezel as background, then the screenshot on top
-   *  clipped to the inner corner radius. DeviceKit composites have
-   *  opaque dark "off" glass where the screen sits, so the screen
-   *  must go ABOVE the bezel — same Z order as Apple's Simulator
-   *  window and as BrowserRecorder. */
-  function composite(screenshotDataUrl, frameImg, screen) {
-    return new Promise((resolve) => {
-      const fw = frameImg.naturalWidth, fh = frameImg.naturalHeight;
-      const r = (screen && screen.rect) || null;
-      const ix = r ? r.x      : 0;
-      const iy = r ? r.y      : 0;
-      const sw = r ? r.width  : fw;
-      const sh = r ? r.height : fh;
-      const radius = (screen && typeof screen.clipRadius === 'number')
-        ? screen.clipRadius : 0;
-
-      const canvas = document.createElement('canvas');
-      canvas.width = fw; canvas.height = fh;
-      const ctx = canvas.getContext('2d');
-
-      const ssImg = new Image();
-      ssImg.onload = () => {
-        ctx.drawImage(frameImg, 0, 0, fw, fh);
-        ctx.save();
-        ctx.beginPath();
-        ctx.moveTo(ix + radius, iy);
-        ctx.lineTo(ix + sw - radius, iy);
-        ctx.quadraticCurveTo(ix + sw, iy, ix + sw, iy + radius);
-        ctx.lineTo(ix + sw, iy + sh - radius);
-        ctx.quadraticCurveTo(ix + sw, iy + sh, ix + sw - radius, iy + sh);
-        ctx.lineTo(ix + radius, iy + sh);
-        ctx.quadraticCurveTo(ix, iy + sh, ix, iy + sh - radius);
-        ctx.lineTo(ix, iy + radius);
-        ctx.quadraticCurveTo(ix, iy, ix + radius, iy);
-        ctx.closePath();
-        ctx.clip();
-        ctx.drawImage(ssImg, ix, iy, sw, sh);
-        ctx.restore();
-        resolve(canvas.toDataURL('image/png'));
-      };
-      ssImg.src = screenshotDataUrl;
+  /** A decoded <img>, which `drawImage` takes exactly like a canvas. */
+  function decodeImage(win, dataUrl) {
+    return new Promise((resolve, reject) => {
+      const img = new win.Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error('screenshot decode failed'));
+      img.src = dataUrl;
     });
   }
 
-  window.CaptureGallery = CaptureGallery;
-})();
+  root.CaptureGallery = CaptureGallery;
+})(window);

--- a/Tests/Web/capture-gallery.test.js
+++ b/Tests/Web/capture-gallery.test.js
@@ -1,0 +1,356 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { loadBrowserModules } = require('./helpers/load-browser-module.js');
+
+const WEB = path.join(__dirname, '..', '..', 'Sources', 'Baguette', 'Resources', 'Web');
+
+// ── fake browser ─────────────────────────────────────────────
+// CaptureGallery is the one capture surface that talks to the network
+// AND the DOM, so the fake has to cover both: `fetch` + `FileReader` +
+// `Image` for the screenshot round-trip, `document.createElement` for
+// the canvas it composites on and the thumbnail strip it renders.
+// Everything records state (URLs asked for, canvas dimensions, anchors
+// clicked) so the tests assert on values rather than on call order.
+
+class FakeNode {
+  constructor(tag) {
+    this.tagName = tag;
+    this.style = {};
+    this.children = [];
+    this.textContent = '';
+    this.title = '';
+    this._listeners = new Map();
+  }
+
+  appendChild(child) { this.children.push(child); return child; }
+
+  set innerHTML(_) { this.children = []; }
+
+  get innerHTML() { return ''; }
+
+  addEventListener(type, fn) {
+    if (!this._listeners.has(type)) this._listeners.set(type, new Set());
+    this._listeners.get(type).add(fn);
+  }
+
+  fire(type, event = {}) {
+    for (const fn of this._listeners.get(type) || []) fn(event);
+  }
+}
+
+function fakeWindow({ shot = { width: 1290, height: 2796 }, response } = {}) {
+  const state = { urls: [], canvases: [], anchors: [], shot };
+
+  const document = {
+    createElement(tag) {
+      if (tag === 'canvas') {
+        const canvas = {
+          width: 0,
+          height: 0,
+          getContext: () => ({
+            fillStyle: '',
+            save() {}, restore() {},
+            translate() {}, scale() {},
+            clearRect() {}, fillRect() {},
+            drawImage() {},
+            beginPath() {}, moveTo() {}, lineTo() {},
+            quadraticCurveTo() {}, closePath() {}, clip() {},
+          }),
+          toDataURL: (type) => `data:${type};base64,W${canvas.width}H${canvas.height}`,
+        };
+        state.canvases.push(canvas);
+        return canvas;
+      }
+      if (tag === 'a') {
+        const a = { href: '', download: '', clicked: 0, click() { this.clicked += 1; } };
+        state.anchors.push(a);
+        return a;
+      }
+      return new FakeNode(tag);
+    },
+  };
+
+  const window = {
+    document,
+    state,
+    fetch(url) {
+      state.urls.push(url);
+      return Promise.resolve(response || {
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve({ tag: 'blob' }),
+      });
+    },
+    FileReader: class {
+      readAsDataURL() {
+        this.result = 'data:image/jpeg;base64,SHOT';
+        queueMicrotask(() => this.onloadend && this.onloadend());
+      }
+    },
+    Image: class {
+      set src(value) {
+        this._src = value;
+        this.width = state.shot.width;
+        this.height = state.shot.height;
+        this.naturalWidth = state.shot.width;
+        this.naturalHeight = state.shot.height;
+        queueMicrotask(() => this.onload && this.onload());
+      }
+
+      get src() { return this._src; }
+    },
+  };
+  return window;
+}
+
+const SCREEN = {
+  viewport: { width: 1400, height: 2900 },
+  rect: { x: 55, y: 52, width: 1290, height: 2796 },
+  clipRadius: 130,
+};
+
+const BEZEL = { naturalWidth: 1400, naturalHeight: 2900, tag: 'bezel' };
+
+function galleryFor({
+  screen = SCREEN, frameImg = BEZEL, shot, response, vocabulary = true,
+} = {}) {
+  const window = fakeWindow({ shot, response });
+  loadBrowserModules([
+    ...(vocabulary ? [
+      path.join(WEB, 'capture', 'capture-size.js'),
+      path.join(WEB, 'capture', 'capture-settings.js'),
+      path.join(WEB, 'capture', 'capture-composer.js'),
+    ] : []),
+    path.join(WEB, 'capture-gallery.js'),
+  ], window);
+  const CaptureSettings = window.Baguette && window.Baguette._CaptureSettings;
+  const gallery = new window.CaptureGallery({ udid: 'UD-1', screen, frameImg });
+  return { window, gallery, CaptureSettings, state: window.state };
+}
+
+const paramsOf = (url) => Object.fromEntries(new URL(url, 'http://x').searchParams);
+
+// ── request ──────────────────────────────────────────────────
+
+test('asks the screenshot route for the picked size, fit and background', async () => {
+  const { gallery, CaptureSettings, state } = galleryFor({ frameImg: null });
+  await gallery.capture({
+    settings: new CaptureSettings({
+      size: 'appstore-6.9', fit: 'cover', background: '#101010', withFrame: false,
+    }),
+  });
+
+  const q = paramsOf(state.urls[0]);
+  assert.equal(q.size, 'appstore-6.9');
+  assert.equal(q.fit, 'cover');
+  assert.equal(q.background, '#101010');
+});
+
+test('asks for a plain screenshot at native size', async () => {
+  const { gallery, CaptureSettings, state } = galleryFor({ frameImg: null });
+  await gallery.capture({ settings: new CaptureSettings({ withFrame: false }) });
+
+  const q = paramsOf(state.urls[0]);
+  assert.equal(q.size, undefined);
+  assert.equal(q.fit, undefined);
+});
+
+test('asks for the raw screen when the bezel is composited in', async () => {
+  const { gallery, CaptureSettings, state } = galleryFor();
+  await gallery.capture({
+    settings: new CaptureSettings({ size: 'square', withFrame: true }),
+  });
+
+  // The bezel composite needs an unpadded screen to paste into the
+  // cutout — the resize happens after, around the whole composite.
+  const q = paramsOf(state.urls[0]);
+  assert.equal(q.size, undefined);
+});
+
+// ── canvas geometry ──────────────────────────────────────────
+
+test('sizes a framed capture to the preset, not to the bezel', async () => {
+  const { gallery, CaptureSettings, state } = galleryFor();
+  const entry = await gallery.capture({
+    settings: new CaptureSettings({ size: 'appstore-6.9', withFrame: true }),
+  });
+
+  assert.deepEqual(
+    { w: state.canvases[0].width, h: state.canvases[0].height },
+    { w: 1290, h: 2796 }
+  );
+  assert.deepEqual({ w: entry.w, h: entry.h }, { w: 1290, h: 2796 });
+});
+
+test('grows a ratio size around the bezel viewport', async () => {
+  const { gallery, CaptureSettings } = galleryFor();
+  const entry = await gallery.capture({
+    settings: new CaptureSettings({ size: 'square', withFrame: true }),
+  });
+
+  assert.deepEqual({ w: entry.w, h: entry.h }, { w: 2900, h: 2900 });
+});
+
+test('grows a ratio size around the raw screenshot when unframed', async () => {
+  const { gallery, CaptureSettings } = galleryFor({ frameImg: null });
+  const entry = await gallery.capture({
+    settings: new CaptureSettings({ size: 'square', withFrame: false }),
+  });
+
+  assert.deepEqual({ w: entry.w, h: entry.h }, { w: 2796, h: 2796 });
+});
+
+test('falls back to the screenshot size when there is no bezel image', async () => {
+  const { gallery, CaptureSettings } = galleryFor({ frameImg: null });
+  const entry = await gallery.capture({
+    settings: new CaptureSettings({ withFrame: true }),
+  });
+
+  assert.equal(entry.withFrame, false);
+  assert.deepEqual({ w: entry.w, h: entry.h }, { w: 1290, h: 2796 });
+});
+
+// ── entry metadata ───────────────────────────────────────────
+
+test('records the resolved pixels and the preset label on the entry', async () => {
+  const { window, gallery, CaptureSettings } = galleryFor();
+  await gallery.capture({
+    settings: new CaptureSettings({ size: 'appstore-6.9', withFrame: true }),
+  });
+
+  const entry = window.simCaptures[0];
+  assert.equal(entry.name, 'Screen 1');
+  assert.equal(entry.sizeId, 'appstore-6.9');
+  assert.equal(entry.sizeLabel, 'App Store 6.9″');
+  assert.equal(entry.w, 1290);
+  assert.equal(entry.h, 2796);
+  assert.equal(entry.withFrame, true);
+  assert.equal(entry.dataUrl, 'data:image/png;base64,W1290H2796');
+});
+
+test('keeps the server image when nothing needs re-drawing', async () => {
+  const { gallery, CaptureSettings, state } = galleryFor({ frameImg: null });
+  const entry = await gallery.capture({
+    settings: new CaptureSettings({ withFrame: false }),
+  });
+
+  // A native, unframed capture is exactly what the route already sent —
+  // re-encoding it as PNG would multiply the retained bytes for nothing.
+  assert.equal(entry.dataUrl, 'data:image/jpeg;base64,SHOT');
+  assert.equal(state.canvases.length, 0);
+});
+
+test('reports the route error instead of a decode failure', async () => {
+  const { gallery, CaptureSettings } = galleryFor({
+    frameImg: null,
+    response: {
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('{"error":"unknown udid"}'),
+    },
+  });
+
+  await assert.rejects(
+    gallery.capture({ settings: new CaptureSettings({ withFrame: false }) }),
+    /404.*unknown udid/s
+  );
+});
+
+test('captures natively when the capture vocabulary is not on the page', async () => {
+  const { gallery, window } = galleryFor({ vocabulary: false });
+  const entry = await gallery.capture({ withFrame: true });
+
+  assert.deepEqual({ w: entry.w, h: entry.h }, { w: 1290, h: 2796 });
+  assert.equal(entry.withFrame, false);
+  assert.equal(entry.dataUrl, 'data:image/jpeg;base64,SHOT');
+  assert.equal(window.simCaptures.length, 1);
+});
+
+test('the legacy call shape composites no bezel unless it asks for one', async () => {
+  const { gallery } = galleryFor();
+  const entry = await gallery.capture({ naturalSize: { w: 1290, h: 2796 } });
+
+  assert.equal(entry.withFrame, false);
+});
+
+test('keeps the legacy withFrame / naturalSize call shape working', async () => {
+  const { window, gallery } = galleryFor({ frameImg: null });
+  const entry = await gallery.capture({
+    withFrame: false, naturalSize: { w: 1290, h: 2796 },
+  });
+
+  assert.deepEqual({ w: entry.w, h: entry.h }, { w: 1290, h: 2796 });
+  assert.equal(window.simCaptures.length, 1);
+});
+
+// ── strip ────────────────────────────────────────────────────
+
+test('shows the dimensions and the frame badge on the thumbnail', async () => {
+  const { window, gallery, CaptureSettings } = galleryFor();
+  await gallery.capture({
+    settings: new CaptureSettings({ size: 'appstore-6.9', withFrame: true }),
+  });
+
+  const strip = window.document.createElement('div');
+  const count = window.document.createElement('span');
+  gallery.renderInto(strip, count);
+
+  assert.equal(count.textContent, '(1)');
+  assert.equal(strip.children.length, 1);
+  const thumb = strip.children[0];
+  assert.match(thumb.title, /1290 × 2796/);
+  assert.match(thumb.title, /App Store 6.9/);
+  assert.equal(thumb.children.some((c) => c.textContent === 'F'), true);
+  assert.equal(thumb.children.some((c) => c.textContent === '1290×2796'), true);
+});
+
+test('names the download after the capture number, preset and pixels', async () => {
+  const { window, gallery, CaptureSettings, state } = galleryFor();
+  const settings = new CaptureSettings({ size: 'appstore-6.9', withFrame: true });
+  await gallery.capture({ settings });
+  await gallery.capture({ settings });
+  await gallery.capture({ settings });
+
+  const strip = window.document.createElement('div');
+  gallery.renderInto(strip, null);
+  strip.children[2].children[0].fire('click');
+
+  const a = state.anchors[state.anchors.length - 1];
+  assert.equal(a.download, 'capture-3-appstore-6.9-1290x2796.png');
+  assert.equal(a.href, 'data:image/png;base64,W1290H2796');
+  assert.equal(a.clicked, 1);
+});
+
+test('keeps a ratio preset filename-safe', async () => {
+  const { window, gallery, CaptureSettings, state } = galleryFor({ frameImg: null });
+  await gallery.capture({
+    settings: new CaptureSettings({ size: '16:9', withFrame: false }),
+  });
+
+  const strip = window.document.createElement('div');
+  gallery.renderInto(strip, null);
+  strip.children[0].children[0].fire('click');
+
+  // `16:9` is a legal spec but an illegal filename on Windows, and
+  // Finder shows a `:` as `/` — the colon can't reach the download.
+  const a = state.anchors[state.anchors.length - 1];
+  assert.equal(a.download, 'capture-1-16-9-4971x2796.png');
+});
+
+test('clear empties the strip and the legacy window.simCaptures mirror', async () => {
+  const { window, gallery, CaptureSettings } = galleryFor();
+  await gallery.capture({ settings: new CaptureSettings({ withFrame: true }) });
+  gallery.clear();
+
+  assert.deepEqual(window.simCaptures, []);
+
+  const strip = window.document.createElement('div');
+  const count = window.document.createElement('span');
+  gallery.renderInto(strip, count);
+  assert.equal(count.textContent, '');
+  assert.equal(strip.children.length, 1);
+  assert.match(strip.children[0].textContent, /No captures yet/);
+});

--- a/Tests/Web/capture-gallery.test.js
+++ b/Tests/Web/capture-gallery.test.js
@@ -203,6 +203,18 @@ test('grows a ratio size around the raw screenshot when unframed', async () => {
   assert.deepEqual({ w: entry.w, h: entry.h }, { w: 2796, h: 2796 });
 });
 
+test('captures the bare bezel when the screenshot decodes to nothing', async () => {
+  const { gallery, CaptureSettings } = galleryFor({ shot: { width: 0, height: 0 } });
+  const entry = await gallery.capture({
+    settings: new CaptureSettings({ withFrame: true }),
+  });
+
+  // Nothing to paste into the cutout, but the device frame is loaded and
+  // worth having — an empty PNG would be the worse answer.
+  assert.deepEqual({ w: entry.w, h: entry.h }, { w: 1400, h: 2900 });
+  assert.equal(entry.dataUrl, 'data:image/png;base64,W1400H2900');
+});
+
 test('falls back to the screenshot size when there is no bezel image', async () => {
   const { gallery, CaptureSettings } = galleryFor({ frameImg: null });
   const entry = await gallery.capture({
@@ -334,8 +346,9 @@ test('keeps a ratio preset filename-safe', async () => {
   gallery.renderInto(strip, null);
   strip.children[0].children[0].fire('click');
 
-  // `16:9` is a legal spec but an illegal filename on Windows, and
-  // Finder shows a `:` as `/` — the colon can't reach the download.
+  // CaptureSettings.slug() sanitises the `:` out of a ratio spec; this
+  // guards that the strip's download name inherits that, rather than
+  // the gallery re-deriving a name of its own.
   const a = state.anchors[state.anchors.length - 1];
   assert.equal(a.download, 'capture-1-16-9-4971x2796.png');
 });


### PR DESCRIPTION
## What

`CaptureGallery` now speaks the shared capture-size vocabulary from `Resources/Web/capture/`, so "App Store 6.9″" / "square" / "16:9" means the same thing for a screenshot as it does for a recording.

- `capture({ settings })` takes a `CaptureSettings`; the legacy `{ withFrame, naturalSize }` shape still works (native size, bezel off unless asked) so the existing `sim-stream.js` call site keeps working untouched.
- The settings ride to the route as `?size=&fit=&background=` — the same names `baguette screenshot` takes. Server-side support for those params is landing separately; a server that ignores them costs nothing, because re-planning a size onto an image already at that size is the identity transform.
- A bezel composite deliberately asks for the **raw** screen: the cutout needs an unpadded screenshot, and the resize happens around the finished composite.
- The composite goes through `CaptureComposer.paintComposite` + `compose`; the duplicated rounded-rect clip is deleted from this file.
- Each entry records the resolved `w`/`h`, the preset id and its label. The thumbnail shows the dimensions beside the `F` badge and spells both out in `title`.
- Downloads are `capture-3-appstore-6.9-1290x2796.png` via `settings.slug()`, filename-sanitised so a `16:9` spec can't put a colon in the name. The click is a real `addEventListener` now, not an `onclick` attribute with the data URL interpolated into it.
- Converted from prototype style to `class`.

Two robustness fixes found in review while here: an unframed, unresized capture keeps the route's own JPEG instead of re-encoding megabytes of lossless PNG per thumbnail, and a non-ok response reports the route's status and body instead of surfacing as "decode failed".

## Testing

`Tests/Web/capture-gallery.test.js` is new — the module had no test. 17 cases over the query params (both branches), the canvas geometry per preset, the no-bezel fallback, entry metadata, the thumbnail, the download filename, and `clear()`. `make test-web`: 235 passing, 0 failing.

E2E against a live `baguette serve` + booted iPhone 17 Pro Max (real route, real JPEG, real dimensions): native 1320×2868 (kept verbatim, no re-encode), square 2868×2868, appstore-6.9 1290×2796, 16:9 5099×2868.

## Note for the coordinator

`sim.html` does not load `/capture/*.js` yet — that belongs to another unit. This file degrades to a plain native capture rather than throwing if the vocabulary isn't on the page, so the Screenshot button keeps working either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a flexible capture workflow supporting current and legacy settings.
  * Added optional device bezels, configurable image sizing, capture metadata, and native image preservation.
  * Added thumbnails with dimensions, frame indicators, titles, and downloads.
  * Added safer, sanitized download filenames and support for pages without optional capture features.

* **Bug Fixes**
  * Improved handling of failed capture requests and fallback rendering.
  * Added support for clearing captured images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->