### PR TITLE
feat: capture size picker on the legacy stream sidebar (Capture + Record)

### DIFF
--- a/Sources/Baguette/Resources/Web/sim-stream.html
+++ b/Sources/Baguette/Resources/Web/sim-stream.html
@@ -86,7 +86,15 @@
     #simStreamSidebar .adv .kv .v{display:flex;gap:4px;flex:1}
     #simStreamSidebar .adv .kv .v .btn{flex:1;min-width:0;font-size:11px;padding:0 6px}
     #simStreamSidebar .captures-head{display:flex;align-items:center;gap:6px}
-    #simStreamSidebar .captures-head .with-frame{font-size:11px;color:var(--text-muted);display:flex;align-items:center;gap:4px;cursor:pointer;user-select:none}
+    /* The size picker's popover is absolutely positioned inside the card
+       header, and `.card` clips with overflow:hidden to round its corners.
+       Let this one card overflow and round the header itself instead, so
+       the popover can drop down over the body. */
+    #simStreamSidebar #simCapturesCard{overflow:visible}
+    /* `inherit` rather than a literal radius: `.card` is styled by the
+       host page, so the header follows whatever corner it actually has. */
+    #simStreamSidebar #simCapturesCard > .card-header{border-radius:inherit;border-bottom-left-radius:0;border-bottom-right-radius:0}
+    #simStreamSidebar #simCaptureSizeOut{font-size:10px;color:var(--text-muted);font-variant-numeric:tabular-nums;text-align:center;min-height:12px}
     #simStreamSidebar details.events > summary{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;padding:10px 12px;background:#f8fafc;border-bottom:1px solid var(--border);user-select:none}
     #simStreamSidebar details.events > summary::-webkit-details-marker{display:none}
     #simStreamSidebar details.events > summary::after{content:'▸';font-size:10px;color:var(--text-muted);transition:transform 0.15s ease}
@@ -241,13 +249,18 @@
         </div>
       </div>
 
-      <div class="card">
+      <div class="card" id="simCapturesCard">
         <div class="card-header">
           <div class="captures-head">
             <span class="card-title" style="font-size:12px;flex:1">Captures <span id="simCaptureCount" style="font-weight:500;color:var(--text-muted)"></span></span>
-            <label class="with-frame">
-              <input type="checkbox" id="simFrameToggle" onchange="window._simToggleFrame(this.checked)" style="cursor:pointer"> with frame
-            </label>
+            <!-- CaptureSizeMenu mounts here (sim-stream.js). It owns the
+                 output size, fit, background AND the "Include bezel"
+                 switch, which is why the old standalone `#simFrameToggle`
+                 checkbox is gone: `CaptureSettings.withFrame` is the same
+                 state, and two controls for one flag drift apart the
+                 moment one of them is used. `window._simToggleFrame`
+                 still exists and now routes into this menu. -->
+            <span id="simCaptureSizeHost"></span>
           </div>
         </div>
         <div class="card-body padded" style="display:flex;flex-direction:column;gap:8px">
@@ -260,6 +273,9 @@
             <span id="simRecordLabel">Record</span>
             <span id="simRecordTimer" style="font-variant-numeric:tabular-nums;color:var(--text-muted);font-size:11px;margin-left:4px"></span>
           </button>
+          <!-- What the current selection actually produces, so the user
+               sees the pixels before spending a capture on them. -->
+          <div id="simCaptureSizeOut"></div>
           <div id="simRecordList" style="display:flex;flex-direction:column;gap:4px"></div>
           <div id="simCaptureGallery" style="display:flex;flex-wrap:wrap;gap:6px;min-height:32px">
             <div style="color:var(--text-muted);font-size:11px;padding:4px 2px">No captures yet</div>

--- a/Sources/Baguette/Resources/Web/sim-stream.js
+++ b/Sources/Baguette/Resources/Web/sim-stream.js
@@ -25,8 +25,14 @@
 
   let activeUdid = null;
   let activeName = null;
+  let sizeMenu = null;      // CaptureSizeMenu — output size / fit / bezel
   let captureWithFrame = false;
   let lastPaintedSize = { w: 0, h: 0 };
+
+  // One persisted selection for both capture surfaces in this sidebar —
+  // a screenshot and a recording of the same device should come out the
+  // same shape without asking twice.
+  const CAPTURE_STORAGE_KEY = 'asc.capture.stream';
 
   // Recording state. BrowserRecorder spins up a compose canvas only
   // while active; references are pulled from what's already on the
@@ -181,7 +187,13 @@
     session = new window.StreamSession({
       udid, format, version: 'v2',
       canvas: sim.canvas,
-      onSize: (w, h) => { lastPaintedSize = { w, h }; },
+      onSize: (w, h) => {
+        const changed = w !== lastPaintedSize.w || h !== lastPaintedSize.h;
+        lastPaintedSize = { w, h };
+        // Ratio presets resolve against the source, so the hint moves
+        // when the stream scale does.
+        if (changed) renderCaptureSizeHint();
+      },
       onFps:  (fps) => {
         const el = document.getElementById('simStreamFps');
         if (el) el.textContent = fps + ' fps';
@@ -196,6 +208,7 @@
     });
     gallery.clear();
     renderGallery();
+    mountCaptureSizeMenu();
 
     // Live unified-log panel — opens its own WS to /simulators/<udid>/logs.
     // Independent of the stream socket so logs survive even when the
@@ -241,6 +254,7 @@
     if (recordingState.recorder) {
       try { recordingState.recorder.cancel(); } catch { /* ignore */ }
     }
+    if (sizeMenu) { sizeMenu.detach(); sizeMenu = null; }
     if (axInspector) { axInspector.detach(); axInspector = null; }
     if (cameraPanel) { cameraPanel.detach(); cameraPanel = null; }
     if (session) { session.stop(); session = null; }
@@ -256,6 +270,104 @@
     const list = document.getElementById('simListView');
     if (list) list.style.display = '';
     if (window.loadSimDeviceList) window.loadSimDeviceList();
+  }
+
+  // --- Capture size ---------------------------------------------------
+  // The sidebar's screenshot and its recording share one CaptureSettings,
+  // edited through the CaptureSizeMenu chip in the Captures card header.
+
+  /** The current selection, or null when /capture/*.js isn't loaded
+   *  (the host SPA can pull in sim-stream.js on its own). Call sites
+   *  treat null as "no resizing", i.e. exactly the old behaviour. */
+  function captureSettings() {
+    return sizeMenu ? sizeMenu.settings : null;
+  }
+
+  /**
+   * What a ratio preset resolves against.
+   *
+   * With the bezel composited in, the output is bezel-sized — both
+   * surfaces draw the source into the frame image's natural box.
+   *
+   * Bare, it's the device's *native* pixel size, not `lastPaintedSize`:
+   * `/screenshot.jpg` is always served at native resolution regardless
+   * of the stream's Resolution knob, and the recorder ratchets the
+   * stream to scale 1 before it starts. `lastPaintedSize` is the
+   * decoded frame, i.e. native divided by that knob — so multiply it
+   * back out rather than resolving a `square` against a third of the
+   * device.
+   *
+   * Reads `withFrame` off the menu rather than the module mirror: the
+   * menu re-renders its popover (calling back in here) before it fires
+   * `onChange`, so the mirror is one interaction stale mid-toggle.
+   */
+  function captureSourceSize() {
+    const wantFrame = sizeMenu ? sizeMenu.settings.withFrame : captureWithFrame;
+    const fimg = wantFrame && sim && sim._bezel ? sim._bezel.frameImg : null;
+    if (fimg && fimg.naturalWidth > 0) {
+      return { width: fimg.naturalWidth, height: fimg.naturalHeight };
+    }
+    if (lastPaintedSize.w && lastPaintedSize.h) {
+      const divisor = readActiveQuality().scale || 1;
+      return {
+        width: lastPaintedSize.w * divisor,
+        height: lastPaintedSize.h * divisor,
+      };
+    }
+    return null;
+  }
+
+  function mountCaptureSizeMenu() {
+    const host = document.getElementById('simCaptureSizeHost');
+    if (!host || !window.CaptureSizeMenu) return;
+    if (sizeMenu) { sizeMenu.detach(); sizeMenu = null; }
+    host.innerHTML = '';
+    sizeMenu = new window.CaptureSizeMenu({
+      storageKey: CAPTURE_STORAGE_KEY,
+      showFrameToggle: true,
+      sourceSize: captureSourceSize,
+      onChange: (settings) => {
+        // `withFrame` lives on the settings value; this mirror is what
+        // the rest of the file (and the legacy `_simToggleFrame` entry
+        // point) reads, so there is still exactly one flag.
+        captureWithFrame = settings.withFrame;
+        renderCaptureSizeHint();
+      },
+    });
+    sizeMenu.mount(host);
+    // CaptureSettings defaults `withFrame` to true, but the checkbox this
+    // menu replaces shipped unchecked — and it drives the *recorder* as
+    // well as the screenshot. Seed the first run to false so an upgrading
+    // user's recordings don't silently gain a bezel; once they've touched
+    // the switch, the persisted value wins.
+    if (!hasStoredCaptureSettings()) sizeMenu.apply({ withFrame: false });
+    captureWithFrame = sizeMenu.settings.withFrame;
+    renderCaptureSizeHint();
+  }
+
+  function hasStoredCaptureSettings() {
+    try {
+      return window.localStorage.getItem(CAPTURE_STORAGE_KEY) != null;
+    } catch {
+      return false;  // Safari private browsing — treat as first run
+    }
+  }
+
+  // The pixels the current selection resolves to, shown under the two
+  // capture buttons. Reads the same `plan()` the capture surfaces do, so
+  // it can't drift from what they produce once both are on the shared
+  // vocabulary (capture-gallery.js / recorder.js land alongside this).
+  function renderCaptureSizeHint() {
+    const el = document.getElementById('simCaptureSizeOut');
+    if (!el) return;
+    const settings = captureSettings();
+    const source = captureSourceSize();
+    if (!settings || !source) { el.textContent = ''; return; }
+    const plan = settings.plan(source.width, source.height);
+    if (!plan.width || !plan.height) { el.textContent = ''; return; }
+    el.textContent = settings.size.isNative
+      ? `${plan.width} × ${plan.height} · native`
+      : `${plan.width} × ${plan.height} · ${settings.size.label} · ${settings.fit}`;
   }
 
   function renderGallery() {
@@ -292,7 +404,14 @@
     sim.type(t);
     el.value = '';
   };
-  window._simToggleFrame = (checked) => { captureWithFrame = checked; };
+  // The standalone "with frame" checkbox is gone — CaptureSizeMenu's
+  // "Include bezel" switch is the same flag. This entry point stays for
+  // anything still calling it (host SPA, plugins) and routes into the
+  // menu so both stay one state.
+  window._simToggleFrame = (checked) => {
+    if (sizeMenu) sizeMenu.apply({ withFrame: !!checked });
+    else captureWithFrame = !!checked;
+  };
 
   window._simSetFormat = (btn) => {
     if (!btn) return;
@@ -327,7 +446,14 @@
   window._simCapture = async () => {
     if (!gallery) return;
     try {
+      // Belt and braces: `settings` is the new shape CaptureGallery reads
+      // for output size / fit / background, `withFrame` + `naturalSize`
+      // are the shape it has always read. Passing both means this call
+      // site works against either version of capture-gallery.js — the
+      // two land on separate branches and neither has to wait for the
+      // other. Drop the legacy pair once `settings` is required.
       const r = await gallery.capture({
+        settings: captureSettings(),
         withFrame: captureWithFrame,
         naturalSize: lastPaintedSize,
       });
@@ -359,11 +485,7 @@
       if (label) label.textContent = 'Saving…';
       if (timer) timer.textContent = '';
       if (btn)   btn.classList.remove('recording');
-      // Restore the stream quality the user had before we bumped it.
-      if (recordingState.savedQuality) {
-        applyQuality(recordingState.savedQuality);
-        recordingState.savedQuality = null;
-      }
+      restoreSavedQuality();
       try {
         const artifact = await rec.stop();
         onRecordFinished(artifact);
@@ -386,10 +508,17 @@
       recordingState.savedQuality = readActiveQuality();
       applyQuality({ scale: 1, fps: 60, bps: 8_000_000 });
 
-      // The "with frame" toggle drives both screenshots AND
-      // recordings — passing `screen: null` to the recorder makes it
-      // fall through to bare-screen mode (no bezel composite).
+      // The bezel switch drives both screenshots AND recordings —
+      // passing `screen: null` to the recorder makes it fall through to
+      // bare-screen mode (no bezel composite).
+      //
+      // Belt and braces, same as `_simCapture`: `settings` carries the
+      // output size for a recorder that understands it, while the
+      // canvas / frameImg / screen / overlayHost / fps quartet is what
+      // today's recorder.js reads. Both shapes ship together so this
+      // call site is correct whichever version is loaded.
       const rec = new window.BrowserRecorder({
+        settings:    captureSettings(),
         canvas:      sim.canvas,
         frameImg:    captureWithFrame ? sim._bezel.frameImg     : null,
         screen:      captureWithFrame ? sim.screen.def          : null,
@@ -403,6 +532,18 @@
       onRecordError(err);
     }
   };
+
+  // Put the pre-recording knobs back. Unconditional on every path that
+  // leaves "not recording": stop, *and* a start that threw. Restoring
+  // only on stop pins the live stream at scale 1 / 60fps / 8 Mbps for
+  // the rest of the session when `new BrowserRecorder(...)` or
+  // `.start()` fails, with no recording to show for it and no way back
+  // short of a reload.
+  function restoreSavedQuality() {
+    if (!recordingState.savedQuality) return;
+    applyQuality(recordingState.savedQuality);
+    recordingState.savedQuality = null;
+  }
 
   function onRecordStarted() {
     recordingState.active = true;
@@ -426,6 +567,7 @@
   function onRecordError(err) {
     recordingState.active = false;
     recordingState.recorder = null;
+    restoreSavedQuality();  // a start that never began must not keep the bump
     if (recordingState.timer) { clearInterval(recordingState.timer); recordingState.timer = null; }
     updateRecordButton();
     updateRecordTimer();

--- a/Sources/Baguette/Resources/Web/sim.html
+++ b/Sources/Baguette/Resources/Web/sim.html
@@ -53,6 +53,15 @@
      happily answers with sim.html — leaving the browser to parse HTML
      as JS and throw `Unexpected token '<'`. -->
 <script src="/frame-decoder.js"></script>
+<!-- Shared capture-size vocabulary (Resources/Web/capture/). These must
+     load BEFORE capture-gallery.js / recorder.js / sim-stream.js: the
+     picker and both capture surfaces read `window.Baguette._CaptureSize`
+     and `_CaptureSettings` at construction time. Order inside the group
+     matters too — settings parses a size, the menu renders settings. -->
+<script src="/capture/capture-size.js"></script>
+<script src="/capture/capture-settings.js"></script>
+<script src="/capture/capture-composer.js"></script>
+<script src="/capture/capture-size-menu.js"></script>
 <script src="/capture-gallery.js"></script>
 <script src="/recorder.js"></script>
 <script src="/stream-session.js"></script>


### PR DESCRIPTION
Unit 5 of the shared capture-size feature: the legacy `/simulators#stream=<udid>` sidebar can now pick an output size once and get it from **both** the screenshot and the recording.

## What changed

- **`sim.html`** loads the four `/capture/*.js` modules ahead of `capture-gallery.js` and `recorder.js` (both read the vocabulary at construction time).
- **`sim-stream.html`** mounts `CaptureSizeMenu` in the Captures card header (`storageKey: 'asc.capture.stream'`) and adds a one-line resolved-size readout under the two buttons. The Captures card gets `overflow: visible` so the popover can drop over the body.
- **`sim-stream.js`** owns the menu lifecycle and threads the resulting `CaptureSettings` into `CaptureGallery.capture(...)` and `new BrowserRecorder(...)`.

## The two-controls-for-one-flag reconciliation

The standalone `#simFrameToggle` checkbox is **removed**. `CaptureSettings` already carries `withFrame` and the menu renders an "Include bezel" switch — keeping both would let them drift the moment one is used. `window._simToggleFrame(checked)` stays as an entry point and now routes into the menu, so anything still calling it keeps working and stays in sync.

`captureWithFrame` semantics are preserved: `CaptureSettings` defaults `withFrame` to `true`, but the checkbox it replaces shipped unchecked *and drives the recorder*, so the first run is seeded to `false`. Once the user touches the switch, the persisted value wins.

## Resolved-size readout

Shows e.g. `990 × 990 · Square · contain`, computed from the same `plan()` the capture surfaces use. It resolves against the device's **native** pixel size, not the decoded frame: `/screenshot.jpg` ignores the stream Resolution knob, and the recorder ratchets the stream to scale 1 before starting. With the bezel on, the source is the frame image's natural box, which is what both surfaces composite into.

## Belt and braces with units 1 & 2

`capture-gallery.js` (unit 2) and `recorder.js` (unit 1) are gaining a `settings` option in parallel. Both call sites here pass **`settings` plus today's legacy shape**, so they're correct against either version and neither PR has to land first. Commented at both sites; drop the legacy pair once `settings` is required.

## Drive-by fix (reported by unit 1)

The pre-recording stream quality was restored only on the stop path. A `BrowserRecorder` construction or `start()` that threw left the live stream pinned at scale 1 / 60 fps / 8 Mbps for the rest of the session, with no recording to show for it. `restoreSavedQuality()` now runs on the error path too.

## Testing

`make test-web` — 220 pass, 0 fail. No new unit tests: this is DOM wiring in `sim-stream.js`, which is integration-only per CLAUDE.md (same bar as `sim-native.js`); the geometry and persistence it calls into are already covered by `capture-size.test.js` / `capture-settings.test.js`.

End-to-end against a booted iPhone 17 Pro Max (headless Chrome over CDP — the Chrome MCP extension wasn't connected in this session):

- chip mounts in the card header, hint reads `1320 × 2868 · native`
- popover lists resolved dimensions per preset (`App Store 6.9″ 1290×2796`, `Square 2868×2868`, …)
- picking **Square** updates the chip, the hint (`2868 × 2868 · Square · contain`) and `localStorage`
- toggling **Include bezel** moves the hint *and* the popover's per-preset dims to the bezel source (`Native 474×990`, `Square 990×990`) in the same interaction
- **Take screenshot** lands a thumbnail in the gallery; **Record** for 3 s produces a download link and the label returns to `Record`
- `Runtime.exceptionThrown` / console errors: none

Thumbnails are still native until unit 2's `capture-gallery.js` lands — expected, that's the other half of the pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)