### PR TITLE
feat: capture output size on the device farm focus pane

### DIFF
--- a/Sources/Baguette/Resources/Web/farm/farm-app.js
+++ b/Sources/Baguette/Resources/Web/farm/farm-app.js
@@ -274,6 +274,12 @@
           frameImg: focusScreen ? focusScreen.querySelector('img') : null,
           screen: def && def.screen ? def.screen : null,
           overlayHost: tile?.overlayContainer() || null,
+          // The chosen output size rides along with the DOM handles for
+          // exactly the same reason they're read late: the picker is
+          // rebuilt by every `focus.show`, so resolving it at Record-press
+          // time is what keeps a re-focus mid-session from stranding the
+          // recorder on a stale CaptureSettings.
+          settings: this.focus ? this.focus.captureSettings() : null,
         };
       },
     });

--- a/Sources/Baguette/Resources/Web/farm/farm-focus.js
+++ b/Sources/Baguette/Resources/Web/farm/farm-focus.js
@@ -11,6 +11,12 @@
 (function () {
   'use strict';
 
+  // The farm's own slot in the shared capture-size vocabulary — each
+  // surface persists its selection separately (`asc.capture.native`,
+  // `asc.capture.farm`, …) because "square for marketing shots on the
+  // native page" rarely means "square for every farm recording too".
+  const CAPTURE_STORAGE_KEY = 'asc.capture.farm';
+
   function FarmFocus(host) {
     this.host = host;
     this.tile = null;
@@ -28,7 +34,18 @@
       recorder: null,
       active: false, startedAt: 0, timer: null,
       entries: [],
+      // Frozen at Record-press time: what the user asked for, the size we
+      // predicted, and the size the recorder's compose canvas actually is.
+      settings: null, plannedSize: null, outputSize: null,
     };
+
+    // Output-size picker (capture/capture-size-menu.js). Rebuilt on every
+    // `show` because `show` replaces the pane's innerHTML wholesale; the
+    // selection itself survives in localStorage under CAPTURE_STORAGE_KEY.
+    this.captureMenu = null;
+    // Defaulted here so `_captureSourceSize` is safe to call before the
+    // first `show` wires the real closure in.
+    this._getRecorderContext = () => null;
   }
 
   FarmFocus.prototype.show = function (device, tile, callbacks) {
@@ -80,6 +97,15 @@
           <button class="preset" data-button="screenshot">Snap UI</button>
           <button class="preset" data-button="rotate">Rotate</button>
         </div>
+      </div>
+
+      <div class="controls">
+        <h4>Capture Output</h4>
+        <div class="capture-row">
+          <span class="label">Output</span>
+          <span class="dims" data-readout="capture-dims" title="Resolved recording output">—</span>
+        </div>
+        <div class="capture-picker" data-role="capture-size"></div>
       </div>
 
       <div class="controls">
@@ -151,6 +177,89 @@
     if (recBtn) {
       recBtn.onclick = () => this._toggleRecord(recBtn);
     }
+
+    // Mounted last: the menu's `sourceSize` closure reads the recorder
+    // context, which only exists once the callbacks above are wired.
+    this._mountCaptureMenu();
+  };
+
+  // ---- capture output size -------------------------------------------
+
+  // Guarded end to end: this is the last thing `show` does, and FarmApp
+  // re-parents the live canvas + promotes the tile *after* `show`
+  // returns. A capture module that failed to load must cost the user a
+  // size picker, never the video.
+  FarmFocus.prototype._mountCaptureMenu = function () {
+    if (this.captureMenu) { this.captureMenu.detach(); this.captureMenu = null; }
+    const host = this.host.querySelector('[data-role="capture-size"]');
+    if (!host || !window.CaptureSizeMenu ||
+        !window.Baguette || !window.Baguette._CaptureSettings) return;
+    try {
+      this.captureMenu = new window.CaptureSizeMenu({
+        storageKey: CAPTURE_STORAGE_KEY,
+        showFrameToggle: true,
+        sourceSize: () => this._captureSourceSize(),
+        onChange: () => this._renderCaptureDims(),
+      }).mount(host);
+    } catch (err) {
+      this.captureMenu = null;
+      console.warn('[FarmFocus] capture size picker unavailable:', err && err.message);
+    }
+    this._renderCaptureDims();
+  };
+
+  /** The CaptureSettings a recording started right now would use. */
+  FarmFocus.prototype.captureSettings = function () {
+    return this.captureMenu ? this.captureMenu.settings : null;
+  };
+
+  // What the recorder's compose canvas comes out at before the capture
+  // size is applied. Mirrors recorder.js `composeSize`: with a bezel to
+  // composite, the recording is the definition's viewport; otherwise it
+  // is the live canvas's own pixels. Keeping the two in step is what
+  // makes the readout the number the file actually gets.
+  FarmFocus.prototype._captureSourceSize = function () {
+    const ctx = this._getRecorderContext();
+    if (!ctx) return null;
+    const settings = this.captureSettings();
+    const wantsFrame = !settings || settings.withFrame;
+    if (wantsFrame && ctx.frameImg && ctx.frameImg.naturalWidth > 0 &&
+        ctx.screen && ctx.screen.viewport) {
+      return { width: ctx.screen.viewport.width, height: ctx.screen.viewport.height };
+    }
+    if (ctx.canvas && ctx.canvas.width > 0) {
+      return { width: ctx.canvas.width, height: ctx.canvas.height };
+    }
+    return null;
+  };
+
+  // While idle this is a prediction; once recording it's the compose
+  // canvas the recorder actually built, which is the only number that
+  // can't be wrong. They differ only against a BrowserRecorder that
+  // doesn't understand `settings` yet — hence the `stale` flag rather
+  // than silently showing a size the file won't have.
+  FarmFocus.prototype._renderCaptureDims = function () {
+    const el = this.host.querySelector('[data-readout="capture-dims"]');
+    if (!el) return;
+    const recording = this.recording.active && this.recording.outputSize;
+    const out = recording ? this.recording.outputSize : this._resolvedOutputSize();
+    const planned = recording ? this.recording.plannedSize : out;
+    const honoured = sameSize(planned, out);
+    const text = out ? out.width + '\u00d7' + out.height : '\u2014';
+    if (el.textContent !== text) el.textContent = text;
+    el.classList.toggle('stale', !!out && !honoured);
+    el.title = honoured
+      ? 'Resolved recording output'
+      : 'This recorder records at its own size — the chosen capture size was not applied';
+  };
+
+  FarmFocus.prototype._resolvedOutputSize = function () {
+    const settings = this.captureSettings();
+    const source = this._captureSourceSize();
+    if (!settings || !source) return null;
+    const plan = settings.plan(source.width, source.height);
+    if (!plan || !plan.width || !plan.height) return null;
+    return { width: plan.width, height: plan.height };
   };
 
   FarmFocus.prototype._toggleRecord = async function (recBtn) {
@@ -164,9 +273,17 @@
       if (label) label.textContent = 'Saving…';
       if (timer) timer.textContent = '';
       recBtn.classList.remove('recording');
+      // Snapshot what this clip was recorded as before awaiting: focusing
+      // another device mid-save runs `show` → `_resetRecording`, which
+      // clears these slots out from under the resolved artifact.
+      const naming = {
+        settings:    this.recording.settings,
+        plannedSize: this.recording.plannedSize,
+        outputSize:  this.recording.outputSize,
+      };
       try {
         const artifact = await rec.stop();
-        this._onRecordFinished(artifact);
+        this._onRecordFinished(artifact, naming);
       } catch (err) {
         this._onRecordError(err);
       }
@@ -179,6 +296,11 @@
     }
     const ctx = this._getRecorderContext();
     if (!ctx || !ctx.canvas) { this._onRecordError(new Error('no live canvas')); return; }
+    // The size travels in the context alongside the DOM handles (see
+    // FarmApp.getRecorderContext) so a re-focus mid-session can't strand
+    // us on a stale selection; the local menu is the fallback for a
+    // caller that doesn't supply one.
+    const settings = ctx.settings || this.captureSettings();
     try {
       const rec = new window.BrowserRecorder({
         canvas:      ctx.canvas,
@@ -186,9 +308,22 @@
         screen:      ctx.screen,
         overlayHost: ctx.overlayHost,
         fps: 60,
+        // Belt and braces: `settings` is the new capture-size option and
+        // the four handles above are the shape BrowserRecorder has always
+        // taken. Both are passed so this works against the recorder as it
+        // is today (which ignores `settings`) and against the resized one,
+        // in either landing order.
+        settings,
       });
+      const planned = this._resolvedOutputSize();
       rec.start();
       this.recording.recorder = rec;
+      this.recording.settings = settings || null;
+      this.recording.plannedSize = planned;
+      // `start()` builds the compose canvas the recording is sampled
+      // from, so reading it back is the truth about the output size —
+      // whichever BrowserRecorder build is loaded.
+      this.recording.outputSize = composeCanvasSize(rec) || planned;
       this._onRecordStarted();
     } catch (err) {
       this._onRecordError(err);
@@ -201,6 +336,9 @@
     if (this.fpsEl && t.fps !== undefined) this.fpsEl.textContent = t.fps + ' fps';
     if (this.latEl && t.lat !== undefined) this.latEl.textContent = t.lat + ' ms';
     if (this.brEl  && t.br  !== undefined) this.brEl.textContent  = t.br  + ' kbps';
+    // The live canvas only settles on its size once frames arrive, so
+    // piggyback the readout on the telemetry tick rather than polling.
+    this._renderCaptureDims();
   };
 
   FarmFocus.prototype._onRecordStarted = function () {
@@ -212,17 +350,35 @@
     this._renderRecordTimer();
   };
 
-  FarmFocus.prototype._onRecordFinished = function (artifact) {
+  FarmFocus.prototype._onRecordFinished = function (artifact, naming) {
     this._renderRecordButton();
     this._renderRecordTimer();
     if (!artifact || typeof artifact.url !== 'string') return;
     this.recording.entries.unshift({
       url: artifact.url,
-      filename: artifact.filename || 'recording.webm',
+      filename: this._recordFilename(artifact, naming),
       duration: typeof artifact.durationSeconds === 'number' ? artifact.durationSeconds : 0,
       bytes:    typeof artifact.bytes === 'number'           ? artifact.bytes           : 0,
     });
     this._renderRecordList();
+  };
+
+  // `download="…"` is what the file lands as, so the size belongs in the
+  // name. Two honesty rules: a recorder that ignored the chosen size gets
+  // its plain pixels rather than the preset it didn't honour, and a name
+  // the recorder already slugged is left alone instead of doubled.
+  FarmFocus.prototype._recordFilename = function (artifact, naming) {
+    const base = (artifact && artifact.filename) || 'recording.webm';
+    const n = naming || this.recording;
+    const settings = n.settings;
+    const out = n.outputSize;
+    if (!settings || settings.size.isNative || !out) return base;
+    const slug = sameSize(n.plannedSize, out)
+      ? settings.slug(out.width, out.height)
+      : out.width + 'x' + out.height;
+    if (base.indexOf(slug) >= 0) return base;
+    const dot = base.lastIndexOf('.');
+    return dot > 0 ? base.slice(0, dot) + '-' + slug + base.slice(dot) : base + '-' + slug;
   };
 
   FarmFocus.prototype._onRecordError = function (err) {
@@ -247,6 +403,7 @@
       recorder: null,
       active: false, startedAt: 0, timer: null,
       entries: [],
+      settings: null, plannedSize: null, outputSize: null,
     };
     this._renderRecordButton();
     this._renderRecordTimer();
@@ -283,11 +440,24 @@
 
   FarmFocus.prototype.dispose = function () {
     this._resetRecording();
+    if (this.captureMenu) { this.captureMenu.detach(); this.captureMenu = null; }
     this.host.innerHTML = '';
     if (window.FarmViews) window.FarmViews.renderFocusEmpty(this.host);
     this.tile = null;
     this.device = null;
   };
+
+  // The recorder's compose canvas is the recording's output surface.
+  // Reading it back after `start()` is version-proof: a BrowserRecorder
+  // that resizes and one that doesn't both report what they really built.
+  function composeCanvasSize(rec) {
+    const c = rec && rec.compose;
+    return c && c.width > 0 && c.height > 0 ? { width: c.width, height: c.height } : null;
+  }
+
+  function sameSize(a, b) {
+    return !!a && !!b && a.width === b.width && a.height === b.height;
+  }
 
   function formatDuration(seconds) {
     if (!isFinite(seconds) || seconds < 0) seconds = 0;

--- a/Sources/Baguette/Resources/Web/farm/farm.css
+++ b/Sources/Baguette/Resources/Web/farm/farm.css
@@ -924,6 +924,66 @@ body.focus-resizing {
 }
 .preset:hover { border-color: var(--phosphor); color: var(--phosphor); }
 
+/* ===== CAPTURE OUTPUT SIZE =====
+   CaptureSizeMenu (capture/capture-size-menu.js) ships its own <style>,
+   themed off `--nv-*` hooks with light-mode fallbacks. The farm runs a
+   dark mission-control palette, so bind those hooks to farm tokens here
+   and take over the two places the shared sheet hard-codes white on
+   `--accent` — white on phosphor lime is unreadable.
+
+   The picker host is full-width and the popover is pinned to both its
+   edges (`left:0;right:0`) rather than the sheet's `right:0` alone: the
+   focus pane is a scroll container that clips, and it resizes down to
+   260px, narrower than the popover's natural 236px + padding. */
+.capture-row {
+  display: flex; align-items: baseline; gap: 12px;
+  padding: 8px 0 0;
+}
+.capture-row .label {
+  font: 600 10px/1 var(--mono);
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+.capture-row .dims {
+  margin-left: auto;
+  font: 600 11px/1 var(--mono);
+  color: var(--phosphor);
+  font-variant-numeric: tabular-nums;
+}
+/* Amber, the farm's "reading is off" colour: the recorder built its
+   compose canvas at a different size than the picker asked for. */
+.capture-row .dims.stale { color: var(--amber); }
+.capture-picker { margin-top: 8px; }
+.focus .cap-size {
+  --nv-text:      var(--text);
+  --nv-panel:     var(--panel);
+  --nv-btn:       var(--panel-hi);
+  --nv-btn-hover: var(--rule-2);
+  --nv-border:    var(--rule-2);
+  --text-muted:   var(--muted);
+  --accent:       var(--phosphor);
+  display: block; width: 100%;
+}
+.focus .cap-size-chip {
+  width: 100%; justify-content: space-between;
+  height: 30px; border-radius: 3px;
+  font: 600 10px/1 var(--mono);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.focus .cap-size-pop {
+  left: 0; right: 0; width: auto;
+  border-radius: 3px;
+  font-family: var(--mono);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+}
+.focus .cap-size-list button[aria-checked="true"] { color: var(--bg); }
+.focus .cap-size-list button[aria-checked="true"] .dim { color: rgba(10, 12, 16, 0.7); }
+.focus .cap-size-seg button[aria-checked="true"] {
+  background: var(--panel-hi); color: var(--phosphor); box-shadow: none;
+}
+.focus .cap-size-row input[type="text"] { background: var(--bg); }
+
 /* ===== CLI MIRROR FOOTER ===== */
 footer {
   display: flex; align-items: center;

--- a/Sources/Baguette/Resources/Web/farm/farm.html
+++ b/Sources/Baguette/Resources/Web/farm/farm.html
@@ -42,6 +42,16 @@
 
 <script src="/stream-session.js"></script>
 <script src="/frame-decoder.js"></script>
+<!-- Capture-size vocabulary — the size a user picks once ("App Store
+     6.9″", "square") in the focus pane, spelled the same way the routes
+     and the CLI spell it. Ahead of /recorder.js: BrowserRecorder reads
+     the shared CaptureSize/CaptureComposer to size its output. Within
+     the group, size → settings → composer → menu, since each restores
+     the previous one in its constructor. -->
+<script src="/capture/capture-size.js"></script>
+<script src="/capture/capture-settings.js"></script>
+<script src="/capture/capture-composer.js"></script>
+<script src="/capture/capture-size-menu.js"></script>
 <script src="/recorder.js"></script>
 <!-- Baguette SDK — farm-tile uses Transport / Screen / Keyboard
      directly (no Bezel; the farm tile is its own surface). -->

--- a/Tests/Web/farm-focus-capture.test.js
+++ b/Tests/Web/farm-focus-capture.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+// The two pieces of the farm focus pane's capture wiring that are value
+// logic rather than DOM: what output size a recording will come out at,
+// and what the download gets called. Everything else in farm-focus.js is
+// page composition and stays integration-only.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { loadBrowserModules } = require('./helpers/load-browser-module.js');
+
+const WEB = path.join(
+  __dirname, '..', '..', 'Sources', 'Baguette', 'Resources', 'Web'
+);
+
+// farm-focus.js attaches to `window.FarmFocus` (the farm/ convention);
+// the capture modules it reads through hang off `window.Baguette._X`.
+function load() {
+  const win = loadBrowserModules([
+    path.join(WEB, 'capture', 'capture-size.js'),
+    path.join(WEB, 'capture', 'capture-settings.js'),
+    path.join(WEB, 'farm', 'farm-focus.js'),
+  ]);
+  return { FarmFocus: win.FarmFocus, CaptureSettings: win.Baguette._CaptureSettings };
+}
+
+// A focus pane with no DOM: `show()` is what builds the markup and mounts
+// the real picker, and neither is needed to ask what size comes out.
+function focusWith({ settings, context }) {
+  const { FarmFocus, CaptureSettings } = load();
+  const focus = new FarmFocus({ querySelector: () => null });
+  focus.captureMenu = { settings: new CaptureSettings(settings) };
+  focus._getRecorderContext = () => context;
+  return focus;
+}
+
+const BEZEL = {
+  canvas: { width: 585, height: 1266 },
+  frameImg: { naturalWidth: 1290 },
+  screen: { viewport: { width: 1290, height: 2796 } },
+};
+
+test('a ratio resolves against the composited bezel, not the scaled canvas', () => {
+  const focus = focusWith({ settings: { size: 'square' }, context: BEZEL });
+  assert.deepEqual(focus._resolvedOutputSize(), { width: 2796, height: 2796 });
+});
+
+test('leaving the bezel out resolves against the live canvas instead', () => {
+  const focus = focusWith({
+    settings: { size: 'square', withFrame: false },
+    context: BEZEL,
+  });
+  assert.deepEqual(focus._resolvedOutputSize(), { width: 1266, height: 1266 });
+});
+
+test('a fixed preset ignores the source entirely', () => {
+  const focus = focusWith({ settings: { size: 'appstore-6.9' }, context: BEZEL });
+  assert.deepEqual(focus._resolvedOutputSize(), { width: 1290, height: 2796 });
+});
+
+test('nothing resolves without a live canvas to record', () => {
+  const focus = focusWith({ settings: { size: 'square' }, context: null });
+  assert.equal(focus._resolvedOutputSize(), null);
+});
+
+// ── download naming ──────────────────────────────────────────────
+
+function naming(sizeSpec, planned, output) {
+  const { CaptureSettings } = load();
+  return {
+    settings: new CaptureSettings({ size: sizeSpec }),
+    plannedSize: planned,
+    outputSize: output,
+  };
+}
+
+function nameOf(sizeSpec, planned, output, filename) {
+  const focus = focusWith({ settings: {}, context: null });
+  return focus._recordFilename({ filename }, naming(sizeSpec, planned, output));
+}
+
+test('the download carries the size the recording actually came out at', () => {
+  assert.equal(
+    nameOf('square', { width: 2796, height: 2796 }, { width: 2796, height: 2796 },
+      'simulator-2026.mp4'),
+    'simulator-2026-square-2796x2796.mp4'
+  );
+});
+
+// A recorder that doesn't understand the capture size still produces a
+// file — it just isn't the size that was asked for. Naming it after the
+// preset anyway would be a lie, so only the real pixels go in.
+test('a recorder that ignored the size gets plain dimensions, not the preset', () => {
+  assert.equal(
+    nameOf('square', { width: 2796, height: 2796 }, { width: 1290, height: 2796 },
+      'simulator-2026.mp4'),
+    'simulator-2026-1290x2796.mp4'
+  );
+});
+
+test('a name the recorder already slugged is left alone', () => {
+  assert.equal(
+    nameOf('square', { width: 2796, height: 2796 }, { width: 2796, height: 2796 },
+      'simulator-2026-square-2796x2796.mp4'),
+    'simulator-2026-square-2796x2796.mp4'
+  );
+});
+
+test('a native recording keeps the recorder own name', () => {
+  assert.equal(
+    nameOf('native', { width: 1290, height: 2796 }, { width: 1290, height: 2796 },
+      'simulator-2026.mp4'),
+    'simulator-2026.mp4'
+  );
+});
+
+test('a ratio spec never puts a colon in the filename', () => {
+  assert.equal(
+    nameOf('16:9', { width: 4971, height: 2796 }, { width: 4971, height: 2796 },
+      'simulator-2026.webm'),
+    'simulator-2026-16-9-4971x2796.webm'
+  );
+});


### PR DESCRIPTION
## What

The device farm's focus pane can record the focused device, but only ever at whatever size the compose canvas happened to be. It now mounts the shared `CaptureSizeMenu` under a **Capture Output** block, so picking "App Store 6.9″" / "Square" / "16:9" here means the same pixels it means on the native page, the HTTP routes, and the CLI.

- `farm.html` loads `/capture/capture-size.js` → `capture-settings.js` → `capture-composer.js` → `capture-size-menu.js`, **ahead of `/recorder.js`** (BrowserRecorder reads the shared vocabulary).
- `farm-focus.js` mounts the picker (`storageKey: 'asc.capture.farm'`), shows the resolved output dimensions next to it, and threads the chosen `CaptureSettings` into `BrowserRecorder`.
- `farm-app.js` carries the settings inside `getRecorderContext()` alongside the DOM handles — the picker is rebuilt by every `focus.show`, so resolving it at Record-press time is what keeps a re-focus mid-session from stranding the recorder on a stale selection.
- `farm.css` binds the menu's `--nv-*` hooks to farm tokens and takes over the two spots where the shared sheet paints white on `--accent` (unreadable on phosphor lime).

The `[data-action="snapshot"]` button is untouched — it is the "re-seed the decoder with one JPEG" WS verb, not a screenshot. Stills are out of scope here.

## Honesty against a recorder that doesn't resize yet

`BrowserRecorder` doesn't consume `settings` on `main` (that's a parallel change), so this PR does not assume it does:

- `settings` is passed **alongside** today's `{canvas, frameImg, screen, overlayHost, fps}` shape, so it works in either landing order.
- After `start()`, the pane reads the recorder's compose canvas back. That is the recording's real output whichever recorder build is loaded — so while recording the readout shows the actual size, turns amber when it differs from what was asked for, and the download keeps plain dimensions instead of claiming a preset the file doesn't have.

## Tests

`Tests/Web/farm-focus-capture.test.js` — 9 tests over the two pieces that are value logic rather than DOM: what size a recording resolves to (bezel viewport vs live canvas, ratio vs fixed), and what the download gets called (honoured preset, ignored preset, already-slugged name, native, colon-free ratio spec). Page composition stays integration-only, per CLAUDE.md.

`make test-web` → 229 pass, 0 fail.

## Verified end to end

`baguette serve --port 8806` against a booted iPhone 17 Pro Max: focused the live tile, opened the picker (all nine presets with per-preset resolved dims, custom field, fit, background, bezel toggle — all legible on the farm's dark palette), picked **Square** (readout `990×990`), recorded ~15 s, and got a download entry. Selection survived closing and re-focusing the device. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)