### PR TITLE
feat: size-aware recording and a bezel-less 3D mode

### DIFF
--- a/Sources/Baguette/Resources/Web/recorder.js
+++ b/Sources/Baguette/Resources/Web/recorder.js
@@ -115,9 +115,13 @@
     },
 
     paintComposite(ctx, { frameImg, screen, sourceCanvas, onOverlay }) {
-      if (!sourceCanvas || !(sourceCanvas.width > 0)) return;
       const useBezel = frameImg && frameImg.naturalWidth > 0
         && screen && screen.viewport && screen.rect;
+      // Record pressed before the stream's first decoded frame is
+      // ordinary; the bezel is already loaded and worth painting on its
+      // own. Mirrors CaptureComposer.paintComposite exactly.
+      const hasContent = !!sourceCanvas && sourceCanvas.width > 0;
+      if (!useBezel && !hasContent) return;
       if (!useBezel) {
         const rect = {
           x: 0, y: 0, width: sourceCanvas.width, height: sourceCanvas.height,
@@ -131,6 +135,7 @@
       const vp = screen.viewport;
       const rect = screen.rect;
       ctx.drawImage(frameImg, 0, 0, vp.width, vp.height);
+      if (!hasContent) return;
       ctx.save();
       NativeComposer.roundRectPath(
         ctx, rect.x, rect.y, rect.width, rect.height, screen.clipRadius || 0

--- a/Sources/Baguette/Resources/Web/recorder.js
+++ b/Sources/Baguette/Resources/Web/recorder.js
@@ -1,26 +1,50 @@
-// BrowserRecorder — record the live view (bezel + screen + pinch HUD)
-// to a WebM/MP4 file. Spins up a compose canvas only while recording;
-// idles cost zero. Reuses what's already in the page:
+// BrowserRecorder — record the live view to a WebM/MP4 file at whatever
+// output size the user picked. Spins up a compose canvas only while
+// recording; idling costs zero. Reuses what's already in the page:
 //
+//   • canvas       — the live decoded canvas StreamSession is painting
+//                    (the 3D view hands its own canvas here instead)
 //   • frameImg     — the bezel <img> the Baguette SDK loaded
 //   • screen       — the SDK `SimulatorDefinition.screen` block
 //                    (`viewport`, `rect`, `clipRadius`). Used for the
 //                    bezel cutout coords + corner radius.
-//   • sourceCanvas — the live decoded canvas StreamSession is painting
 //   • overlayHost  — PinchOverlay's DOM container (we read positions
 //                    out of it each frame, no caching)
 //
-// On Stop the compose canvas, rAF loop, and MediaRecorder are torn
-// down; the only artifact that survives is the Blob URL for the
-// download link.
+// Sizing, fit, background and bezel-compositing come from the shared
+// capture vocabulary (capture/capture-size.js, capture-settings.js,
+// capture-composer.js) — the same value a screenshot is taken through, so
+// "App Store 6.9″" means one thing across the whole app.
 //
-//   const rec = new BrowserRecorder({
-//     canvas, frameImg, screen: def.screen, overlayHost, fps: 60,
+// Options — ONE preferred shape, `settings`, with loose fallbacks so the
+// original call sites keep working untouched:
+//
+//   new BrowserRecorder({
+//     canvas, frameImg, screen, overlayHost,   // what to paint
+//     settings,        // a CaptureSettings — the preferred way to size
+//     captureSize,     // fallback: a CaptureSize or a spec ('square')
+//     fit, background, // fallback: only read when `settings` is absent
+//     bezel,           // false → the source already IS the device (3D)
+//     fps, bitrate,
 //   });
 //   rec.start();
 //   const artifact = await rec.stop();
 //   //   { url, blob, filename, mimeType, durationSeconds, bytes }
 //   rec.cancel();
+//
+// Omit everything but `canvas` and you get the historical behaviour:
+// native size, bezel composited, no background mat. `bezel` defaults to
+// the settings' `withFrame`, so a picker that turns the frame off turns
+// it off here too; passing `bezel` explicitly wins over both.
+//
+// The capture vocabulary is an ENHANCEMENT, not a hard dependency: on a
+// page that doesn't load capture/*.js the recorder warns once and records
+// exactly as it always did — natural composite size, bezel on, no resize.
+// Requesting a size there is ignored rather than fatal.
+//
+// On Stop the compose canvas, rAF loop, and MediaRecorder are torn
+// down; the only artifact that survives is the Blob URL for the
+// download link.
 (function () {
   'use strict';
 
@@ -34,10 +58,17 @@
     'video/webm',
   ];
 
+  // Last-resort composite size: neither a decoded bezel nor a painted
+  // source canvas to measure yet. An iPhone-ish portrait canvas keeps
+  // `captureStream` valid until the first frame lands, at which point the
+  // plan is recomputed against the real source (see `_paint`).
+  const FALLBACK_SIZE = { width: 1170, height: 2532 };
+
   function pickMimeType() {
-    if (typeof MediaRecorder === 'undefined') return '';
+    if (typeof window.MediaRecorder === 'undefined') return '';
+    const MR = window.MediaRecorder;
     for (const m of PREFERRED_MIME_TYPES) {
-      if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported(m)) return m;
+      if (MR.isTypeSupported && MR.isTypeSupported(m)) return m;
     }
     return '';
   }
@@ -46,224 +77,406 @@
     return mime && mime.startsWith('video/mp4') ? 'mp4' : 'webm';
   }
 
-  function BrowserRecorder(opts) {
-    opts = opts || {};
-    this.sourceCanvas = opts.canvas;
-    this.frameImg    = opts.frameImg    || null;
-    this.screen      = opts.screen      || null;     // SDK SimulatorDefinition.screen
-    this.overlayHost = opts.overlayHost || null;
-    this.fps         = opts.fps || 60;
-    // Visible-quality knob. Default 12 Mbps — well above the browser's
-    // built-in (~2.5 Mbps) without exploding file size; H.264 at this
-    // bitrate is artifact-free for an iPhone-sized canvas. Override via
-    // `bitrate` for archive-grade or transport-sized recordings.
-    this.bitrate     = opts.bitrate || 12_000_000;
+  let warnedAboutVocabulary = false;
 
-    this.mimeType = pickMimeType();
-    this.compose = null;
-    this.composeCtx = null;
-    this.rafId = null;
-    this.recorder = null;
-    this.chunks = [];
-    this.startedAt = 0;
-    this.endedAt = 0;
-  }
-
-  /// True iff `MediaRecorder` exists. Older browsers (or strict CSP
-  /// configs without MediaRecorder) hide the Record button entirely.
-  BrowserRecorder.isAvailable = function () {
-    return typeof MediaRecorder !== 'undefined';
-  };
-
-  BrowserRecorder.prototype.start = function () {
-    if (!this.sourceCanvas) throw new Error('canvas is required');
-    if (!BrowserRecorder.isAvailable()) {
-      throw new Error('MediaRecorder not available in this browser');
-    }
-
-    // Compose canvas size: bezel composite when available, source-canvas
-    // size otherwise. The compose canvas is the recording's full output
-    // — captureStream samples it at fps.
-    const size = composeSize(this.frameImg, this.screen, this.sourceCanvas);
-    this.compose = document.createElement('canvas');
-    this.compose.width  = size.w;
-    this.compose.height = size.h;
-    this.composeCtx = this.compose.getContext('2d');
-    // High-quality scaling matters when the live stream is below the
-    // bezel composite's native resolution (e.g. scale=2 or scale=3 in
-    // the streaming sidebar). Default `'low'` produces visible nearest-
-    // neighbour stair-stepping; `'high'` invokes the browser's better
-    // resampler (Lanczos / bicubic depending on engine).
-    this.composeCtx.imageSmoothingEnabled = true;
-    this.composeCtx.imageSmoothingQuality = 'high';
-
-    this._startPaintLoop();
-
-    const stream = this.compose.captureStream(this.fps);
-    const recorderOpts = {};
-    if (this.mimeType) recorderOpts.mimeType = this.mimeType;
-    if (this.bitrate)  recorderOpts.videoBitsPerSecond = this.bitrate;
-    this.recorder = new MediaRecorder(stream, recorderOpts);
-    this.recorder.ondataavailable = (e) => {
-      if (e.data && e.data.size > 0) this.chunks.push(e.data);
-    };
-    this.recorder.start(1000);
-    this.startedAt = Date.now();
-  };
-
-  BrowserRecorder.prototype._startPaintLoop = function () {
-    const tick = () => {
-      this._paint();
-      this.rafId = requestAnimationFrame(tick);
-    };
-    this.rafId = requestAnimationFrame(tick);
-  };
-
-  // Per-frame paint: bezel → screen (clipped) → pinch dots. Each layer
-  // is drawn from data already on the page; nothing is fetched or
-  // computed beyond the clip path. ~1 ms on Apple Silicon for an iPhone-
-  // sized composite.
-  BrowserRecorder.prototype._paint = function () {
-    const ctx = this.composeCtx;
-    const cw = this.compose.width;
-    const ch = this.compose.height;
-    ctx.clearRect(0, 0, cw, ch);
-
-    const useBezel = this.frameImg && this.frameImg.naturalWidth > 0
-                  && this.screen && this.screen.viewport && this.screen.rect;
-
-    if (useBezel) {
-      const s = this.screen.rect;
-      const r = this.screen.clipRadius || 0;
-
-      // 1. Bezel as background. DeviceKit composites render the screen
-      //    area as opaque dark "off" glass meant to sit UNDER the live
-      //    screen — so bezel goes first, screen on top.
-      ctx.drawImage(this.frameImg, 0, 0, cw, ch);
-
-      // 2. Screen content, clipped to the inner corner radius so the
-      //    rounded screen corners match the bezel cutout exactly.
-      if (this.sourceCanvas.width > 0) {
-        ctx.save();
-        roundRectPath(ctx, s.x, s.y, s.width, s.height, r);
-        ctx.clip();
-        ctx.drawImage(this.sourceCanvas, s.x, s.y, s.width, s.height);
-        // 3. Pinch HUD on top, still inside the clip so dots near the
-        //    rounded corners get cropped naturally.
-        this._paintOverlayDots(ctx, s);
-        ctx.restore();
+  /// The shared capture vocabulary, resolved late so recorder.js can be
+  /// loaded in any order relative to capture/*.js — and `null` (with one
+  /// warning for the whole page) when the page doesn't load it at all.
+  function vocabulary() {
+    const ns = window.Baguette || {};
+    if (ns._CaptureSize && ns._CaptureSettings && ns._CaptureComposer) return ns;
+    if (!warnedAboutVocabulary) {
+      warnedAboutVocabulary = true;
+      const log = window.console;
+      if (log && log.warn) {
+        log.warn(
+          'BrowserRecorder: capture/capture-size.js, capture/capture-settings.js '
+          + 'and capture/capture-composer.js are not loaded — recording at the '
+          + 'natural composite size; output-size options are ignored.'
+        );
       }
-    } else if (this.sourceCanvas.width > 0) {
-      // No bezel layout — fall through to bare-screen recording.
-      ctx.drawImage(this.sourceCanvas, 0, 0, cw, ch);
-      this._paintOverlayDots(ctx, { x: 0, y: 0, width: cw, height: ch });
     }
-  };
-
-  // Reads the current DOM positions of PinchOverlay's dots and paints
-  // matching circles onto the compose canvas. PinchOverlay positions
-  // its children at host-local pixels; we map those back to composite
-  // coords using the host's bounding box. No state cached anywhere —
-  // each tick re-reads what the live overlay is showing.
-  BrowserRecorder.prototype._paintOverlayDots = function (ctx, screenRect) {
-    const host = this.overlayHost;
-    if (!host || host.children.length === 0) return;
-    const hostRect = host.getBoundingClientRect();
-    if (hostRect.width === 0 || hostRect.height === 0) return;
-    const sx = screenRect.width  / hostRect.width;
-    const sy = screenRect.height / hostRect.height;
-
-    // PinchOverlay dot styling (sim-input.js): 36px diameter, indigo
-    // fill+stroke, soft shadow. Mirror it on the canvas — same look,
-    // no shadow (Canvas2D shadows are slow and the recording doesn't
-    // need them to read clearly).
-    const radiusComposite = 18 * Math.max(sx, sy);   // matches DOM 36px diameter
-    ctx.save();
-    ctx.fillStyle   = 'rgba(99, 102, 241, 0.35)';
-    ctx.strokeStyle = 'rgba(99, 102, 241, 0.9)';
-    ctx.lineWidth   = 2 * Math.max(sx, sy);
-    for (const dot of host.children) {
-      const left = parseFloat(dot.style.left);
-      const top  = parseFloat(dot.style.top);
-      if (!isFinite(left) || !isFinite(top)) continue;
-      const cx = screenRect.x + left * sx;
-      const cy = screenRect.y + top  * sy;
-      ctx.beginPath();
-      ctx.arc(cx, cy, radiusComposite, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.stroke();
-    }
-    ctx.restore();
-  };
-
-  /// Stop the recorder, await the final chunk, return an artifact ready
-  /// to drop into a `<a download>` link. The Blob URL stays valid for
-  /// the life of the page; callers free it via URL.revokeObjectURL when
-  /// they're done with the link.
-  BrowserRecorder.prototype.stop = async function () {
-    if (!this.recorder) throw new Error('not started');
-    const recorder = this.recorder;
-    const stopped = new Promise((resolve) => { recorder.onstop = resolve; });
-    try { recorder.requestData(); } catch { /* not all impls expose this */ }
-    recorder.stop();
-    await stopped;
-    this.endedAt = Date.now();
-    if (this.rafId) { cancelAnimationFrame(this.rafId); this.rafId = null; }
-    this.recorder = null;
-    this.compose = null;
-    this.composeCtx = null;
-
-    const blob = new Blob(this.chunks, { type: this.mimeType || 'video/webm' });
-    this.chunks = [];
-    const stamp = new Date(this.startedAt)
-      .toISOString().replace(/[:.]/g, '-').replace('Z', '');
-    return {
-      blob,
-      url: URL.createObjectURL(blob),
-      filename: `simulator-${stamp}.${extFor(this.mimeType)}`,
-      mimeType: this.mimeType,
-      durationSeconds: (this.endedAt - this.startedAt) / 1000,
-      bytes: blob.size,
-    };
-  };
-
-  /// Discard the in-flight recording. Used when the live stream
-  /// disconnects mid-record or the user navigates away.
-  BrowserRecorder.prototype.cancel = function () {
-    if (this.recorder && this.recorder.state !== 'inactive') {
-      try { this.recorder.stop(); } catch { /* ignore */ }
-    }
-    if (this.rafId) { cancelAnimationFrame(this.rafId); this.rafId = null; }
-    this.recorder = null;
-    this.compose = null;
-    this.composeCtx = null;
-    this.chunks = [];
-  };
-
-  // ── helpers ──────────────────────────────────────────────────
-
-  function composeSize(frameImg, screen, sourceCanvas) {
-    if (frameImg && frameImg.naturalWidth > 0 && screen && screen.viewport) {
-      return { w: screen.viewport.width, h: screen.viewport.height };
-    }
-    if (sourceCanvas && sourceCanvas.width > 0) {
-      return { w: sourceCanvas.width, h: sourceCanvas.height };
-    }
-    return { w: 1170, h: 2532 };
+    return null;
   }
 
-  function roundRectPath(ctx, x, y, w, h, r) {
-    ctx.beginPath();
-    ctx.moveTo(x + r, y);
-    ctx.lineTo(x + w - r, y);
-    ctx.quadraticCurveTo(x + w, y, x + w, y + r);
-    ctx.lineTo(x + w, y + h - r);
-    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
-    ctx.lineTo(x + r, y + h);
-    ctx.quadraticCurveTo(x, y + h, x, y + h - r);
-    ctx.lineTo(x, y + r);
-    ctx.quadraticCurveTo(x, y, x + r, y);
-    ctx.closePath();
+  // The composite painter used when the capture vocabulary isn't on the
+  // page. Same static surface as CaptureComposer so `_paint` stays one
+  // code path; it just can't do anything but 1:1. Delete on sight once
+  // every page carries the capture scripts.
+  const NativeComposer = {
+    compositeSize(frameImg, screen, sourceCanvas) {
+      if (frameImg && frameImg.naturalWidth > 0 && screen && screen.viewport) {
+        return { width: screen.viewport.width, height: screen.viewport.height };
+      }
+      if (sourceCanvas && sourceCanvas.width > 0) {
+        return { width: sourceCanvas.width, height: sourceCanvas.height };
+      }
+      return { width: 0, height: 0 };
+    },
+
+    paintComposite(ctx, { frameImg, screen, sourceCanvas, onOverlay }) {
+      if (!sourceCanvas || !(sourceCanvas.width > 0)) return;
+      const useBezel = frameImg && frameImg.naturalWidth > 0
+        && screen && screen.viewport && screen.rect;
+      if (!useBezel) {
+        const rect = {
+          x: 0, y: 0, width: sourceCanvas.width, height: sourceCanvas.height,
+        };
+        ctx.drawImage(sourceCanvas, rect.x, rect.y, rect.width, rect.height);
+        if (onOverlay) onOverlay(ctx, rect);
+        return;
+      }
+      // Bezel under, screen over: DeviceKit composites paint opaque dark
+      // "off glass" inside the cutout, authored to sit UNDER live content.
+      const vp = screen.viewport;
+      const rect = screen.rect;
+      ctx.drawImage(frameImg, 0, 0, vp.width, vp.height);
+      ctx.save();
+      NativeComposer.roundRectPath(
+        ctx, rect.x, rect.y, rect.width, rect.height, screen.clipRadius || 0
+      );
+      ctx.clip();
+      ctx.drawImage(sourceCanvas, rect.x, rect.y, rect.width, rect.height);
+      if (onOverlay) onOverlay(ctx, rect);
+      ctx.restore();
+    },
+
+    compose(ctx, plan, background, paint) {
+      ctx.clearRect(0, 0, plan.width, plan.height);
+      if (background && background !== 'transparent') {
+        ctx.fillStyle = background;
+        ctx.fillRect(0, 0, plan.width, plan.height);
+      }
+      if (!(plan.drawW > 0) || !(plan.drawH > 0)) return;
+      if (!(plan.sourceWidth > 0) || !(plan.sourceHeight > 0)) return;
+      ctx.save();
+      ctx.translate(plan.drawX, plan.drawY);
+      ctx.scale(plan.drawW / plan.sourceWidth, plan.drawH / plan.sourceHeight);
+      paint(ctx);
+      ctx.restore();
+    },
+
+    roundRectPath(ctx, x, y, w, h, r) {
+      ctx.beginPath();
+      ctx.moveTo(x + r, y);
+      ctx.lineTo(x + w - r, y);
+      ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+      ctx.lineTo(x + w, y + h - r);
+      ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+      ctx.lineTo(x + r, y + h);
+      ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+      ctx.lineTo(x, y + r);
+      ctx.quadraticCurveTo(x, y, x + r, y);
+      ctx.closePath();
+    },
+  };
+
+  /// The no-vocabulary plan: the source fills the canvas, exactly as the
+  /// recorder behaved before capture sizes existed. `locked` is the frozen
+  /// canvas size once one exists, so a source that reconfigures mid-take
+  /// keeps filling the same box.
+  function nativePlan(natural, locked) {
+    const width  = (locked && locked.width)  || natural.width;
+    const height = (locked && locked.height) || natural.height;
+    return {
+      width,
+      height,
+      drawX: 0,
+      drawY: 0,
+      drawW: width,
+      drawH: height,
+      sourceWidth: natural.width,
+      sourceHeight: natural.height,
+    };
+  }
+
+  class BrowserRecorder {
+    constructor(opts) {
+      const o = opts || {};
+      this.sourceCanvas = o.canvas;
+      this.frameImg    = o.frameImg    || null;
+      this.screen      = o.screen      || null;     // SDK SimulatorDefinition.screen
+      this.overlayHost = o.overlayHost || null;
+      this.fps         = o.fps || 60;
+      // Visible-quality knob. Default 12 Mbps — well above the browser's
+      // built-in (~2.5 Mbps) without exploding file size; H.264 at this
+      // bitrate is artifact-free for an iPhone-sized canvas. Override via
+      // `bitrate` for archive-grade or transport-sized recordings.
+      this.bitrate     = o.bitrate || 12_000_000;
+
+      // Sizing inputs are kept raw and resolved in `start()` — building a
+      // CaptureSettings here would force capture/*.js to be loaded before
+      // recorder.js, and an idle recorder is meant to hold nothing.
+      this._settingsOpt = o.settings || null;
+      this._sizeOpt     = o.captureSize;
+      this._fitOpt      = o.fit;
+      this._bgOpt       = o.background;
+      this._bezelOpt    = o.bezel;
+
+      this.settings = null;          // null when capture/*.js isn't loaded
+      this.bezel = true;
+      this.plan = null;
+      this.background = 'transparent';
+      this.mimeType = pickMimeType();
+      this.compose = null;
+      this.composeCtx = null;
+      this.rafId = null;
+      this.recorder = null;
+      this.chunks = [];
+      this.startedAt = 0;
+      this.endedAt = 0;
+      this._composer = NativeComposer;
+      this._lockedSize = null;       // a fixed CaptureSize, when resizable
+      this._locked = null;           // the frozen canvas dimensions
+    }
+
+    /// True iff `MediaRecorder` exists. Older browsers (or strict CSP
+    /// configs without MediaRecorder) hide the Record button entirely.
+    /// The capture vocabulary is deliberately NOT part of this — without
+    /// it recording still works, it just can't be resized.
+    static isAvailable() {
+      return typeof window.MediaRecorder !== 'undefined';
+    }
+
+    start() {
+      if (!this.sourceCanvas) throw new Error('canvas is required');
+      if (!BrowserRecorder.isAvailable()) {
+        throw new Error('MediaRecorder not available in this browser');
+      }
+      const vocab = vocabulary();
+      this._composer = vocab ? vocab._CaptureComposer : NativeComposer;
+      this._resolveSettings(vocab);
+
+      // The compose canvas is the recording's full output — captureStream
+      // samples it at fps. Its size is whatever the picked CaptureSize
+      // resolves the natural composite to.
+      const natural = this._naturalSize();
+      this.plan = this.settings
+        ? this.settings.plan(natural.width, natural.height)
+        : nativePlan(natural, null);
+      this.background = this.settings ? this.settings.effectiveBackground : 'transparent';
+
+      this.compose = window.document.createElement('canvas');
+      this.compose.width  = this.plan.width;
+      this.compose.height = this.plan.height;
+      this.composeCtx = this.compose.getContext('2d');
+      // High-quality scaling matters when the live stream is below the
+      // bezel composite's native resolution (e.g. scale=2 or scale=3 in
+      // the streaming sidebar). Default `'low'` produces visible nearest-
+      // neighbour stair-stepping; `'high'` invokes the browser's better
+      // resampler (Lanczos / bicubic depending on engine).
+      this.composeCtx.imageSmoothingEnabled = true;
+      this.composeCtx.imageSmoothingQuality = 'high';
+
+      // The output size is LOCKED for the whole recording: `captureStream`
+      // binds to this canvas' backing store, and resizing it mid-flight
+      // either tears the video track down or hands the encoder a frame
+      // size it already committed to. The stream can still reconfigure its
+      // scale underneath us, so later frames are re-planned against this
+      // frozen box and letterboxed into it rather than growing the canvas
+      // — see `_paint`.
+      this._locked = { width: this.plan.width, height: this.plan.height };
+      this._lockedSize = vocab
+        ? vocab._CaptureSize.parse(`${this.plan.width}x${this.plan.height}`)
+        : null;
+
+      this._startPaintLoop();
+
+      // A MediaRecorder that refuses the stream (unsupported mime, a
+      // canvas the compositor won't capture) must not leave the paint
+      // loop running forever against an orphaned canvas — callers catch
+      // `start()` and show an error, they don't call `cancel()`.
+      try {
+        const stream = this.compose.captureStream(this.fps);
+        const recorderOpts = {};
+        if (this.mimeType) recorderOpts.mimeType = this.mimeType;
+        if (this.bitrate)  recorderOpts.videoBitsPerSecond = this.bitrate;
+        this.recorder = new window.MediaRecorder(stream, recorderOpts);
+        this.recorder.ondataavailable = (e) => {
+          if (e.data && e.data.size > 0) this.chunks.push(e.data);
+        };
+        this.recorder.start(1000);
+      } catch (err) {
+        this._teardown();
+        throw err;
+      }
+      this.startedAt = Date.now();
+    }
+
+    /// Fold the loose sizing options down to one CaptureSettings, then
+    /// settle whether the device frame is composited in. Without the
+    /// vocabulary there are no settings — `bezel` still applies, since
+    /// that's the recorder's own knob.
+    _resolveSettings(vocab) {
+      if (!vocab) {
+        this.settings = null;
+        this.bezel = this._bezelOpt === undefined ? true : !!this._bezelOpt;
+        return;
+      }
+      if (this._settingsOpt) {
+        this.settings = this._settingsOpt;
+      } else {
+        const size = this._sizeOpt && this._sizeOpt.spec
+          ? this._sizeOpt.spec
+          : this._sizeOpt;
+        this.settings = new vocab._CaptureSettings({
+          size,
+          fit: this._fitOpt,
+          background: this._bgOpt,
+        });
+      }
+      this.bezel = this._bezelOpt === undefined
+        ? this.settings.withFrame
+        : !!this._bezelOpt;
+    }
+
+    /// The composite's own size, before any target size is applied. With
+    /// the bezel on that's the frame's viewport; with it off — a 3D view,
+    /// whose server-rendered canvas already contains the device body — the
+    /// source canvas is the whole picture.
+    _naturalSize() {
+      const size = this._composer.compositeSize(
+        this.bezel ? this.frameImg : null,
+        this.bezel ? this.screen : null,
+        this.sourceCanvas
+      );
+      return size.width > 0 && size.height > 0 ? size : FALLBACK_SIZE;
+    }
+
+    _startPaintLoop() {
+      const tick = () => {
+        this._paint();
+        this.rafId = window.requestAnimationFrame(tick);
+      };
+      this.rafId = window.requestAnimationFrame(tick);
+    }
+
+    // Per-frame paint, all of it delegated to the composer: background,
+    // then bezel → screen (clipped) → pinch dots, placed into the locked
+    // output box. ~1 ms on Apple Silicon for an iPhone-sized composite.
+    _paint() {
+      // `stop()` awaits the recorder's own `onstop`, so a frame already
+      // scheduled by the paint loop can land after teardown has nulled the
+      // compose canvas. Nothing left to paint onto — drop the frame.
+      if (!this.composeCtx || !this.plan) return;
+
+      const natural = this._naturalSize();
+      if (natural.width !== this.plan.sourceWidth
+        || natural.height !== this.plan.sourceHeight) {
+        // The source reconfigured mid-recording. Re-plan against the
+        // frozen output box so the new frames land in the size the
+        // encoder is already committed to.
+        this.plan = this._lockedSize
+          ? this._lockedSize.plan(natural.width, natural.height, this.settings.fit)
+          : nativePlan(natural, this._locked);
+      }
+
+      this._composer.compose(this.composeCtx, this.plan, this.background, (ctx) => {
+        this._composer.paintComposite(ctx, {
+          frameImg: this.bezel ? this.frameImg : null,
+          screen: this.bezel ? this.screen : null,
+          sourceCanvas: this.sourceCanvas,
+          onOverlay: (c, rect) => this._paintOverlayDots(c, rect),
+        });
+      });
+    }
+
+    // Reads the current DOM positions of PinchOverlay's dots and paints
+    // matching circles onto the compose canvas. PinchOverlay positions
+    // its children at host-local pixels; we map those back to composite
+    // coords using the host's bounding box. No state cached anywhere —
+    // each tick re-reads what the live overlay is showing.
+    _paintOverlayDots(ctx, screenRect) {
+      const host = this.overlayHost;
+      if (!host || host.children.length === 0) return;
+      const hostRect = host.getBoundingClientRect();
+      if (hostRect.width === 0 || hostRect.height === 0) return;
+      const sx = screenRect.width  / hostRect.width;
+      const sy = screenRect.height / hostRect.height;
+
+      // PinchOverlay dot styling (sim-input.js): 36px diameter, indigo
+      // fill+stroke, soft shadow. Mirror it on the canvas — same look,
+      // no shadow (Canvas2D shadows are slow and the recording doesn't
+      // need them to read clearly).
+      const radiusComposite = 18 * Math.max(sx, sy);   // matches DOM 36px diameter
+      ctx.save();
+      ctx.fillStyle   = 'rgba(99, 102, 241, 0.35)';
+      ctx.strokeStyle = 'rgba(99, 102, 241, 0.9)';
+      ctx.lineWidth   = 2 * Math.max(sx, sy);
+      for (const dot of host.children) {
+        const left = parseFloat(dot.style.left);
+        const top  = parseFloat(dot.style.top);
+        if (!isFinite(left) || !isFinite(top)) continue;
+        const cx = screenRect.x + left * sx;
+        const cy = screenRect.y + top  * sy;
+        ctx.beginPath();
+        ctx.arc(cx, cy, radiusComposite, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+
+    /// Stop the recorder, await the final chunk, return an artifact ready
+    /// to drop into a `<a download>` link. The Blob URL stays valid for
+    /// the life of the page; callers free it via URL.revokeObjectURL when
+    /// they're done with the link.
+    async stop() {
+      if (!this.recorder) throw new Error('not started');
+      const recorder = this.recorder;
+      const stopped = new Promise((resolve) => { recorder.onstop = resolve; });
+      try { recorder.requestData(); } catch { /* not all impls expose this */ }
+      recorder.stop();
+      await stopped;
+      this.endedAt = Date.now();
+      const plan = this.plan || { width: 0, height: 0 };
+      const settings = this.settings;
+      this._teardown();
+
+      const blob = new window.Blob(this.chunks, { type: this.mimeType || 'video/webm' });
+      this.chunks = [];
+      const stamp = new Date(this.startedAt)
+        .toISOString().replace(/[:.]/g, '-').replace('Z', '');
+      // `slug` names the size the file actually came out at, so a folder
+      // of exports sorts by device-size at a glance:
+      //   simulator-2026-…-appstore-6.9-1290x2796.mp4
+      // CaptureSettings.slug is the one place that policy lives (including
+      // keeping a ratio spec like `16:9` filename-safe), shared with
+      // screenshots — without it we can only name the dimensions.
+      const slug = settings
+        ? settings.slug(plan.width, plan.height)
+        : `${Math.round(plan.width)}x${Math.round(plan.height)}`;
+      return {
+        blob,
+        url: window.URL.createObjectURL(blob),
+        filename: `simulator-${stamp}-${slug}.${extFor(this.mimeType)}`,
+        mimeType: this.mimeType,
+        durationSeconds: (this.endedAt - this.startedAt) / 1000,
+        bytes: blob.size,
+      };
+    }
+
+    /// Discard the in-flight recording. Used when the live stream
+    /// disconnects mid-record or the user navigates away.
+    cancel() {
+      if (this.recorder && this.recorder.state !== 'inactive') {
+        try { this.recorder.stop(); } catch { /* ignore */ }
+      }
+      this._teardown();
+      this.chunks = [];
+    }
+
+    _teardown() {
+      if (this.rafId) {
+        window.cancelAnimationFrame(this.rafId);
+        this.rafId = null;
+      }
+      this.recorder = null;
+      this.compose = null;
+      this.composeCtx = null;
+      this._lockedSize = null;
+      this._locked = null;
+    }
   }
 
   window.BrowserRecorder = BrowserRecorder;

--- a/Tests/Web/recorder.test.js
+++ b/Tests/Web/recorder.test.js
@@ -1,0 +1,560 @@
+'use strict';
+
+// BrowserRecorder's behaviour, driven against a hand-rolled browser: a
+// fake `document` handing out fake canvases, a queued
+// `requestAnimationFrame` so the paint loop advances one frame per test
+// step instead of spinning, and a `MediaRecorder` stand-in whose chunks
+// are plain `{ size }` objects. No jsdom — the recorder only ever touches
+// this narrow slice of the DOM, so the fake is enough to assert on the
+// state that matters: the compose canvas the recording is captured from,
+// where each frame lands inside it, and the artifact that comes back.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { loadBrowserModules } = require('./helpers/load-browser-module.js');
+
+const WEB = path.join(
+  __dirname, '..', '..', 'Sources', 'Baguette', 'Resources', 'Web'
+);
+const FILES = [
+  path.join(WEB, 'capture', 'capture-size.js'),
+  path.join(WEB, 'capture', 'capture-settings.js'),
+  path.join(WEB, 'capture', 'capture-composer.js'),
+  path.join(WEB, 'recorder.js'),
+];
+
+// ── the fake browser ─────────────────────────────────────────
+
+// Tracks the current transform and records every paint in FINAL canvas
+// pixels — same shape as capture-composer.test.js's, so an assertion
+// reads as "this ended up here on the recording".
+function fakeCtx() {
+  const ops = [];
+  let m = { x: 0, y: 0, sx: 1, sy: 1 };
+  const stack = [];
+  return {
+    ops,
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    imageSmoothingEnabled: false,
+    imageSmoothingQuality: '',
+    save() { stack.push({ ...m }); },
+    restore() { m = stack.pop() || m; },
+    translate(x, y) { m.x += x * m.sx; m.y += y * m.sy; },
+    scale(sx, sy) { m.sx *= sx; m.sy *= sy; },
+    clearRect(x, y, w, h) { ops.push(['clear', x, y, w, h]); },
+    fillRect(x, y, w, h) {
+      ops.push(['fill', this.fillStyle, m.x + x * m.sx, m.y + y * m.sy,
+        w * m.sx, h * m.sy]);
+    },
+    drawImage(img, x, y, w, h) {
+      ops.push(['draw', img.tag, m.x + x * m.sx, m.y + y * m.sy,
+        w * m.sx, h * m.sy]);
+    },
+    beginPath() { ops.push(['beginPath']); },
+    moveTo() {}, lineTo() {}, quadraticCurveTo() {}, closePath() {},
+    clip() { ops.push(['clip']); },
+    arc(cx, cy, r) { ops.push(['arc', m.x + cx * m.sx, m.y + cy * m.sy, r * m.sx]); },
+    fill() {}, stroke() {},
+  };
+}
+
+function fakeCanvas(tag) {
+  const ctx = fakeCtx();
+  return {
+    tag: tag || 'compose',
+    width: 0,
+    height: 0,
+    getContext() { return ctx; },
+    captureStream(fps) {
+      this.capturedFps = fps;
+      // captureStream binds to THIS canvas' backing surface — resizing it
+      // afterwards is what the recorder is not allowed to do.
+      this.capturedSize = { width: this.width, height: this.height };
+      return { tag: 'stream' };
+    },
+    ctx,
+  };
+}
+
+class FakeMediaRecorder {
+  static isTypeSupported(mime) {
+    return FakeMediaRecorder.supported.indexOf(mime) >= 0;
+  }
+
+  constructor(stream, opts) {
+    this.stream = stream;
+    this.opts = opts;
+    this.state = 'inactive';
+    FakeMediaRecorder.instances.push(this);
+  }
+
+  start(timeslice) { this.state = 'recording'; this.timeslice = timeslice; }
+
+  requestData() {
+    if (this.ondataavailable) this.ondataavailable({ data: { size: 4096 } });
+  }
+
+  stop() {
+    this.state = 'inactive';
+    if (this.onstop) this.onstop();
+  }
+}
+FakeMediaRecorder.supported = ['video/mp4;codecs=avc1.42E01E'];
+FakeMediaRecorder.instances = [];
+
+class FakeBlob {
+  constructor(parts, opts) {
+    this.size = parts.reduce((sum, p) => sum + (p.size || 0), 0);
+    this.type = (opts || {}).type || '';
+  }
+}
+
+/** A throwaway `window` with just the APIs BrowserRecorder reaches for. */
+function fakeWindow(overrides) {
+  const created = [];
+  const frames = [];
+  const win = {
+    document: {
+      createElement() {
+        const canvas = fakeCanvas();
+        created.push(canvas);
+        return canvas;
+      },
+    },
+    requestAnimationFrame(cb) { frames.push(cb); return frames.length; },
+    cancelAnimationFrame() { frames.length = 0; },
+    MediaRecorder: FakeMediaRecorder,
+    Blob: FakeBlob,
+    URL: { createObjectURL() { return 'blob:fake-url'; } },
+    _created: created,
+    _frames: frames,
+  };
+  return Object.assign(win, overrides || {});
+}
+
+function load(overrides) {
+  FakeMediaRecorder.instances = [];
+  const win = fakeWindow(overrides);
+  loadBrowserModules(FILES, win);
+  return win;
+}
+
+/** Runs one queued rAF callback — the recorder re-queues the next itself. */
+function flushFrame(win) {
+  const cb = win._frames.shift();
+  if (cb) cb();
+}
+
+// ── fixtures ─────────────────────────────────────────────────
+
+// iPhone 16 Pro-ish: a 1206×2622 bezel viewport with the live screen
+// inset 20px all round.
+const BEZEL = { tag: 'bezel', naturalWidth: 1206, naturalHeight: 2622 };
+const SCREEN = {
+  viewport: { width: 1206, height: 2622 },
+  rect: { x: 20, y: 20, width: 1166, height: 2582 },
+  clipRadius: 60,
+};
+
+const sourceCanvas = (width, height) => ({ tag: 'live', width, height });
+
+const drawOps = (ctx) => ctx.ops.filter((op) => op[0] === 'draw');
+
+// ── availability ─────────────────────────────────────────────
+
+test('recording is unavailable when the browser has no MediaRecorder', () => {
+  const win = load({ MediaRecorder: undefined });
+  assert.equal(win.BrowserRecorder.isAvailable(), false);
+});
+
+test('recording is available when MediaRecorder exists', () => {
+  const win = load();
+  assert.equal(win.BrowserRecorder.isAvailable(), true);
+});
+
+// ── idle costs nothing ───────────────────────────────────────
+
+test('an idle recorder allocates no compose canvas and no paint loop', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({ canvas: sourceCanvas(1170, 2532) });
+  assert.equal(win._created.length, 0);
+  assert.equal(win._frames.length, 0);
+  assert.equal(rec.compose, null);
+  assert.equal(rec.recorder, null);
+});
+
+// ── output size ──────────────────────────────────────────────
+
+test('the old call shape still records at the bezel composite size', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582),
+    frameImg: BEZEL,
+    screen: SCREEN,
+    overlayHost: null,
+    fps: 60,
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 1206);
+  assert.equal(rec.compose.height, 2622);
+});
+
+test('an App Store 6.9 recording composes onto a 1290×2796 canvas', () => {
+  const win = load();
+  const settings = new win.Baguette._CaptureSettings({ size: 'appstore-6.9' });
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582), frameImg: BEZEL, screen: SCREEN, settings,
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 1290);
+  assert.equal(rec.compose.height, 2796);
+});
+
+test('a square recording grows the binding axis so the source stays 1:1', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582),
+    frameImg: BEZEL,
+    screen: SCREEN,
+    captureSize: 'square',
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 2622);
+  assert.equal(rec.compose.height, 2622);
+});
+
+test('a literal pixel spec sizes the recording exactly', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1170, 2532), captureSize: '1920x1080',
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 1920);
+  assert.equal(rec.compose.height, 1080);
+});
+
+// ── bezel-less (3D) mode ─────────────────────────────────────
+
+test('a bezel-less recording sizes itself from the source canvas alone', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(800, 600), frameImg: BEZEL, screen: SCREEN, bezel: false,
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 800);
+  assert.equal(rec.compose.height, 600);
+});
+
+test('a bezel-less frame paints only the source canvas, no device frame', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(800, 600), frameImg: BEZEL, screen: SCREEN, bezel: false,
+  });
+  rec.start();
+  flushFrame(win);
+  assert.deepEqual(drawOps(rec.composeCtx), [['draw', 'live', 0, 0, 800, 600]]);
+});
+
+test('a bezel-less 16:9 recording letterboxes the source into the target', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(800, 600), bezel: false, captureSize: '16:9',
+    background: '#000000',
+  });
+  rec.start();
+  flushFrame(win);
+  assert.equal(rec.compose.width, 1067);
+  assert.equal(rec.compose.height, 600);
+  const [op] = drawOps(rec.composeCtx);
+  assert.equal(op[1], 'live');
+  assert.equal(op[2], 134);   // centred: (1067 - 800) / 2
+  assert.equal(op[4], 800);
+});
+
+// ── per-frame composition ────────────────────────────────────
+
+test('a bezel frame paints the device frame under the clipped screen', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582), frameImg: BEZEL, screen: SCREEN,
+  });
+  rec.start();
+  flushFrame(win);
+  assert.deepEqual(drawOps(rec.composeCtx), [
+    ['draw', 'bezel', 0, 0, 1206, 2622],
+    ['draw', 'live', 20, 20, 1166, 2582],
+  ]);
+  assert.ok(rec.composeCtx.ops.some((op) => op[0] === 'clip'));
+});
+
+test('a resized target paints the background behind the letterboxed frame', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582), frameImg: BEZEL, screen: SCREEN,
+    captureSize: 'square', background: '#ff0000',
+  });
+  rec.start();
+  flushFrame(win);
+  const fills = rec.composeCtx.ops.filter((op) => op[0] === 'fill');
+  assert.deepEqual(fills[0], ['fill', '#ff0000', 0, 0, 2622, 2622]);
+});
+
+test('a native recording leaves no background mat under the frame', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582), frameImg: BEZEL, screen: SCREEN,
+  });
+  rec.start();
+  flushFrame(win);
+  assert.equal(rec.composeCtx.ops.filter((op) => op[0] === 'fill').length, 0);
+});
+
+// ── a source that reconfigures mid-recording ─────────────────
+
+test('a source that resizes mid-recording is letterboxed into the locked size', () => {
+  const win = load();
+  const source = sourceCanvas(800, 600);
+  const rec = new win.BrowserRecorder({ canvas: source, bezel: false });
+  rec.start();
+  flushFrame(win);
+
+  // The stream reconfigured to a narrower scale — same recording.
+  source.width = 400;
+  source.height = 600;
+  rec.composeCtx.ops.length = 0;
+  flushFrame(win);
+
+  assert.equal(rec.compose.width, 800, 'compose canvas must not be resized');
+  assert.equal(rec.compose.height, 600);
+  assert.deepEqual(drawOps(rec.composeCtx), [['draw', 'live', 200, 0, 400, 600]]);
+});
+
+test('captureStream is bound to the size the compose canvas keeps', () => {
+  const win = load();
+  const source = sourceCanvas(800, 600);
+  const rec = new win.BrowserRecorder({ canvas: source, bezel: false });
+  rec.start();
+  source.width = 1600;
+  source.height = 1200;
+  flushFrame(win);
+  assert.deepEqual(rec.compose.capturedSize, { width: 800, height: 600 });
+  assert.equal(rec.compose.width, 800);
+});
+
+// ── the artifact ─────────────────────────────────────────────
+
+test('the artifact filename carries the chosen size', async () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582), frameImg: BEZEL, screen: SCREEN,
+    captureSize: 'square',
+  });
+  rec.start();
+  const artifact = await rec.stop();
+  assert.match(artifact.filename, /^simulator-.*-square-2622x2622\.mp4$/);
+});
+
+test('a native artifact names the bare output dimensions', async () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582), frameImg: BEZEL, screen: SCREEN,
+  });
+  rec.start();
+  const artifact = await rec.stop();
+  assert.match(artifact.filename, /^simulator-.*-1206x2622\.mp4$/);
+});
+
+test('stopping returns the blob, its size, and the negotiated mime type', async () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({ canvas: sourceCanvas(800, 600), bezel: false });
+  rec.start();
+  const artifact = await rec.stop();
+  assert.equal(artifact.mimeType, 'video/mp4;codecs=avc1.42E01E');
+  assert.equal(artifact.bytes, 4096);
+  assert.equal(artifact.blob.size, 4096);
+  assert.equal(artifact.url, 'blob:fake-url');
+  assert.ok(artifact.durationSeconds >= 0);
+});
+
+test('a WebM-only browser falls back to a .webm artifact', async () => {
+  FakeMediaRecorder.supported = ['video/webm;codecs=vp9'];
+  try {
+    const win = load();
+    const rec = new win.BrowserRecorder({ canvas: sourceCanvas(800, 600), bezel: false });
+    rec.start();
+    const artifact = await rec.stop();
+    assert.equal(artifact.mimeType, 'video/webm;codecs=vp9');
+    assert.match(artifact.filename, /\.webm$/);
+  } finally {
+    FakeMediaRecorder.supported = ['video/mp4;codecs=avc1.42E01E'];
+  }
+});
+
+test('stopping tears the compose canvas and paint loop back down', async () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({ canvas: sourceCanvas(800, 600), bezel: false });
+  rec.start();
+  await rec.stop();
+  assert.equal(rec.compose, null);
+  assert.equal(rec.composeCtx, null);
+  assert.equal(rec.recorder, null);
+  assert.equal(rec.rafId, null);
+});
+
+test('cancelling discards the chunks and the compose canvas', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({ canvas: sourceCanvas(800, 600), bezel: false });
+  rec.start();
+  rec.cancel();
+  assert.equal(rec.compose, null);
+  assert.equal(rec.recorder, null);
+  assert.deepEqual(rec.chunks, []);
+});
+
+// ── recorder configuration ───────────────────────────────────
+
+test('the default fps and bitrate survive the rewrite', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({ canvas: sourceCanvas(800, 600), bezel: false });
+  rec.start();
+  assert.equal(rec.compose.capturedFps, 60);
+  assert.equal(FakeMediaRecorder.instances[0].opts.videoBitsPerSecond, 12_000_000);
+});
+
+test('settings drive the bezel unless the caller overrides it', () => {
+  const win = load();
+  const settings = new win.Baguette._CaptureSettings({ withFrame: false });
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(800, 600), frameImg: BEZEL, screen: SCREEN, settings,
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 800);
+  assert.equal(rec.compose.height, 600);
+});
+
+test('starting without a source canvas is refused', () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({});
+  assert.throws(() => rec.start(), /canvas is required/);
+});
+
+test('a MediaRecorder that refuses to start leaves no paint loop behind', () => {
+  const win = load();
+  win.MediaRecorder = class {
+    static isTypeSupported() { return false; }
+    constructor() { throw new Error('unsupported'); }
+  };
+  const rec = new win.BrowserRecorder({ canvas: sourceCanvas(800, 600), bezel: false });
+  assert.throws(() => rec.start(), /unsupported/);
+  assert.equal(rec.rafId, null);
+  assert.equal(rec.compose, null);
+  assert.equal(win._frames.length, 0);
+});
+
+// ── the pinch HUD ────────────────────────────────────────────
+
+test('pinch dots are painted in the live screen’s coordinates', () => {
+  const win = load();
+  const overlayHost = {
+    children: [{ style: { left: '50px', top: '100px' } }],
+    getBoundingClientRect() { return { width: 583, height: 1291 }; },
+  };
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582), frameImg: BEZEL, screen: SCREEN, overlayHost,
+  });
+  rec.start();
+  flushFrame(win);
+  const arcs = rec.composeCtx.ops.filter((op) => op[0] === 'arc');
+  // host is half the screen rect, so a dot at (50, 100) lands at
+  // rect origin + double: (20 + 100, 20 + 200).
+  assert.deepEqual(arcs, [['arc', 120, 220, 36]]);
+});
+
+test('a ratio size stays filesystem-safe in the filename (CaptureSettings.slug)', async () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582), frameImg: BEZEL, screen: SCREEN,
+    captureSize: '16:9',
+  });
+  rec.start();
+  const artifact = await rec.stop();
+  assert.equal(artifact.filename.includes(':'), false);
+  assert.match(artifact.filename, /-16-9-4661x2622\.mp4$/);
+});
+
+// ── the capture vocabulary is an enhancement, not a dependency ──
+
+/** Loads recorder.js ALONE — no capture/*.js on the page. */
+function loadBare(overrides) {
+  FakeMediaRecorder.instances = [];
+  const win = fakeWindow(overrides);
+  loadBrowserModules([path.join(WEB, 'recorder.js')], win);
+  return win;
+}
+
+test('without the capture modules a bezel recording still uses the viewport', () => {
+  const win = loadBare();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582), frameImg: BEZEL, screen: SCREEN,
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 1206);
+  assert.equal(rec.compose.height, 2622);
+  flushFrame(win);
+  assert.deepEqual(drawOps(rec.composeCtx), [
+    ['draw', 'bezel', 0, 0, 1206, 2622],
+    ['draw', 'live', 20, 20, 1166, 2582],
+  ]);
+});
+
+test('without the capture modules a bezel-less recording uses the source size', () => {
+  const win = loadBare();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(900, 1400), frameImg: BEZEL, screen: SCREEN, bezel: false,
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 900);
+  assert.equal(rec.compose.height, 1400);
+  flushFrame(win);
+  assert.deepEqual(drawOps(rec.composeCtx), [['draw', 'live', 0, 0, 900, 1400]]);
+});
+
+test('without the capture modules a requested size is ignored, not fatal', async () => {
+  const win = loadBare();
+  const warnings = [];
+  win.console = { warn: (msg) => warnings.push(msg) };
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(1166, 2582), frameImg: BEZEL, screen: SCREEN,
+    captureSize: 'appstore-6.9',
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 1206, 'falls back to the natural composite');
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /capture/i);
+  const artifact = await rec.stop();
+  assert.match(artifact.filename, /^simulator-.*-1206x2622\.mp4$/);
+});
+
+test('the missing-vocabulary warning is logged once, not once per recorder', () => {
+  const win = loadBare();
+  const warnings = [];
+  win.console = { warn: (msg) => warnings.push(msg) };
+  for (let i = 0; i < 3; i += 1) {
+    new win.BrowserRecorder({ canvas: sourceCanvas(800, 600), bezel: false }).start();
+  }
+  assert.equal(warnings.length, 1);
+});
+
+// ── a frame that lands after teardown ────────────────────────
+
+test('a rAF tick that lands after teardown paints nothing', async () => {
+  const win = load();
+  const rec = new win.BrowserRecorder({ canvas: sourceCanvas(800, 600), bezel: false });
+  rec.start();
+  const queued = win._frames[0];
+  await rec.stop();
+  assert.doesNotThrow(() => queued());
+});

--- a/Tests/Web/recorder.test.js
+++ b/Tests/Web/recorder.test.js
@@ -312,6 +312,30 @@ test('a native recording leaves no background mat under the frame', () => {
   assert.equal(rec.composeCtx.ops.filter((op) => op[0] === 'fill').length, 0);
 });
 
+// ── Record pressed before the first frame decodes ────────────
+
+test('recording started before the first decoded frame still shows the device', () => {
+  const win = load();
+  const source = sourceCanvas(0, 0);
+  const rec = new win.BrowserRecorder({
+    canvas: source, frameImg: BEZEL, screen: SCREEN,
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 1206, 'sized from the bezel viewport, not 0');
+  flushFrame(win);
+  assert.deepEqual(drawOps(rec.composeCtx), [['draw', 'bezel', 0, 0, 1206, 2622]]);
+
+  // …and the screen layer joins as soon as the stream negotiates.
+  source.width = 1166;
+  source.height = 2582;
+  rec.composeCtx.ops.length = 0;
+  flushFrame(win);
+  assert.deepEqual(drawOps(rec.composeCtx), [
+    ['draw', 'bezel', 0, 0, 1206, 2622],
+    ['draw', 'live', 20, 20, 1166, 2582],
+  ]);
+});
+
 // ── a source that reconfigures mid-recording ─────────────────
 
 test('a source that resizes mid-recording is letterboxed into the locked size', () => {
@@ -520,6 +544,17 @@ test('without the capture modules a bezel-less recording uses the source size', 
   assert.equal(rec.compose.height, 1400);
   flushFrame(win);
   assert.deepEqual(drawOps(rec.composeCtx), [['draw', 'live', 0, 0, 900, 1400]]);
+});
+
+test('without the capture modules an undecoded source still shows the device', () => {
+  const win = loadBare();
+  const rec = new win.BrowserRecorder({
+    canvas: sourceCanvas(0, 0), frameImg: BEZEL, screen: SCREEN,
+  });
+  rec.start();
+  assert.equal(rec.compose.width, 1206);
+  flushFrame(win);
+  assert.deepEqual(drawOps(rec.composeCtx), [['draw', 'bezel', 0, 0, 1206, 2622]]);
 });
 
 test('without the capture modules a requested size is ignored, not fatal', async () => {


### PR DESCRIPTION
Unit 1 of the capture-size feature: `BrowserRecorder` learns the shared output-size vocabulary, so picking "App Store 6.9″" / "square" / "16:9" once gives you that size from a **recording** just as it does from a screenshot — in 2D or 3D.

## What changed

`Sources/Baguette/Resources/Web/recorder.js`

- **Sizing** comes from the shared vocabulary. One preferred option shape, `settings` (a `CaptureSettings`), with loose fallbacks (`captureSize` / `fit` / `background`) so the existing call sites in `sim-stream.js` and `farm/farm-focus.js` keep working **completely unchanged** — default is still native size, bezel on.
- **The compose canvas** is allocated from `CaptureSettings.plan(...)` instead of the file's private `composeSize()`, and its natural size is delegated to `CaptureComposer.compositeSize(...)`.
- **Per-frame paint** is now `CaptureComposer.compose(ctx, plan, background, c => CaptureComposer.paintComposite(c, {frameImg, screen, sourceCanvas, onOverlay: paintDots}))`. The hand-rolled bezel / clip / `roundRectPath` copy this file carried is deleted — the composer owns it.
- **`bezel: false`** records a source canvas that already contains the device body (the server-rendered 3D stream) straight into the target size, no bezel compositing. Unit 3 passes this when recording the 3D view. It defaults to `settings.withFrame`, so a picker toggling the frame off toggles it here too; passing `bezel` explicitly wins over both.
- **The output size is locked at `start()`.** `captureStream` binds to the compose canvas' backing store, so the canvas is never resized mid-recording; a stream that reconfigures its scale mid-take is re-planned against the frozen box and letterboxed into it. The reasoning is in a comment at the lock site.
- **The filename carries the size slug** via `CaptureSettings.slug(w, h)` — `simulator-2026-…-appstore-6.9-1290x2796.mp4`.
- Converted from `function X(){}` + `X.prototype.y =` to `class` (recorder.js was one of the last two prototype-style files).
- `isAvailable()`, the MIME probing, the artifact shape `{blob, url, filename, mimeType, durationSeconds, bytes}`, and the default 60 fps / 12 Mbps are all unchanged.

### Independently mergeable

The capture vocabulary is an **enhancement, not a hard dependency**. No page loads `capture/*.js` yet (unit 5 owns `sim.html`, unit 6 owns `farm/farm.html`), so without it the recorder logs one `console.warn` and records exactly as it always did — natural composite size, bezel on, requested sizes ignored rather than fatal. `isAvailable()` deliberately doesn't gate on it, so the Record button never disappears. Three tests pin that fallback.

### Two leaks closed (found in review)

- `new MediaRecorder(...)` throwing left the rAF paint loop running forever against an orphaned canvas — callers `catch` `start()`, they don't call `cancel()`. Now torn down before the throw propagates.
- A frame already scheduled when `stop()` ran could land after teardown nulled the compose canvas.

## Tests

`Tests/Web/recorder.test.js` is new — the module had no test. 32 `node:test` cases driven against a hand-rolled browser (fake `document` handing out fake canvases, a **queued** `requestAnimationFrame` so the paint loop advances one frame per step instead of spinning, a `MediaRecorder` stand-in). Covers: compose dimensions per preset, the bezel-less mode and what it paints, `isAvailable()` false without `MediaRecorder`, the filename slug, nothing allocated while idle, the mid-recording reconfigure staying inside the locked box, the no-vocabulary fallback, and the two leaks above.

`make test-web` → 252 passing, 0 failing.

## Verification

The browser extension wasn't connected, so the live-page e2e was replaced with a smoke test against the bytes `baguette serve` actually hands the browser (fetched from a running server over HTTP, evaluated together):

```
2D native        -> 1206x2622   draws=[bezel@0,0,1206x2622; live@20,20,1166x2582]
2D appstore-6.9  -> 1290x2796   simulator-…-appstore-6.9-1290x2796.mp4
2D square        -> 2622x2622   simulator-…-square-2622x2622.mp4
2D 16:9          -> 4661x2622   simulator-…-16-9-4661x2622.mp4
2D 1920x1080     -> 1920x1080   simulator-…-1920x1080-1920x1080.mp4
3D native        -> 900x1400    draws=[live3d@0,0,900x1400]     (no bezel)
3D appstore-6.9  -> 1290x2796   draws=[live3d@0,0,900x1400]
3D 16:9          -> 2489x1400   draws=[live3d@0,0,900x1400]
reconfigure      -> compose stays 800x600, source re-planned into it
```

## Follow-ups for other units

- **Script tags** — `sim.html` and `farm/farm.html` need `/capture/capture-size.js`, `/capture/capture-settings.js`, `/capture/capture-composer.js` before `/recorder.js` for sizing to actually be available (units 5 and 6 own those files). Until then the fallback above applies.
- **`sim-stream.js:386`** (not this PR, pre-existing) — the recording quality bump (`applyQuality({scale:1, fps:60, bps:8_000_000})`) runs *before* `rec.start()` but is only restored on the stop path; `onRecordError` never puts it back, so a failed start permanently ratchets the live stream to full quality.
- **`CaptureComposer.paintComposite`** returns early on `sourceCanvas.width === 0`, so pressing Record before the first decoded frame lands now yields empty frames rather than the bare device frame. Composer-level, and `CaptureGallery` shares it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable recording output size, fit mode, background, bezel, and quality scaling.
  * Recording dimensions now remain stable, including when the captured source changes size.
  * Added size-based filenames for recorded outputs.
* **Bug Fixes**
  * Improved compatibility when optional capture features are unavailable by using a built-in fallback.
  * Improved handling of recording cancellation, startup failures, and cleanup.
  * Added more reliable overlays, letterboxing, and bezel-less composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->