### PR TITLE
feat: lossless sized 3D capture in Sim3DPanel

### DIFF
--- a/Sources/Baguette/Resources/Web/sim-3d.js
+++ b/Sources/Baguette/Resources/Web/sim-3d.js
@@ -5,6 +5,10 @@
   function Sim3DPanel() {
     this.host = null;
     this.stage = null;
+    // The live 3D frame, painted by the shared StreamSession. Public on
+    // purpose: it is what a recorder captures (`canvas.captureStream()`)
+    // for a 3D screen recording. Non-null from `mountStage()` until
+    // `detach()`, i.e. for the whole time the stream is running.
     this.canvas = null;
     this.udid = '';
     this.model = null;
@@ -16,6 +20,11 @@
     this.mode = 'pose';
     this.variants = {};
     this.screenGlass = false;
+    // The size/fit/background the user picked in the toolbar, shared with
+    // every other capture surface. `null` on pages that don't load the
+    // capture modules — saving still works, it just tracks the live frame.
+    this.captureSettings = null;
+    this.saving = false;
     this.deviceSize = { width: 1, height: 1 };
     this.onFps = null;
     this.pointer = null;
@@ -212,6 +221,16 @@
         background.toLowerCase() === this.background.toLowerCase()) return;
     this.background = background;
     this.scheduleRestart(0);
+  };
+
+  /**
+   * Adopt the toolbar's CaptureSettings. Deliberately does NOT restart the
+   * stream: the live view keeps its own screen-sized framing (see
+   * `outputSize`), and the chosen size only applies to what gets saved —
+   * a one-shot re-render at full resolution.
+   */
+  Sim3DPanel.prototype.setCaptureSettings = function (settings) {
+    this.captureSettings = settings || null;
   };
 
   Sim3DPanel.prototype.detach = function () {
@@ -530,13 +549,214 @@
     this.sendCamera();
   };
 
-  Sim3DPanel.prototype.download = function () {
-    if (!this.canvas || !this.canvas.hasAttribute('data-painted')) return;
-    const link = document.createElement('a');
-    link.href = this.canvas.toDataURL('image/png');
-    link.download = (this.model.id || 'device') + '-live-3d.png';
-    link.click();
+  /**
+   * The dimensions of the live 3D frame — what a ratio size (`square`,
+   * `16:9`) resolves against, since a 3D render has no other intrinsic
+   * size in the browser. Falls back to the size the stream was asked for
+   * before the first frame lands.
+   */
+  Sim3DPanel.prototype.streamSize = function () {
+    if (this.canvas && this.canvas.width && this.canvas.height) {
+      return { width: this.canvas.width, height: this.canvas.height };
+    }
+    return this.stage ? this.outputSize() : null;
   };
+
+  /**
+   * Save the current pose as a PNG.
+   *
+   * The canvas holds a *video-decoded* frame at the live stream's clamped
+   * resolution — fine to look at, lossy to ship. So we ask the server to
+   * re-render the very same pose once, off the stream, at the size the
+   * user picked; that comes back as a clean full-resolution PNG. The
+   * canvas is still the safety net: if the route is missing or the render
+   * fails, the user gets the live frame rather than no file at all.
+   */
+  Sim3DPanel.prototype.download = async function () {
+    if (!this.canvas || !this.canvas.hasAttribute('data-painted')) return;
+    // One click, one render. Each save costs the server a fresh screen
+    // capture plus a RealityKit render, so a double-click must not queue
+    // two of them (and hand the user two files).
+    if (this.saving) return;
+    this.saving = true;
+    this.setSaving(true);
+    const settings = this.captureSettings;
+    try {
+      if (Math.abs(this.zoom - 1) > 0.01) {
+        // `DeviceRenderOptions` has no zoom field — the one-shot render
+        // always frames at the model's default camera distance. Say so
+        // rather than quietly handing back a differently-framed PNG.
+        console.warn(
+            '[3d] saved render ignores the live zoom (' +
+            this.zoom.toFixed(2) + '×) — it frames at 1×'
+        );
+      }
+      const body = Sim3DPanel.renderBody({
+        rotation: this.rotation,
+        variants: this.variants,
+        screenGlass: this.screenGlass,
+        background: this.background,
+        settings: settings,
+        streamSize: this.streamSize(),
+      });
+      const response = await fetch(
+          '/simulators/' + encodeURIComponent(this.udid) + '/render-3d.png',
+          {
+            method: 'POST',
+            cache: 'no-store',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+          }
+      );
+      if (!response.ok) {
+        throw new Error('render-3d.png returned HTTP ' + response.status);
+      }
+      const blob = await response.blob();
+      // Name the file after what actually came back, not what we asked
+      // for — `native` doesn't send a size at all, and the server is the
+      // one that knows the screen's true pixel dimensions.
+      const size = Sim3DPanel.pngSize(new Uint8Array(await blob.arrayBuffer()));
+      const name = settings && size
+        ? this.modelId() + '-3d-' + fileSafe(settings.slug(size.width, size.height))
+        : this.modelId() + '-3d';
+      const url = URL.createObjectURL(blob);
+      saveLink(url, name + '.png');
+      // Revoke on the next turn — Safari needs the URL to still resolve
+      // when it processes the synthetic click.
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    } catch (error) {
+      console.warn(
+          '[3d] lossless render failed, saving the live frame instead', error
+      );
+      this.downloadLiveFrame();
+    } finally {
+      this.saving = false;
+      this.setSaving(false);
+    }
+  };
+
+  /** Busy state on the Save Frame button while a render is in flight. */
+  Sim3DPanel.prototype.setSaving = function (busy) {
+    const button = this.host && this.host.querySelector('[data-role="download"]');
+    if (!button) return;
+    button.disabled = !!busy;
+    button.textContent = busy ? 'Rendering…' : 'Save Frame';
+  };
+
+  /** Last resort: the lossy on-screen frame, named for what it is. */
+  Sim3DPanel.prototype.downloadLiveFrame = function () {
+    if (!this.canvas || !this.canvas.hasAttribute('data-painted')) return;
+    saveLink(this.canvas.toDataURL('image/png'), this.modelId() + '-live-3d.png');
+  };
+
+  Sim3DPanel.prototype.modelId = function () {
+    return (this.model && this.model.id) || 'device';
+  };
+
+  /**
+   * The `DeviceRenderOptions` JSON for `POST /simulators/:udid/render-3d.png`,
+   * built from the current pose plus the shared CaptureSettings.
+   *
+   * Pure and static so the arithmetic is testable without a canvas: given
+   * a pose and a size choice, exactly one body comes out.
+   *
+   * Two things worth knowing about the mapping:
+   *  • `size` is OMITTED for `native` — the server then renders at the
+   *    simulator screen's own pixel size, which is larger (and truer)
+   *    than anything the browser could name.
+   *  • the requested size is NOT run through `outputSize()`'s 480–1600
+   *    clamp. That clamp exists to keep the live video stream cheap; a
+   *    one-shot App Store render is meant to be 1290 × 2796.
+   *
+   * @param {object} o
+   * @param {{x:number,y:number,z:number}} [o.rotation]
+   * @param {object} [o.variants]
+   * @param {boolean} [o.screenGlass]
+   * @param {object} [o.settings]    CaptureSettings; absent → live framing
+   * @param {{width:number,height:number}} [o.streamSize] ratio sizes resolve
+   *   against this
+   * @param {string} [o.background]  fallback canvas colour when there are
+   *   no settings — keeps the saved PNG looking like the live view
+   */
+  Sim3DPanel.renderBody = function (o) {
+    const options = o || {};
+    const rotation = options.rotation || {};
+    const body = {
+      rotation: {
+        x: Number(rotation.x) || 0,
+        y: Number(rotation.y) || 0,
+        z: Number(rotation.z) || 0,
+      },
+      // Copied, not aliased: the panel keeps mutating `this.variants` as
+      // the user clicks finishes, and an in-flight request must not move.
+      variants: Object.assign({}, options.variants),
+      screenGlass: !!options.screenGlass,
+      // Always `cover`, never the CaptureSettings fit. On this route `fit`
+      // is NOT canvas placement — the server hands it to the screen
+      // texture's UV placement on the device mesh, i.e. how the captured
+      // frame sits on the display. The live stream asks for `cover`, so
+      // asking for anything else here would save a render that doesn't
+      // match what the user was looking at. Canvas placement on a 3D
+      // render is the camera's job, and there is no fit for it.
+      fit: 'cover',
+    };
+    const settings = options.settings;
+    if (!settings) {
+      body.background = options.background || 'transparent';
+      return body;
+    }
+    // `effectiveBackground` reports `transparent` at native size, so a
+    // transparent 3D render never gains an unwanted white mat.
+    body.background = settings.effectiveBackground;
+    if (!settings.size.isNative) {
+      const stream = options.streamSize || {};
+      const size = settings.size.resolve(stream.width, stream.height);
+      // A ratio with no source to resolve against yields 0 × 0; leaving
+      // `size` off falls back to the server's native render instead of
+      // asking for an empty image.
+      if (size.width > 0 && size.height > 0) body.size = size;
+    }
+    return body;
+  };
+
+  /**
+   * Width/height straight out of a PNG's IHDR chunk — the 8-byte
+   * signature, then a chunk header, then two big-endian uint32s at byte
+   * 16. Cheaper and synchronous compared with decoding the blob into an
+   * `Image` just to read `naturalWidth` for a filename.
+   *
+   * @param {Uint8Array} bytes
+   * @returns {{width:number,height:number}|null}
+   */
+  Sim3DPanel.pngSize = function (bytes) {
+    if (!bytes || bytes.length < 24) return null;
+    const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+    for (let i = 0; i < signature.length; i += 1) {
+      if (bytes[i] !== signature[i]) return null;
+    }
+    const read = (at) => (
+      (bytes[at] << 24 | bytes[at + 1] << 16 | bytes[at + 2] << 8 | bytes[at + 3]) >>> 0
+    );
+    const width = read(16);
+    const height = read(20);
+    return width > 0 && height > 0 ? { width, height } : null;
+  };
+
+  /**
+   * A CaptureSettings slug can carry a ratio spec (`16:9-1600x900`), and
+   * a colon is an illegal filename character on Windows and shows up as
+   * `/` in Finder — fold anything outside the safe set to a dash.
+   */
+  function fileSafe(name) {
+    return String(name).replace(/[^a-z0-9._-]+/gi, '-');
+  }
+
+  function saveLink(href, name) {
+    const link = document.createElement('a');
+    link.href = href;
+    link.download = name;
+    link.click();
+  }
 
   function rangeRow(axis, label, min, max, value) {
     return '<div class="r3d-range-row"><span>' + label + '</span>' +

--- a/Tests/Web/sim-3d-capture.test.js
+++ b/Tests/Web/sim-3d-capture.test.js
@@ -1,0 +1,279 @@
+'use strict';
+
+// Sim3DPanel's capture path: the JSON body it POSTs to
+// `/simulators/:udid/render-3d.png` when the user saves a frame, and the
+// PNG header read it does to name the file after the real dimensions.
+//
+// The panel itself (canvas, pointer orbiting, stream lifecycle) stays
+// integration-only — same bar as sim-native.js. These two statics are the
+// part with arithmetic in it, so they get covered.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { loadBrowserModules } = require('./helpers/load-browser-module.js');
+
+const WEB = path.join(__dirname, '..', '..', 'Sources', 'Baguette', 'Resources', 'Web');
+
+function load() {
+  return loadBrowserModules([
+    path.join(WEB, 'capture', 'capture-size.js'),
+    path.join(WEB, 'capture', 'capture-settings.js'),
+    path.join(WEB, 'sim-3d.js'),
+  ]);
+}
+
+function panelAndSettings(opts) {
+  const window = load();
+  return {
+    Sim3DPanel: window.Sim3DPanel,
+    settings: new window.Baguette._CaptureSettings(opts),
+  };
+}
+
+const POSE = { rotation: { x: -8, y: 18, z: 0 }, variants: { finish: 'space-black' } };
+
+// ── the render request ───────────────────────────────────────
+
+test('carries the pose, variants and glass choice verbatim', () => {
+  const { Sim3DPanel } = panelAndSettings();
+  const body = Sim3DPanel.renderBody({ ...POSE, screenGlass: true });
+  assert.deepEqual(body.rotation, { x: -8, y: 18, z: 0 });
+  assert.deepEqual(body.variants, { finish: 'space-black' });
+  assert.equal(body.screenGlass, true);
+});
+
+test('asks the server for exactly the App Store pixels, unclamped', () => {
+  const { Sim3DPanel, settings } = panelAndSettings({ size: 'appstore-6.9' });
+  const body = Sim3DPanel.renderBody({
+    ...POSE, settings, streamSize: { width: 960, height: 960 },
+  });
+  // The live stream is clamped to 480–1600 px; the one-shot render is not.
+  assert.deepEqual(body.size, { width: 1290, height: 2796 });
+});
+
+test('every fixed preset goes out at its own catalogue size', () => {
+  const window = load();
+  const CaptureSettings = window.Baguette._CaptureSettings;
+  const sizes = ['appstore-6.9', 'appstore-6.5', 'appstore-ipad-13', '1920x1080'].map(
+      (spec) => window.Sim3DPanel.renderBody({
+        ...POSE,
+        settings: new CaptureSettings({ size: spec }),
+        streamSize: { width: 960, height: 960 },
+      }).size
+  );
+  assert.deepEqual(sizes, [
+    { width: 1290, height: 2796 },
+    { width: 1242, height: 2688 },
+    { width: 2064, height: 2752 },
+    { width: 1920, height: 1080 },
+  ]);
+});
+
+test('a native capture omits size so the server renders at its own size', () => {
+  const { Sim3DPanel, settings } = panelAndSettings({ size: 'native' });
+  const body = Sim3DPanel.renderBody({
+    ...POSE, settings, streamSize: { width: 960, height: 720 },
+  });
+  assert.equal('size' in body, false);
+});
+
+test('a ratio preset resolves against the live stream frame', () => {
+  const { Sim3DPanel, settings } = panelAndSettings({ size: '16:9' });
+  const body = Sim3DPanel.renderBody({
+    ...POSE, settings, streamSize: { width: 960, height: 720 },
+  });
+  // 16:9 never downscales — the taller axis binds and the width grows.
+  assert.deepEqual(body.size, { width: 1280, height: 720 });
+});
+
+test('a ratio preset with no known stream size falls back to the native render', () => {
+  const { Sim3DPanel, settings } = panelAndSettings({ size: 'square' });
+  const body = Sim3DPanel.renderBody({ ...POSE, settings });
+  assert.equal('size' in body, false);
+});
+
+test('the letterbox background comes from the chosen settings', () => {
+  const { Sim3DPanel, settings } = panelAndSettings({
+    size: 'appstore-6.9', background: '#101820',
+  });
+  const body = Sim3DPanel.renderBody({
+    ...POSE, settings, streamSize: { width: 960, height: 960 },
+  });
+  assert.equal(body.background, '#101820');
+});
+
+test('the screen keeps the live view\u2019s cover placement whatever fit is picked', () => {
+  const window = load();
+  const CaptureSettings = window.Baguette._CaptureSettings;
+  // `fit` on this route places the captured frame on the device's screen
+  // surface, not the render inside the canvas — so the user's canvas-fit
+  // choice must not reach it, or the app screenshot would letterbox
+  // inside the phone display.
+  const fits = ['contain', 'cover', 'stretch'].map((fit) => window.Sim3DPanel.renderBody({
+    ...POSE,
+    settings: new CaptureSettings({ size: 'appstore-6.9', fit }),
+    streamSize: { width: 960, height: 960 },
+  }).fit);
+  assert.deepEqual(fits, ['cover', 'cover', 'cover']);
+});
+
+test('a native capture stays transparent so the PNG gains no white mat', () => {
+  const { Sim3DPanel, settings } = panelAndSettings({ background: '#ffffff' });
+  const body = Sim3DPanel.renderBody({
+    ...POSE, settings, streamSize: { width: 960, height: 960 },
+  });
+  assert.equal(body.background, 'transparent');
+});
+
+test('without capture settings the render matches the live stream framing', () => {
+  const { Sim3DPanel } = panelAndSettings();
+  const body = Sim3DPanel.renderBody({ ...POSE, background: '#f1f3f6' });
+  assert.equal('size' in body, false);
+  assert.equal(body.fit, 'cover');
+  assert.equal(body.background, '#f1f3f6');
+});
+
+test('an absent pose renders the model square-on rather than failing', () => {
+  const { Sim3DPanel } = panelAndSettings();
+  const body = Sim3DPanel.renderBody({});
+  assert.deepEqual(body.rotation, { x: 0, y: 0, z: 0 });
+  assert.deepEqual(body.variants, {});
+  assert.equal(body.screenGlass, false);
+  assert.equal(body.background, 'transparent');
+});
+
+test('the body does not alias the panel state it was built from', () => {
+  const { Sim3DPanel } = panelAndSettings();
+  const variants = { finish: 'space-black' };
+  const body = Sim3DPanel.renderBody({ ...POSE, variants });
+  variants.finish = 'silver';
+  assert.deepEqual(body.variants, { finish: 'space-black' });
+});
+
+// ── naming the file after what actually came back ────────────
+
+function pngBytes(width, height) {
+  const bytes = new Uint8Array(24);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  new DataView(bytes.buffer).setUint32(16, width);
+  new DataView(bytes.buffer).setUint32(20, height);
+  return bytes;
+}
+
+test('reads the rendered size out of the PNG header', () => {
+  const { Sim3DPanel } = panelAndSettings();
+  assert.deepEqual(Sim3DPanel.pngSize(pngBytes(1290, 2796)), {
+    width: 1290, height: 2796,
+  });
+});
+
+test('reports no size for bytes that are not a PNG', () => {
+  const { Sim3DPanel } = panelAndSettings();
+  assert.equal(Sim3DPanel.pngSize(new Uint8Array(24)), null);
+  assert.equal(Sim3DPanel.pngSize(pngBytes(1, 1).slice(0, 16)), null);
+  assert.equal(Sim3DPanel.pngSize(null), null);
+});
+
+// ── saving a frame end to end ────────────────────────────────
+//
+// The panel's DOM is integration-only, but saving is now a wire call with
+// a fallback behind it, and "the user always ends up with a file" is the
+// promise worth pinning. A fake document is enough to drive it.
+
+// `document`, `fetch` and `URL` are bare globals inside sim-3d.js (it is a
+// browser file, not a module), so the fakes have to be real Node globals
+// rather than properties of the throwaway `window`. Every test restores
+// them so the stubs don't leak into the rest of the process.
+function fakePanel(respond) {
+  const anchors = [];
+  const requests = [];
+  const saved = { document: global.document, fetch: global.fetch, URL: global.URL };
+  global.document = {
+    createElement() {
+      return { href: '', download: '', click() { anchors.push(this); } };
+    },
+  };
+  global.URL = {
+    createObjectURL: (blob) => 'blob:' + blob.id,
+    revokeObjectURL() {},
+  };
+  global.fetch = (url, init) => {
+    requests.push({ url, init, body: JSON.parse(init.body) });
+    return respond();
+  };
+  const restore = () => Object.assign(global, saved);
+
+  const window = loadBrowserModules([
+    path.join(WEB, 'capture', 'capture-size.js'),
+    path.join(WEB, 'capture', 'capture-settings.js'),
+    path.join(WEB, 'sim-3d.js'),
+  ]);
+  const panel = new window.Sim3DPanel();
+  panel.udid = 'BC3E-138D';
+  panel.model = { id: 'iphone-17-pro-max' };
+  panel.canvas = {
+    width: 960,
+    height: 960,
+    hasAttribute: () => true,
+    toDataURL: () => 'data:image/png;base64,LIVE',
+  };
+  return { window, panel, anchors, requests, restore };
+}
+
+function pngResponse(width, height) {
+  return async () => ({
+    ok: true,
+    blob: async () => ({
+      id: 'render',
+      arrayBuffer: async () => pngBytes(width, height).buffer,
+    }),
+  });
+}
+
+test('saving posts the pose to render-3d.png and files it under its real size', async (t) => {
+  const { window, panel, anchors, requests, restore } = fakePanel(pngResponse(1290, 2796));
+  t.after(restore);
+  panel.setCaptureSettings(new window.Baguette._CaptureSettings({ size: 'appstore-6.9' }));
+  await panel.download();
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, '/simulators/BC3E-138D/render-3d.png');
+  assert.equal(requests[0].init.method, 'POST');
+  assert.deepEqual(requests[0].body.size, { width: 1290, height: 2796 });
+  assert.equal(anchors.length, 1);
+  assert.equal(anchors[0].href, 'blob:render');
+  assert.equal(anchors[0].download, 'iphone-17-pro-max-3d-appstore-6.9-1290x2796.png');
+});
+
+test('a ratio spec never puts a colon in the saved filename', async (t) => {
+  const { window, panel, anchors, restore } = fakePanel(pngResponse(1600, 900));
+  t.after(restore);
+  panel.setCaptureSettings(new window.Baguette._CaptureSettings({ size: '16:9' }));
+  await panel.download();
+  assert.equal(anchors[0].download, 'iphone-17-pro-max-3d-16-9-1600x900.png');
+});
+
+test('a failed render still saves the live frame rather than nothing', async (t) => {
+  const { panel, anchors, restore } = fakePanel(async () => ({ ok: false, status: 404 }));
+  t.after(restore);
+  await panel.download();
+  assert.equal(anchors.length, 1);
+  assert.equal(anchors[0].href, 'data:image/png;base64,LIVE');
+  assert.equal(anchors[0].download, 'iphone-17-pro-max-live-3d.png');
+});
+
+test('a settings object that cannot plan still leaves the user with a file', async (t) => {
+  const { panel, anchors, restore } = fakePanel(pngResponse(1290, 2796));
+  t.after(restore);
+  panel.setCaptureSettings({ size: 'appstore-6.9' });  // not a CaptureSettings
+  await panel.download();
+  assert.equal(anchors[0].href, 'data:image/png;base64,LIVE');
+});
+
+test('a second click while a render is in flight is ignored', async (t) => {
+  const { panel, requests, restore } = fakePanel(pngResponse(1290, 2796));
+  t.after(restore);
+  await Promise.all([panel.download(), panel.download()]);
+  assert.equal(requests.length, 1);
+});


### PR DESCRIPTION
Unit 4 of the shared capture-size feature: the 3D panel now saves a **re-rendered** PNG at the size the user picked, instead of a lossy video frame at the live stream's clamp.

## What changed

`Sim3DPanel.download()` used to be `canvas.toDataURL('image/png')` — the MJPEG/H.264-decoded live frame, clamped to 480–1600 px by `outputSize()`. It now POSTs the current pose to `/simulators/:udid/render-3d.png` (a clean one-shot RealityKit render nothing in `Resources/Web/` was calling) and saves that.

Measured against a booted iPhone 17 Pro Max:

| capture | before | after |
|---|---|---|
| native | ~960 × 960, video-decoded | **1320 × 2868**, clean render |
| `appstore-6.9` | not possible | **1290 × 2796** |

## Details

- **`Sim3DPanel.renderBody({rotation, variants, screenGlass, settings, streamSize, background})`** — a pure static that builds the `DeviceRenderOptions` body, so the arithmetic is testable without a canvas. `native` omits `size` (the server then renders at the screen's own pixel size, truer than anything the browser can name); ratio presets resolve against the live frame; the live stream's 480–1600 clamp never applies.
- **`fit` is pinned to `cover`, not passed through from CaptureSettings.** On this route `fit` is *not* canvas placement — `Server.render3D` hands it to `DeviceScreenFit.placement`, the screen texture's UV placement on the device mesh. Passing the toolbar's default `contain` would letterbox the app screenshot *inside* the phone display and no longer match the live view. Canvas placement for a 3D render is the camera's job; there is no fit for it. Flagged for the docs/toolbar units.
- **`setCaptureSettings(settings)`** for the toolbar picker (unit 3), and `panel.canvas` documented as the recorder's capture source for 3D recording.
- **The canvas path is now a total fallback.** Any failure — route missing, HTTP error, malformed settings — logs why and saves the live frame as `<model>-live-3d.png`, so a save never leaves the user with no file.
- A save in flight ignores further clicks (each one costs a screen capture + a RealityKit render) and shows a busy button; a live zoom logs a warning, since `DeviceRenderOptions` carries no zoom field and the render always frames at 1×.
- Filenames come from `settings.slug(w, h)` using the dimensions read out of the returned PNG's IHDR — what actually came back, not what was asked for — sanitised so a `16:9` spec can't put a colon in a filename.

## Testing

`Tests/Web/sim-3d-capture.test.js` (19 tests) covers the request building per preset, the PNG header read, and the save path end to end against a fake document — including both fallback routes and the re-entrancy guard. Full suite: 237/237 green (`make test-web`).

Verified against a booted simulator with `curl` at both native and App Store sizes. The browser leg of the e2e recipe could not run — the Chrome extension was not connected in this environment — so the DOM wiring is covered by the fake-document tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added high-resolution frame downloads using the current pose, variants, glass, background, and capture size.
  * Capture settings can now be updated while the live stream remains active.
  * Downloaded images receive dimension-based, sanitized filenames.
  * Added fallback to save the live frame when server rendering is unavailable.

* **Bug Fixes**
  * Prevented overlapping frame-save operations and improved save button state handling.

* **Tests**
  * Added comprehensive coverage for capture settings, rendering, downloads, fallbacks, filenames, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->