### PR TITLE
feat: render-3d and the live 3D stream accept capture-size presets

### DIFF
--- a/Sources/Baguette/App/Commands/Render3DCommand.swift
+++ b/Sources/Baguette/App/Commands/Render3DCommand.swift
@@ -26,9 +26,19 @@ struct Render3DCommand: AsyncParsableCommand {
     @Option(help: "Device rotation as X,Y,Z degrees")
     var rotation: String = "0,0,0"
 
-    @Option(help: "Output dimensions as WIDTHxHEIGHT (defaults to screen size)")
+    // The shared capture vocabulary: a preset, literal pixels, or a bare
+    // ratio. Omitted is `native` — the captured screen's own dimensions,
+    // which is what --size has always defaulted to.
+    @Option(help: """
+    Output size: WIDTHxHEIGHT, W:H, or one of: \(CaptureSize.presetList) \
+    (defaults to the captured screen size)
+    """)
     var size: String?
 
+    // `--fit` is NOT the canvas fit `CaptureFit` describes, despite the
+    // shared case names: this is how the screenshot is laid onto the device's
+    // screen mesh (a UV placement), while `--size` above governs the canvas
+    // the whole render lands on. The two never meet.
     @Option(help: "Screen placement: cover, contain, or stretch")
     var fit: String = "cover"
 
@@ -50,7 +60,7 @@ struct Render3DCommand: AsyncParsableCommand {
             throw ValidationError("--device is required with --screen")
         }
         _ = try DeviceRenderArguments.rotation(rotation)
-        if let size { _ = try DeviceRenderArguments.size(size) }
+        if let size { _ = try DeviceRenderArguments.captureSize(size) }
         _ = try DeviceRenderArguments.variants(variants)
         guard DeviceScreenFit(rawValue: fit) != nil else {
             throw ValidationError("--fit must be cover, contain, or stretch")
@@ -100,8 +110,12 @@ struct Render3DCommand: AsyncParsableCommand {
             throw ValidationError("exactly one of --udid and --screen is required")
         }
 
-        let outputSize = try size.map(DeviceRenderArguments.size)
-            ?? Self.pixelSize(of: screenImage)
+        // A ratio (`square`, `3:2`) has no meaning until there is a source
+        // to grow against, and that source is the screenshot we just took —
+        // the same image `native` would render at 1:1.
+        let sourceSize = try Self.pixelSize(of: screenImage)
+        let captureSize = try size.map(DeviceRenderArguments.captureSize) ?? .native
+        let outputSize = captureSize.resolve(source: sourceSize)
         let plan = try DeviceRenderPlan.build(
             model: installed,
             variants: DeviceRenderArguments.variants(variants),

--- a/Sources/Baguette/Domain/Render/Device3DStreamOptions.swift
+++ b/Sources/Baguette/Domain/Render/Device3DStreamOptions.swift
@@ -12,6 +12,11 @@ struct Device3DStreamOptions: Equatable, Sendable {
     let background: DeviceRenderBackground
     let screenGlass: Bool
 
+    /// The largest frame the live path will encode, per axis. `size=` is
+    /// held to it too, so a preset can't route around the bound `width=` /
+    /// `height=` already carry.
+    private static let maximumAxis = 4096
+
     static let `default` = Device3DStreamOptions(
         rotation: DeviceRotation(x: -8, y: 18, z: 0),
         variants: [:],
@@ -28,6 +33,18 @@ struct Device3DStreamOptions: Equatable, Sendable {
             ?? Self.default.outputSize.width
         let height = try query.single("height").map(parsePositiveInt)
             ?? Self.default.outputSize.height
+        // `size=` names an output shape in the vocabulary the picker and
+        // `--size` share; `width=` / `height=` still say it in pixels and
+        // are unchanged. When both arrive, the requested frame is what a
+        // ratio grows from — the live stream stays bounded in practice by
+        // whatever the browser asked for (`Sim3DPanel` clamps 480–1600).
+        let requested = RenderDimensions(width: width, height: height)
+        let resolved = try query.single("size").map(parseSize)?
+            .resolve(source: requested) ?? requested
+        guard resolved.width > 0, resolved.height > 0,
+              resolved.width <= maximumAxis, resolved.height <= maximumAxis else {
+            throw DeviceModelError.invalidRenderOptions
+        }
         let fit = try query.single("fit").map { value in
             guard let fit = DeviceScreenFit(rawValue: value) else {
                 throw DeviceModelError.invalidRenderOptions
@@ -56,7 +73,7 @@ struct Device3DStreamOptions: Equatable, Sendable {
             rotation: rotation,
             variants: variants,
             outputSize: VideoFrameDimensions(
-                requested: RenderDimensions(width: width, height: height)
+                requested: resolved
             ).renderDimensions,
             fit: fit,
             background: background,
@@ -72,8 +89,16 @@ struct Device3DStreamOptions: Equatable, Sendable {
         return DeviceRotation(x: values[0], y: values[1], z: values[2])
     }
 
+    private static func parseSize(_ value: String) throws -> CaptureSize {
+        do {
+            return try CaptureSize.parse(value)
+        } catch {
+            throw DeviceModelError.invalidRenderOptions
+        }
+    }
+
     private static func parsePositiveInt(_ value: String) throws -> Int {
-        guard let result = Int(value), result > 0, result <= 4096 else {
+        guard let result = Int(value), result > 0, result <= maximumAxis else {
             throw DeviceModelError.invalidRenderOptions
         }
         return result

--- a/Sources/Baguette/Domain/Render/DeviceRenderArguments.swift
+++ b/Sources/Baguette/Domain/Render/DeviceRenderArguments.swift
@@ -13,16 +13,22 @@ enum DeviceRenderArguments {
         return DeviceRotation(x: x, y: y, z: z)
     }
 
-    static func size(_ value: String) throws -> RenderDimensions {
-        let parts = value.lowercased()
-            .split(separator: "x", omittingEmptySubsequences: false)
-        guard parts.count == 2,
-              let width = Int(parts[0]),
-              let height = Int(parts[1]),
-              width > 0, height > 0 else {
+    /// `--size` in the shared capture vocabulary: a preset name
+    /// (`appstore-6.9`, `square`), literal `WIDTHxHEIGHT`, or a bare ratio
+    /// (`3:2`). A ratio means nothing on its own — the caller resolves the
+    /// returned value against the captured screen, the same source the
+    /// default (`native`) renders at.
+    ///
+    /// `CaptureSize.parse` speaks `CaptureSizeError`, but this is the CLI's
+    /// `--size` argument, so it keeps reporting the argument error
+    /// `render-3d` has always reported for a size it can't read. Nothing is
+    /// substituted for an unreadable size — same bar as an unknown model.
+    static func captureSize(_ value: String) throws -> CaptureSize {
+        do {
+            return try CaptureSize.parse(value)
+        } catch {
             throw DeviceModelError.invalidSizeArgument(value)
         }
-        return RenderDimensions(width: width, height: height)
     }
 
     static func variants(_ values: [String]) throws -> [String: String] {

--- a/Sources/Baguette/Domain/Render/DeviceRenderOptions.swift
+++ b/Sources/Baguette/Domain/Render/DeviceRenderOptions.swift
@@ -3,10 +3,69 @@ import Foundation
 struct DeviceRenderOptions: Equatable, Sendable {
     let rotation: DeviceRotation
     let variants: [String: String]
-    let size: RenderDimensions?
+    /// What the caller asked the render to come out at, in the vocabulary
+    /// the toolbar picker and `--size` share. `.native` — the default —
+    /// means "whatever the captured screen already is".
+    let captureSize: CaptureSize
+    /// How the screenshot sits on the device's screen mesh — a UV placement.
+    /// Not `CaptureFit`, which places a source on a canvas; the two share
+    /// case names and nothing else.
     let fit: DeviceScreenFit
     let background: DeviceRenderBackground
     let screenGlass: Bool
+
+    /// The exact pixel size, when the caller named one. `nil` for `native`
+    /// and for a ratio, both of which only mean something once there is a
+    /// captured screen to measure against — those go through
+    /// `outputSize(source:)`.
+    var size: RenderDimensions? {
+        guard case .fixed(let dimensions) = captureSize.kind else { return nil }
+        return dimensions
+    }
+
+    /// The canvas this render should be produced on, given the screen that
+    /// was actually captured. A ratio grows against that source rather than
+    /// cropping it, so `square` on a tall phone yields a tall-side square
+    /// with the device centred.
+    func outputSize(source: RenderDimensions) -> RenderDimensions {
+        captureSize.resolve(source: source)
+    }
+
+    /// Pixel-size spelling, kept for the callers that predate the shared
+    /// size vocabulary. `nil` is `native`.
+    init(
+        rotation: DeviceRotation,
+        variants: [String: String],
+        size: RenderDimensions?,
+        fit: DeviceScreenFit,
+        background: DeviceRenderBackground,
+        screenGlass: Bool
+    ) {
+        self.init(
+            rotation: rotation,
+            variants: variants,
+            captureSize: size.map(Self.exact) ?? .native,
+            fit: fit,
+            background: background,
+            screenGlass: screenGlass
+        )
+    }
+
+    init(
+        rotation: DeviceRotation,
+        variants: [String: String],
+        captureSize: CaptureSize,
+        fit: DeviceScreenFit,
+        background: DeviceRenderBackground,
+        screenGlass: Bool
+    ) {
+        self.rotation = rotation
+        self.variants = variants
+        self.captureSize = captureSize
+        self.fit = fit
+        self.background = background
+        self.screenGlass = screenGlass
+    }
 
     static func parsing(json: Data) throws -> DeviceRenderOptions {
         let wire: Wire
@@ -25,12 +84,28 @@ struct DeviceRenderOptions: Equatable, Sendable {
             throw DeviceModelError.invalidRenderOptions
         }
 
-        let size = wire.size.map {
-            RenderDimensions(width: $0.width, height: $0.height)
+        // `size` arrives either as the pixel object the browser has always
+        // posted, or as a spec string in the shared vocabulary — the same
+        // `appstore-6.9` / `square` / `3:2` names the CLI takes. Neither
+        // form ever falls back to a nearby size: an unreadable spec is a
+        // rejected request, exactly like an unknown model variant.
+        let captureSize: CaptureSize
+        switch wire.size {
+        case .none:
+            captureSize = .native
+        case .exact(let dimensions):
+            guard dimensions.width > 0, dimensions.height > 0 else {
+                throw DeviceModelError.invalidRenderOptions
+            }
+            captureSize = Self.exact(dimensions)
+        case .spec(let spec):
+            do {
+                captureSize = try CaptureSize.parse(spec)
+            } catch {
+                throw DeviceModelError.invalidRenderOptions
+            }
         }
-        if let size, size.width <= 0 || size.height <= 0 {
-            throw DeviceModelError.invalidRenderOptions
-        }
+
         guard let fit = DeviceScreenFit(rawValue: wire.fit ?? "cover") else {
             throw DeviceModelError.invalidRenderOptions
         }
@@ -53,10 +128,20 @@ struct DeviceRenderOptions: Equatable, Sendable {
         return DeviceRenderOptions(
             rotation: rotation,
             variants: wire.variants ?? [:],
-            size: size,
+            captureSize: captureSize,
             fit: fit,
             background: background,
             screenGlass: wire.screenGlass ?? false
+        )
+    }
+
+    /// An explicit pixel size wearing the shared vocabulary's clothes —
+    /// the same value `CaptureSize.parse("1200x900")` produces.
+    private static func exact(_ dimensions: RenderDimensions) -> CaptureSize {
+        CaptureSize(
+            spec: "\(dimensions.width)x\(dimensions.height)",
+            label: "\(dimensions.width) × \(dimensions.height)",
+            kind: .fixed(dimensions)
         )
     }
 }
@@ -77,8 +162,27 @@ private extension DeviceRenderOptions {
         let z: Double
     }
 
-    struct Size: Decodable {
-        let width: Int
-        let height: Int
+    /// Both spellings of `"size"`: the `{width, height}` object the browser
+    /// has always posted, and a `"square"` / `"appstore-6.9"` spec string.
+    enum Size: Decodable {
+        case exact(RenderDimensions)
+        case spec(String)
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let spec = try? container.decode(String.self) {
+                self = .spec(spec)
+                return
+            }
+            let pixels = try container.decode(Pixels.self)
+            self = .exact(
+                RenderDimensions(width: pixels.width, height: pixels.height)
+            )
+        }
+
+        private struct Pixels: Decodable {
+            let width: Int
+            let height: Int
+        }
     }
 }

--- a/Tests/BaguetteTests/Render/Device3DStreamOptionsTests.swift
+++ b/Tests/BaguetteTests/Render/Device3DStreamOptionsTests.swift
@@ -70,4 +70,26 @@ struct Device3DStreamOptionsTests {
             _ = try Device3DStreamOptions.parse(["fit": ["squash"]])
         }
     }
+
+    @Test func `parses a size preset for the live stream`() throws {
+        let options = try Device3DStreamOptions.parse(["size": ["appstore-6.9"]])
+
+        #expect(options.outputSize == RenderDimensions(width: 1290, height: 2796))
+    }
+
+    @Test func `resolves a live stream ratio against the requested frame`() throws {
+        let options = try Device3DStreamOptions.parse([
+            "width": ["1280"],
+            "height": ["720"],
+            "size": ["square"],
+        ])
+
+        #expect(options.outputSize == RenderDimensions(width: 1280, height: 1280))
+    }
+
+    @Test func `rejects an unknown live stream size preset`() {
+        #expect(throws: DeviceModelError.invalidRenderOptions) {
+            _ = try Device3DStreamOptions.parse(["size": ["gigantic"]])
+        }
+    }
 }

--- a/Tests/BaguetteTests/Render/DeviceRenderArgumentsTests.swift
+++ b/Tests/BaguetteTests/Render/DeviceRenderArgumentsTests.swift
@@ -7,7 +7,8 @@ struct DeviceRenderArgumentsTests {
     @Test func `parses rotation size and repeatable variants`() throws {
         #expect(try DeviceRenderArguments.rotation("-30,45,30")
             == DeviceRotation(x: -30, y: 45, z: 30))
-        #expect(try DeviceRenderArguments.size("1200x900")
+        #expect(try DeviceRenderArguments.captureSize("1200x900")
+            .resolve(source: RenderDimensions(width: 1179, height: 2556))
             == RenderDimensions(width: 1200, height: 900))
         #expect(try DeviceRenderArguments.variants([
             "finish=space-black", "keyboard=iso"
@@ -25,7 +26,7 @@ struct DeviceRenderArgumentsTests {
 
     @Test func `rejects malformed size`() {
         #expect(throws: DeviceModelError.invalidSizeArgument("1200")) {
-            _ = try DeviceRenderArguments.size("1200")
+            _ = try DeviceRenderArguments.captureSize("1200")
         }
     }
 
@@ -34,6 +35,33 @@ struct DeviceRenderArgumentsTests {
             _ = try DeviceRenderArguments.variants([
                 "finish=black", "finish=silver"
             ])
+        }
+    }
+
+    @Test func `parses a size preset where it used to demand pixels`() throws {
+        #expect(try DeviceRenderArguments.captureSize("appstore-6.9")
+            .resolve(source: RenderDimensions(width: 1179, height: 2556))
+            == RenderDimensions(width: 1290, height: 2796))
+    }
+
+    @Test func `resolves a ratio size against the captured screen`() throws {
+        #expect(try DeviceRenderArguments.captureSize("square")
+            .resolve(source: RenderDimensions(width: 1290, height: 2796))
+            == RenderDimensions(width: 2796, height: 2796))
+        #expect(try DeviceRenderArguments.captureSize("3:2")
+            .resolve(source: RenderDimensions(width: 1200, height: 900))
+            == RenderDimensions(width: 1350, height: 900))
+    }
+
+    @Test func `defaults to the captured screen size when no size is asked for`() {
+        #expect(CaptureSize.native
+            .resolve(source: RenderDimensions(width: 1179, height: 2556))
+            == RenderDimensions(width: 1179, height: 2556))
+    }
+
+    @Test func `rejects an unknown size preset as a malformed size argument`() {
+        #expect(throws: DeviceModelError.invalidSizeArgument("nonsense")) {
+            _ = try DeviceRenderArguments.captureSize("nonsense")
         }
     }
 }

--- a/Tests/BaguetteTests/Render/DeviceRenderOptionsTests.swift
+++ b/Tests/BaguetteTests/Render/DeviceRenderOptionsTests.swift
@@ -43,4 +43,49 @@ struct DeviceRenderOptionsTests {
             """.utf8))
         }
     }
+
+    @Test func `accepts a size preset name in the render body`() throws {
+        let options = try DeviceRenderOptions.parsing(json: Data("""
+        {"size": "appstore-6.9"}
+        """.utf8))
+
+        #expect(options.captureSize.spec == "appstore-6.9")
+        #expect(options.outputSize(source: RenderDimensions(width: 1179, height: 2556))
+            == RenderDimensions(width: 1290, height: 2796))
+    }
+
+    @Test func `resolves a ratio size in the render body against the captured screen`() throws {
+        let options = try DeviceRenderOptions.parsing(json: Data("""
+        {"size": "square"}
+        """.utf8))
+
+        #expect(options.outputSize(source: RenderDimensions(width: 1290, height: 2796))
+            == RenderDimensions(width: 2796, height: 2796))
+    }
+
+    @Test func `keeps the explicit width and height object form`() throws {
+        let options = try DeviceRenderOptions.parsing(json: Data("""
+        {"size": {"width": 1200, "height": 900}}
+        """.utf8))
+
+        #expect(options.size == RenderDimensions(width: 1200, height: 900))
+        #expect(options.outputSize(source: RenderDimensions(width: 1179, height: 2556))
+            == RenderDimensions(width: 1200, height: 900))
+    }
+
+    @Test func `renders at the captured screen size when no size is asked for`() throws {
+        let options = try DeviceRenderOptions.parsing(json: Data("{}".utf8))
+
+        #expect(options.captureSize == .native)
+        #expect(options.outputSize(source: RenderDimensions(width: 1179, height: 2556))
+            == RenderDimensions(width: 1179, height: 2556))
+    }
+
+    @Test func `rejects an unknown size preset name`() {
+        #expect(throws: DeviceModelError.invalidRenderOptions) {
+            _ = try DeviceRenderOptions.parsing(json: Data("""
+            {"size": "gigantic"}
+            """.utf8))
+        }
+    }
 }


### PR DESCRIPTION
Unit 9 of the shared capture-size feature. `render-3d` and the live 3D stream now speak the same size vocabulary as the screenshot path and the toolbar picker.

## What changed

**`--size` takes a preset.** `--size appstore-6.9`, `--size square`, `--size 3:2` — alongside the `--size 1200x900` it always took. `--help` lists the presets. Omitting `--size` is unchanged: the captured screen's own dimensions (`native`).

A ratio only means something against a source, and that source is the screenshot `render-3d` just captured — the same image `native` renders at 1:1. Ratios grow the binding axis rather than cropping, so `--size square` on a 1320x2868 capture gives 2868x2868 with the device centred.

**The JSON body takes both spellings.** `POST /simulators/:udid/render-3d.png` accepts `{"size": "appstore-6.9"}` as well as the `{"size": {"width": 1200, "height": 900}}` object the browser posts today.

**The live 3D stream query takes `size=<spec>`** alongside the unchanged `width=` / `height=`, which still bound the frame. A preset resolves against that requested box (defaults 960x960) and is held to the same 4096 per-axis ceiling, so it can't route around the bound the explicit dimensions already carry.

**Error surface is unchanged.** `CaptureSizeError` is caught and remapped at every boundary, so malformed input still surfaces as `DeviceModelError.invalidSizeArgument` (CLI) / `invalidRenderOptions` (HTTP + stream). Nothing is substituted for a size baguette can't read — the same bar `render-3d` already holds unknown models and variants to.

**`--fit` is untouched.** `DeviceScreenFit` is the UV placement of the screenshot on the device's *screen mesh*; `CaptureFit` is canvas placement. They share three case names and nothing else, and both are now commented to say so.

## Note for the server-routes unit

`DeviceRenderOptions` now stores a `CaptureSize`. `options.size` survives as a computed `RenderDimensions?` — non-nil for every fixed spec — so `Server.render3D`'s `options.size ?? sourceSize` compiles and behaves exactly as before, and the memberwise init keeps its `size:` label so `Render3DRoutesTests` is untouched. Ratios over HTTP (`{"size":"square"}`) parse and validate but still render at native size until that call site becomes:

```swift
outputSize: options.outputSize(source: sourceSize),
```

`outputSize(source:)` is a strict superset of today's behaviour (source for `.native`, the fixed dims for fixed, grown axis for a ratio). Server.swift is owned by another unit in this stack, so it is deliberately not touched here.

## Tests

TDD: the three existing suites were extended, red observed first (`type 'DeviceRenderArguments' has no member 'captureSize'`, `value of type 'DeviceRenderOptions' has no member 'outputSize'`), then implemented.

- `swift test` — 1512 tests, all green
- `make test-web` — 218 tests, all green
- e2e on a booted iPhone 17 Pro Max (iOS 26.4) with `BAGUETTE_3D_MODEL_DIR` pointed at the bundled models: `appstore-6.9` -> 1290x2796, `square` -> 2868x2868, `1200x900` -> 1200x900, no `--size` -> 1320x2868, `nonsense` -> exit 1. Over HTTP: `"appstore-6.9"` -> 1290x2796, the object form -> 1200x900, `"gigantic"` -> 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)