### PR TITLE
feat: --size / --fit / --background / --format for baguette screenshot

### DIFF
--- a/Sources/Baguette/App/Commands/ScreenshotCommand.swift
+++ b/Sources/Baguette/App/Commands/ScreenshotCommand.swift
@@ -1,16 +1,23 @@
 import ArgumentParser
 import Foundation
 
-/// `baguette screenshot --udid <UDID> [--output path] [--quality N] [--scale N]`
+/// `baguette screenshot --udid <UDID> [--output path] [--quality N]
+/// [--scale N] [--size SPEC] [--fit contain|cover|stretch]
+/// [--background transparent|#RRGGBB] [--format png|jpg]`
 ///
-/// Captures one JPEG frame from the simulator's framebuffer. Mirrors
-/// the `GET /simulators/<UDID>/screenshot.jpg` endpoint so the same
-/// helper drives both, and writes to `--output` (or stdout when
-/// omitted, so it composes with shell redirection).
+/// Captures one frame from the simulator's framebuffer. Mirrors the
+/// `GET /simulators/<UDID>/screenshot.jpg` endpoint so the same helper
+/// drives both, and writes to `--output` (or stdout when omitted, so it
+/// composes with shell redirection).
+///
+/// `--size` speaks the shared capture-size vocabulary — the same preset
+/// ids the toolbar picker and the recorder use, so "App Store 6.9″"
+/// means the same pixels wherever you ask for it. See
+/// `docs/features/capture-size.md`.
 struct ScreenshotCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "screenshot",
-        abstract: "Capture one JPEG frame from a simulator's screen"
+        abstract: "Capture one frame from a simulator's screen"
     )
 
     @OptionGroup var options: DeviceOption
@@ -18,11 +25,62 @@ struct ScreenshotCommand: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "Output file (defaults to stdout)")
     var output: String?
 
-    @Option(help: "JPEG quality (0.0 – 1.0)")
+    @Option(help: "JPEG quality (0.0 – 1.0); ignored for PNG")
     var quality: Double = 0.85
 
     @Option(help: "Integer downscale divisor (1 = native)")
     var scale: Int = 1
+
+    @Option(help: ArgumentHelp(
+        "Output size: WIDTHxHEIGHT, W:H, or one of: \(CaptureSize.presetList)"
+    ))
+    var size: String = "native"
+
+    @Option(help: "How the frame fills the size: \(CaptureFit.allCases.map(\.rawValue).joined(separator: ", "))")
+    var fit: String = CaptureFit.contain.rawValue
+
+    // `#ffffff`, not `transparent`, so the CLI and the toolbar picker
+    // agree — `Resources/Web/capture/capture-settings.js` defaults to
+    // white too. At `native` size nothing is letterboxed, so the default
+    // still never paints; it only matters once a size is asked for, and
+    // there a JPEG (which has no alpha) would otherwise flatten the bars
+    // to black. Pass `--background transparent` for a PNG with clear bars.
+    @Option(help: "Letterbox background: transparent or #RRGGBB")
+    var background: String = "#ffffff"
+
+    @Option(help: "Image format: \(CaptureFormat.list) (defaults to the --output extension, else jpg)")
+    var format: String?
+
+    /// Reject what the pipeline can't honour — and normalise the rest,
+    /// so validation is exactly as forgiving as the parsers behind it.
+    /// `CaptureSize.parse` is already case-insensitive; `--fit` and
+    /// `--background` are trimmed and lowercased here so they are too.
+    mutating func validate() throws {
+        do {
+            _ = try CaptureSize.parse(size)
+        } catch let error as CaptureSizeError {
+            throw ValidationError(error.message)
+        }
+
+        fit = fit.trimmingCharacters(in: .whitespaces).lowercased()
+        guard CaptureFit(rawValue: fit) != nil else {
+            throw ValidationError(
+                "--fit must be one of: \(CaptureFit.allCases.map(\.rawValue).joined(separator: ", "))"
+            )
+        }
+
+        if let format, CaptureFormat(argument: format) == nil {
+            throw ValidationError("--format must be one of: \(CaptureFormat.list)")
+        }
+
+        background = background.trimmingCharacters(in: .whitespaces).lowercased()
+        if CaptureCanvas.background(background) != nil {
+            let pattern = #"^#?[0-9a-f]{6}$"#
+            guard background.range(of: pattern, options: .regularExpression) != nil else {
+                throw ValidationError("--background must be transparent or #RRGGBB")
+            }
+        }
+    }
 
     func run() async throws {
         let simulators = CoreSimulators(deviceSetPath: options.deviceSet)
@@ -33,7 +91,14 @@ struct ScreenshotCommand: AsyncParsableCommand {
         let bytes = try await ScreenSnapshot.capture(
             screen: simulator.screen(),
             quality: quality,
-            scale: max(1, scale)
+            scale: max(1, scale),
+            size: try CaptureSize.parse(size),
+            fit: CaptureFit(rawValue: fit) ?? .contain,
+            background: background,
+            format: CaptureFormat.resolve(
+                explicit: format.flatMap(CaptureFormat.init(argument:)),
+                output: output
+            )
         )
         if let output {
             try bytes.write(to: URL(fileURLWithPath: output))

--- a/Sources/Baguette/Infrastructure/Screen/CaptureCanvas.swift
+++ b/Sources/Baguette/Infrastructure/Screen/CaptureCanvas.swift
@@ -1,0 +1,217 @@
+import Foundation
+import CoreGraphics
+import CoreVideo
+import ImageIO
+import IOSurface
+
+/// The CoreGraphics half of the capture-size vocabulary.
+///
+/// `CaptureSize` decides *where* a frame lands — canvas size, draw rect,
+/// crop overflow. `CaptureCanvas` is the part that actually moves the
+/// pixels: fill the background, draw the frame into the placement's
+/// rect, hand back a `CGImage`, and encode it as PNG or JPEG. Splitting
+/// it out this way is what makes the size feature testable — synthetic
+/// `CGImage`s go in, assertable pixels come out, and the only thing left
+/// in `ScreenSnapshot` that needs a booted simulator is SimulatorKit's
+/// framebuffer callback itself.
+///
+/// The one non-obvious bit is the vertical flip in `compose`. A
+/// `CapturePlacement` counts `drawY` **down from the top** — the same
+/// convention the browser-side `CaptureComposer` uses, because that's how
+/// a canvas 2D context talks. CoreGraphics counts **up from the bottom**,
+/// so the draw rect's origin has to be mirrored. Skipping that is
+/// invisible on a symmetric letterbox and quietly wrong on every
+/// odd-pixel or `cover` crop.
+enum CaptureCanvas {
+
+    // MARK: - Background
+
+    /// `transparent` (or an empty string) means "no background at all" —
+    /// the canvas keeps its zeroed alpha. Anything else is a `#RRGGBB`
+    /// colour. The `#` is optional here so a URL query that dropped it
+    /// (`?background=101010`, since `#` starts a fragment) still parses;
+    /// `HexColor` unconditionally drops the first character, so it must
+    /// be handed a prefixed string.
+    static func background(_ spec: String) -> HexColor? {
+        let text = spec.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !text.isEmpty, text != "transparent", text != "none" else { return nil }
+        return HexColor(text.hasPrefix("#") ? text : "#" + text)
+    }
+
+    // MARK: - Composition
+
+    /// Re-lay `source` onto the canvas `size` asks for. Returns the very
+    /// same image when there is nothing to do, so a `native` capture is
+    /// never resampled.
+    static func apply(
+        size: CaptureSize,
+        fit: CaptureFit,
+        background: String,
+        to source: CGImage
+    ) -> CGImage? {
+        let dimensions = RenderDimensions(width: source.width, height: source.height)
+        return compose(
+            source,
+            placement: size.plan(source: dimensions, fit: fit),
+            background: self.background(background)
+        )
+    }
+
+    /// Draw `source` into `placement` on a fresh canvas. A `nil`
+    /// background leaves the uncovered area transparent.
+    static func compose(
+        _ source: CGImage,
+        placement: CapturePlacement,
+        background: HexColor?
+    ) -> CGImage? {
+        let dimensions = RenderDimensions(width: source.width, height: source.height)
+        if placement.isIdentity(for: dimensions) { return source }
+        guard placement.width > 0, placement.height > 0,
+              placement.drawWidth > 0, placement.drawHeight > 0 else { return nil }
+
+        guard let context = CGContext(
+            data: nil,
+            width: placement.width, height: placement.height,
+            bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                | CGBitmapInfo.byteOrder32Little.rawValue
+        ) else { return nil }
+
+        if let background {
+            context.setFillColor(
+                red: background.red, green: background.green,
+                blue: background.blue, alpha: 1
+            )
+            context.fill(CGRect(x: 0, y: 0, width: placement.width, height: placement.height))
+        }
+
+        context.interpolationQuality = .high
+        // Placement counts y down from the top; CoreGraphics counts up.
+        let originY = placement.height - placement.drawY - placement.drawHeight
+        context.draw(source, in: CGRect(
+            x: placement.drawX, y: originY,
+            width: placement.drawWidth, height: placement.drawHeight
+        ))
+        return context.makeImage()
+    }
+
+    // MARK: - Lifting a framebuffer to a CGImage
+
+    /// Wrap a framebuffer surface zero-copy and lift it to a `CGImage`.
+    static func image(from surface: IOSurface) -> CGImage? {
+        var buffer: Unmanaged<CVPixelBuffer>?
+        let status = CVPixelBufferCreateWithIOSurface(
+            kCFAllocatorDefault, surface,
+            [kCVPixelBufferPixelFormatTypeKey: kCVPixelFormatType_32BGRA] as CFDictionary,
+            &buffer
+        )
+        guard status == kCVReturnSuccess,
+              let pixelBuffer = buffer?.takeRetainedValue() else { return nil }
+        return image(from: pixelBuffer)
+    }
+
+    /// Lift a BGRA pixel buffer (a raw framebuffer, or one
+    /// `VideoFrameScaler` produced) to a `CGImage` that **owns its
+    /// bytes**.
+    ///
+    /// The copy is the point. SimulatorKit keeps rendering into the
+    /// surface it handed us — `screen.stop()` only lands after the
+    /// capture returns — so an image still aliasing that memory would be
+    /// composed and encoded out from under a live writer, and come out a
+    /// torn mix of two frames. `CGBitmapContextCreateImage` only promises
+    /// copy-on-write against drawing *through the context*; it can't see
+    /// a foreign writer. So the bytes are copied here, under the lock,
+    /// and handed to a provider that retains them.
+    static func image(from pixelBuffer: CVPixelBuffer) -> CGImage? {
+        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+
+        guard let base = CVPixelBufferGetBaseAddress(pixelBuffer) else { return nil }
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        let stride = CVPixelBufferGetBytesPerRow(pixelBuffer)
+        guard width > 0, height > 0, stride >= width * 4 else { return nil }
+
+        let pixels = Data(bytes: base, count: stride * height)
+        guard let provider = CGDataProvider(data: pixels as CFData) else { return nil }
+
+        return CGImage(
+            width: width, height: height,
+            bitsPerComponent: 8, bitsPerPixel: 32, bytesPerRow: stride,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGBitmapInfo(rawValue:
+                CGImageAlphaInfo.premultipliedFirst.rawValue
+                    | CGBitmapInfo.byteOrder32Little.rawValue),
+            provider: provider, decode: nil,
+            shouldInterpolate: true, intent: .defaultIntent
+        )
+    }
+
+    // MARK: - Encoding
+
+    /// Encode to the requested container. `quality` only reaches JPEG —
+    /// PNG is lossless, and `kCGImageDestinationLossyCompressionQuality`
+    /// is meaningless there.
+    static func encode(_ image: CGImage, format: CaptureFormat, quality: Double) -> Data? {
+        let out = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            out, format.contentType as CFString, 1, nil
+        ) else { return nil }
+
+        var options: [CFString: Any] = [:]
+        if format == .jpeg {
+            options[kCGImageDestinationLossyCompressionQuality] = quality
+        }
+        CGImageDestinationAddImage(destination, image, options as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return out as Data
+    }
+}
+
+/// The container a capture is written in. JPEG is the historical default
+/// — every `<img src="…/screenshot.jpg">` and every `curl -o shot.jpg`
+/// already expects it — and PNG is what a marketing capture with a
+/// transparent letterbox actually needs, since JPEG has no alpha channel
+/// and flattens the bars to black.
+enum CaptureFormat: String, Equatable, Sendable, CaseIterable {
+    case jpeg
+    case png
+
+    /// `jpg` and `jpeg` are the same thing to a user; both parse.
+    init?(argument: String) {
+        switch argument.trimmingCharacters(in: .whitespaces).lowercased() {
+        case "jpg", "jpeg": self = .jpeg
+        case "png": self = .png
+        default: return nil
+        }
+    }
+
+    /// What a file of this format is called on disk.
+    var fileExtension: String {
+        switch self {
+        case .jpeg: return "jpg"
+        case .png: return "png"
+        }
+    }
+
+    var contentType: String {
+        switch self {
+        case .jpeg: return "public.jpeg"
+        case .png: return "public.png"
+        }
+    }
+
+    /// One line for `--help`.
+    static var list: String { "png | jpg" }
+
+    /// What the user named wins; otherwise the output path's extension
+    /// decides, so `-o shot.png` never quietly writes JPEG bytes into a
+    /// `.png` file. Stdout and anything unrecognised stay JPEG.
+    static func resolve(explicit: CaptureFormat?, output: String?) -> CaptureFormat {
+        if let explicit { return explicit }
+        guard let output else { return .jpeg }
+        let ext = (output as NSString).pathExtension.lowercased()
+        return CaptureFormat(argument: ext) ?? .jpeg
+    }
+}

--- a/Sources/Baguette/Infrastructure/Screen/ScreenSnapshot.swift
+++ b/Sources/Baguette/Infrastructure/Screen/ScreenSnapshot.swift
@@ -1,11 +1,13 @@
 import Foundation
+import CoreGraphics
 import IOSurface
 
 /// One-shot frame capture: open `Screen`, wait for the first IOSurface
-/// SimulatorKit delivers, encode JPEG, stop. Shared by the
-/// `baguette screenshot` CLI and the `GET /simulators/:udid/screenshot.jpg`
-/// HTTP route. A timeout guards against an idle / wedged simulator that
-/// never fires its frame callback.
+/// SimulatorKit delivers, lay it onto the requested canvas, encode, stop.
+/// Shared by the `baguette screenshot` CLI and the
+/// `GET /simulators/:udid/screenshot.jpg` HTTP route. A timeout
+/// guards against an idle / wedged simulator that never fires its frame
+/// callback.
 enum ScreenSnapshot {
 
     enum Failure: Error, Equatable {
@@ -13,15 +15,27 @@ enum ScreenSnapshot {
         case encodeFailed
     }
 
-    /// Capture one JPEG. `scale = 1` skips frame scaling; `scale ≥ 2`
-    /// routes through `VideoFrameScaler` so the encoded bytes are smaller.
+    /// Capture one frame.
+    ///
+    /// `scale ≥ 2` routes through `VideoFrameScaler` so the encoded bytes
+    /// are smaller; `size` / `fit` / `background` are the shared
+    /// capture-size vocabulary (see `docs/features/capture-size.md`), and
+    /// every one of them defaults to "exactly what the framebuffer gave
+    /// us" so the historical call sites keep their historical bytes.
     static func capture(
         screen: any Screen,
         quality: Double = 0.85,
         scale: Int = 1,
-        timeout: TimeInterval = 2.0
+        timeout: TimeInterval = 2.0,
+        size: CaptureSize = .native,
+        fit: CaptureFit = .contain,
+        background: String = "transparent",
+        format: CaptureFormat = .jpeg
     ) async throws -> Data {
-        let session = SnapshotSession(quality: quality, scale: scale)
+        let session = SnapshotSession(
+            quality: quality, scale: scale,
+            size: size, fit: fit, background: background, format: format
+        )
 
         defer { screen.stop() }
 
@@ -53,23 +67,34 @@ enum ScreenSnapshot {
     }
 }
 
-/// Owns the per-capture encoder + frame scaler and the single-shot guard.
-/// `VideoFrameScaler` is a class without `Sendable`, so wrapping it in an
-/// `@unchecked Sendable` holder lets the screen-callback closure
-/// capture it without tripping strict concurrency. Safe because each
-/// `capture(...)` call instantiates its own session and `encode` runs
-/// at most once.
+/// Owns the per-capture frame scaler, the chosen output shape, and the
+/// single-shot guard. `VideoFrameScaler` is a class without `Sendable`,
+/// so wrapping it in an `@unchecked Sendable` holder lets the
+/// screen-callback closure capture it without tripping strict
+/// concurrency. Safe because each `capture(...)` call instantiates its
+/// own session and `encode` runs at most once.
 private final class SnapshotSession: @unchecked Sendable {
-    private let jpeg: JPEGEncoder
+    private let quality: Double
     private let scaler: VideoFrameScaler?
     private let scale: Int
+    private let size: CaptureSize
+    private let fit: CaptureFit
+    private let background: String
+    private let format: CaptureFormat
     private let lock = NSLock()
     private var taken = false
 
-    init(quality: Double, scale: Int) {
-        self.jpeg = JPEGEncoder(quality: quality)
+    init(
+        quality: Double, scale: Int,
+        size: CaptureSize, fit: CaptureFit, background: String, format: CaptureFormat
+    ) {
+        self.quality = quality
         self.scaler = scale > 1 ? VideoFrameScaler() : nil
         self.scale = scale
+        self.size = size
+        self.fit = fit
+        self.background = background
+        self.format = format
     }
 
     func claim() -> Bool {
@@ -79,10 +104,21 @@ private final class SnapshotSession: @unchecked Sendable {
         return true
     }
 
+    /// Downscale (if asked), lift to a `CGImage`, re-lay onto the
+    /// requested canvas, encode. A `native` size short-circuits the
+    /// re-lay inside `CaptureCanvas`, so the default path is still one
+    /// context and one encode.
     func encode(_ surface: IOSurface) -> Data? {
-        if let scaler, let pb = scaler.scale(surface, by: scale) {
-            return jpeg.encode(pb)
+        let lifted: CGImage?
+        if let scaler, let scaled = scaler.scale(surface, by: scale) {
+            lifted = CaptureCanvas.image(from: scaled)
+        } else {
+            lifted = CaptureCanvas.image(from: surface)
         }
-        return jpeg.encode(surface)
+        guard let lifted,
+              let composed = CaptureCanvas.apply(
+                  size: size, fit: fit, background: background, to: lifted
+              ) else { return nil }
+        return CaptureCanvas.encode(composed, format: format, quality: quality)
     }
 }

--- a/Tests/BaguetteTests/Screen/CaptureCanvasTests.swift
+++ b/Tests/BaguetteTests/Screen/CaptureCanvasTests.swift
@@ -1,0 +1,276 @@
+import Testing
+import Foundation
+import CoreGraphics
+import CoreVideo
+import ImageIO
+@testable import Baguette
+
+/// `CaptureCanvas` is the CoreGraphics half of the capture-size
+/// vocabulary: it takes the frame baguette grabbed and re-lays it onto
+/// the canvas the user asked for. The geometry is `CapturePlacement`'s
+/// job and already covered by `CaptureSizeTests` — what's asserted here
+/// is that the *pixels* land where the placement says: the letterbox
+/// bars really are the background colour, `cover` really crops, and a
+/// native capture really is left alone rather than resampled.
+@Suite("CaptureCanvas")
+struct CaptureCanvasTests {
+
+    // ── contain ──────────────────────────────────────────────
+
+    @Test func `contain letterboxes the frame onto the background`() throws {
+        // 100×50 all-red frame asked for a square: the ratio grows the
+        // binding axis to 100×100, so 25px of background sits above and
+        // below the centred frame.
+        let source = solid(width: 100, height: 50, red: 255, green: 0, blue: 0)
+        let out = try #require(CaptureCanvas.apply(
+            size: try CaptureSize.parse("square"), fit: .contain,
+            background: "#0000ff", to: source
+        ))
+
+        #expect(out.width == 100)
+        #expect(out.height == 100)
+        let grid = try samples(of: out)
+        #expect(grid.pixel(x: 50, y: 5) == Pixel(r: 0, g: 0, b: 255, a: 255))
+        #expect(grid.pixel(x: 50, y: 95) == Pixel(r: 0, g: 0, b: 255, a: 255))
+        #expect(grid.pixel(x: 50, y: 50) == Pixel(r: 255, g: 0, b: 0, a: 255))
+    }
+
+    @Test func `a transparent background leaves the letterbox bars clear`() throws {
+        let source = solid(width: 100, height: 50, red: 255, green: 0, blue: 0)
+        let out = try #require(CaptureCanvas.apply(
+            size: try CaptureSize.parse("square"), fit: .contain,
+            background: "transparent", to: source
+        ))
+        let grid = try samples(of: out)
+        #expect(grid.pixel(x: 50, y: 5).a == 0)
+        #expect(grid.pixel(x: 50, y: 50).a == 255)
+    }
+
+    // ── cover ────────────────────────────────────────────────
+
+    @Test func `cover crops the overflow instead of letterboxing`() throws {
+        // Left half red, right half green. 100×50 → square under cover
+        // scales ×2 and centres, so the visible window is source x 25…75:
+        // the canvas keeps red on the left, green on the right, and no
+        // background ever shows.
+        let source = halves(width: 100, height: 50)
+        let out = try #require(CaptureCanvas.apply(
+            size: try CaptureSize.parse("square"), fit: .cover,
+            background: "#0000ff", to: source
+        ))
+
+        #expect(out.width == 100)
+        #expect(out.height == 100)
+        let grid = try samples(of: out)
+        #expect(grid.pixel(x: 5, y: 50) == Pixel(r: 255, g: 0, b: 0, a: 255))
+        #expect(grid.pixel(x: 95, y: 50) == Pixel(r: 0, g: 255, b: 0, a: 255))
+        #expect(grid.pixel(x: 50, y: 2).b != 255)
+        #expect(grid.pixel(x: 50, y: 97).b != 255)
+    }
+
+    // ── stretch ──────────────────────────────────────────────
+
+    @Test func `stretch fills the whole canvas, distorting the frame`() throws {
+        let source = solid(width: 100, height: 50, red: 255, green: 0, blue: 0)
+        let out = try #require(CaptureCanvas.apply(
+            size: try CaptureSize.parse("square"), fit: .stretch,
+            background: "#0000ff", to: source
+        ))
+        let grid = try samples(of: out)
+        #expect(grid.pixel(x: 2, y: 2) == Pixel(r: 255, g: 0, b: 0, a: 255))
+        #expect(grid.pixel(x: 97, y: 97) == Pixel(r: 255, g: 0, b: 0, a: 255))
+    }
+
+    // ── native ───────────────────────────────────────────────
+
+    @Test func `a native capture hands back the very same frame`() throws {
+        let source = solid(width: 100, height: 50, red: 255, green: 0, blue: 0)
+        let out = CaptureCanvas.apply(
+            size: .native, fit: .contain, background: "#0000ff", to: source
+        )
+        #expect(out === source)
+    }
+
+    // ── fixed sizes ──────────────────────────────────────────
+
+    @Test func `a fixed size comes out at exactly the requested pixels`() throws {
+        let source = solid(width: 100, height: 50, red: 255, green: 0, blue: 0)
+        let out = try #require(CaptureCanvas.apply(
+            size: try CaptureSize.parse("40x80"), fit: .contain,
+            background: "#0000ff", to: source
+        ))
+        #expect(out.width == 40)
+        #expect(out.height == 80)
+    }
+
+    // ── lifting a framebuffer ────────────────────────────────
+
+    @Test func `a lifted frame keeps its pixels after the framebuffer moves on`() throws {
+        // SimulatorKit keeps rendering into the surface it handed us —
+        // `screen.stop()` only lands after the capture returns. A lifted
+        // frame that still aliased that memory would encode a torn mix of
+        // two frames, so the lift has to own its bytes.
+        let buffer = try #require(pixelBuffer(width: 8, height: 4, red: 255, green: 0, blue: 0))
+        let lifted = try #require(CaptureCanvas.image(from: buffer))
+
+        overwrite(buffer, red: 0, green: 0, blue: 255)
+
+        let grid = try samples(of: lifted)
+        #expect(grid.pixel(x: 4, y: 2) == Pixel(r: 255, g: 0, b: 0, a: 255))
+    }
+
+    // ── background parsing ───────────────────────────────────
+
+    @Test func `transparent is the absence of a background colour`() {
+        #expect(CaptureCanvas.background("transparent") == nil)
+        #expect(CaptureCanvas.background("#0000ff") == HexColor(red: 0, green: 0, blue: 1))
+    }
+
+    // ── encoding ─────────────────────────────────────────────
+
+    @Test func `encodes PNG bytes`() throws {
+        let source = solid(width: 8, height: 4, red: 255, green: 0, blue: 0)
+        let data = try #require(CaptureCanvas.encode(source, format: .png, quality: 0.85))
+        #expect(data.prefix(8) == Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]))
+        #expect(try decodedSize(data) == CGSize(width: 8, height: 4))
+    }
+
+    @Test func `encodes JPEG bytes`() throws {
+        let source = solid(width: 8, height: 4, red: 255, green: 0, blue: 0)
+        let data = try #require(CaptureCanvas.encode(source, format: .jpeg, quality: 0.85))
+        #expect(data.prefix(2) == Data([0xFF, 0xD8]))
+        #expect(try decodedSize(data) == CGSize(width: 8, height: 4))
+    }
+
+    // ── format choice ────────────────────────────────────────
+
+    @Test func `an explicit format wins over the output extension`() {
+        #expect(CaptureFormat.resolve(explicit: .jpeg, output: "/tmp/shot.png") == .jpeg)
+    }
+
+    @Test func `a png output path picks PNG when no format is named`() {
+        #expect(CaptureFormat.resolve(explicit: nil, output: "/tmp/shot.PNG") == .png)
+    }
+
+    @Test func `JPEG stays the default for stdout and every other extension`() {
+        #expect(CaptureFormat.resolve(explicit: nil, output: nil) == .jpeg)
+        #expect(CaptureFormat.resolve(explicit: nil, output: "/tmp/shot.jpg") == .jpeg)
+    }
+
+    @Test func `parses the format names a user types`() {
+        #expect(CaptureFormat(argument: "png") == .png)
+        #expect(CaptureFormat(argument: "jpg") == .jpeg)
+        #expect(CaptureFormat(argument: "jpeg") == .jpeg)
+        #expect(CaptureFormat(argument: "gif") == nil)
+    }
+}
+
+// MARK: - Synthetic frames
+
+/// One sampled pixel, read back out of a known BGRA layout.
+private struct Pixel: Equatable {
+    let r: UInt8, g: UInt8, b: UInt8, a: UInt8
+}
+
+private struct PixelGrid {
+    let width: Int
+    let height: Int
+    let bytes: [UInt8]
+
+    /// `y` counts from the top, matching how the placement talks.
+    func pixel(x: Int, y: Int) -> Pixel {
+        let i = (y * width + x) * 4
+        // premultipliedFirst + byteOrder32Little == B, G, R, A in memory.
+        return Pixel(r: bytes[i + 2], g: bytes[i + 1], b: bytes[i], a: bytes[i + 3])
+    }
+}
+
+/// A solid-colour BGRA image — the simplest stand-in for a framebuffer.
+private func solid(width: Int, height: Int, red: UInt8, green: UInt8, blue: UInt8) -> CGImage {
+    image(width: width, height: height) { _, _ in (red, green, blue) }
+}
+
+/// Left half red, right half green — enough asymmetry to prove a crop
+/// took the middle and not an edge.
+private func halves(width: Int, height: Int) -> CGImage {
+    image(width: width, height: height) { x, _ in
+        x < width / 2 ? (255, 0, 0) : (0, 255, 0)
+    }
+}
+
+private func image(
+    width: Int, height: Int,
+    fill: (Int, Int) -> (UInt8, UInt8, UInt8)
+) -> CGImage {
+    var bytes = [UInt8](repeating: 0, count: width * height * 4)
+    for y in 0..<height {
+        for x in 0..<width {
+            let (r, g, b) = fill(x, y)
+            let i = (y * width + x) * 4
+            bytes[i] = b; bytes[i + 1] = g; bytes[i + 2] = r; bytes[i + 3] = 255
+        }
+    }
+    let made: CGImage? = bytes.withUnsafeMutableBytes { raw in
+        CGContext(
+            data: raw.baseAddress, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                | CGBitmapInfo.byteOrder32Little.rawValue
+        )?.makeImage()
+    }
+    return made!
+}
+
+/// A BGRA pixel buffer standing in for a live framebuffer — one that
+/// the test can then scribble over, the way the simulator does.
+private func pixelBuffer(
+    width: Int, height: Int, red: UInt8, green: UInt8, blue: UInt8
+) -> CVPixelBuffer? {
+    var buffer: CVPixelBuffer?
+    guard CVPixelBufferCreate(
+        kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA, nil, &buffer
+    ) == kCVReturnSuccess, let buffer else { return nil }
+    overwrite(buffer, red: red, green: green, blue: blue)
+    return buffer
+}
+
+private func overwrite(_ buffer: CVPixelBuffer, red: UInt8, green: UInt8, blue: UInt8) {
+    CVPixelBufferLockBaseAddress(buffer, [])
+    defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+    guard let base = CVPixelBufferGetBaseAddress(buffer) else { return }
+    let stride = CVPixelBufferGetBytesPerRow(buffer)
+    let bytes = base.assumingMemoryBound(to: UInt8.self)
+    for y in 0..<CVPixelBufferGetHeight(buffer) {
+        for x in 0..<CVPixelBufferGetWidth(buffer) {
+            let i = y * stride + x * 4
+            bytes[i] = blue; bytes[i + 1] = green; bytes[i + 2] = red; bytes[i + 3] = 255
+        }
+    }
+}
+
+/// Rasterize back into a known BGRA layout so pixels can be asserted.
+private func samples(of image: CGImage) throws -> PixelGrid {
+    let width = image.width, height = image.height
+    var bytes = [UInt8](repeating: 0, count: width * height * 4)
+    try bytes.withUnsafeMutableBytes { raw in
+        guard let context = CGContext(
+            data: raw.baseAddress, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                | CGBitmapInfo.byteOrder32Little.rawValue
+        ) else { throw CaptureCanvasTestFailure.contextFailed }
+        context.clear(CGRect(x: 0, y: 0, width: width, height: height))
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+    }
+    return PixelGrid(width: width, height: height, bytes: bytes)
+}
+
+private func decodedSize(_ data: Data) throws -> CGSize {
+    let source = try #require(CGImageSourceCreateWithData(data as CFData, nil))
+    let image = try #require(CGImageSourceCreateImageAtIndex(source, 0, nil))
+    return CGSize(width: image.width, height: image.height)
+}
+
+private enum CaptureCanvasTestFailure: Error { case contextFailed }

--- a/Tests/BaguetteTests/Screen/ScreenSnapshotTests.swift
+++ b/Tests/BaguetteTests/Screen/ScreenSnapshotTests.swift
@@ -1,0 +1,96 @@
+import Testing
+import Foundation
+import CoreGraphics
+import CoreVideo
+import ImageIO
+import IOSurface
+import Mockable
+@testable import Baguette
+
+/// The SimulatorKit call that hands over a framebuffer is integration-
+/// only, but everything `ScreenSnapshot` does around it is not: the
+/// single-shot race between the frame callback, the timeout timer, and a
+/// throwing `start`, plus the size / fit / format the caller asked for.
+/// `MockScreen` stands in for the simulator and a host-allocated
+/// `IOSurface` stands in for the framebuffer.
+@Suite("ScreenSnapshot")
+struct ScreenSnapshotTests {
+
+    @Test func `a captured frame comes back as JPEG at the screen's own size`() async throws {
+        let surface = try #require(makeSurface(width: 120, height: 60))
+        let screen = MockScreen()
+        given(screen).start(onFrame: .any).willProduce { onFrame in onFrame(surface) }
+        given(screen).stop().willReturn(())
+
+        let bytes = try await ScreenSnapshot.capture(screen: screen)
+
+        #expect(bytes.prefix(2) == Data([0xFF, 0xD8]))
+        #expect(try decoded(bytes) == CGSize(width: 120, height: 60))
+    }
+
+    @Test func `a requested size resizes the captured frame`() async throws {
+        let surface = try #require(makeSurface(width: 120, height: 60))
+        let screen = MockScreen()
+        given(screen).start(onFrame: .any).willProduce { onFrame in onFrame(surface) }
+        given(screen).stop().willReturn(())
+
+        let bytes = try await ScreenSnapshot.capture(
+            screen: screen,
+            size: try CaptureSize.parse("40x80"), fit: .contain, background: "#000000"
+        )
+
+        #expect(try decoded(bytes) == CGSize(width: 40, height: 80))
+    }
+
+    @Test func `a PNG capture carries the PNG signature`() async throws {
+        let surface = try #require(makeSurface(width: 40, height: 20))
+        let screen = MockScreen()
+        given(screen).start(onFrame: .any).willProduce { onFrame in onFrame(surface) }
+        given(screen).stop().willReturn(())
+
+        let bytes = try await ScreenSnapshot.capture(screen: screen, format: .png)
+
+        #expect(bytes.prefix(8) == Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]))
+    }
+
+    @Test func `a screen that never delivers a frame times out`() async throws {
+        let screen = MockScreen()
+        given(screen).start(onFrame: .any).willReturn(())
+        given(screen).stop().willReturn(())
+
+        await #expect(throws: ScreenSnapshot.Failure.timeout) {
+            _ = try await ScreenSnapshot.capture(screen: screen, timeout: 0.05)
+        }
+    }
+
+    @Test func `a screen that refuses to open surfaces its own error`() async throws {
+        let screen = MockScreen()
+        given(screen).start(onFrame: .any).willThrow(SnapshotTestError.notBooted)
+        given(screen).stop().willReturn(())
+
+        await #expect(throws: SnapshotTestError.notBooted) {
+            _ = try await ScreenSnapshot.capture(screen: screen)
+        }
+    }
+}
+
+private enum SnapshotTestError: Error, Equatable { case notBooted }
+
+/// A host-allocated BGRA surface — same shape as the one SimulatorKit
+/// hands over, without needing a booted simulator.
+private func makeSurface(width: Int, height: Int) -> IOSurface? {
+    IOSurface(properties: [
+        .width: width,
+        .height: height,
+        .bytesPerElement: 4,
+        .bytesPerRow: width * 4,
+        .pixelFormat: kCVPixelFormatType_32BGRA,
+        .allocSize: width * height * 4,
+    ])
+}
+
+private func decoded(_ data: Data) throws -> CGSize {
+    let source = try #require(CGImageSourceCreateWithData(data as CFData, nil))
+    let image = try #require(CGImageSourceCreateImageAtIndex(source, 0, nil))
+    return CGSize(width: image.width, height: image.height)
+}


### PR DESCRIPTION
Unit 7 of the capture-size feature: teaches `baguette screenshot` the shared output-size vocabulary, and closes the "No PNG" known limit.

```bash
baguette screenshot --udid X --size appstore-6.9 --format png -o a.png   # 1290 × 2796
baguette screenshot --udid X --size square --fit contain --background '#101010'
baguette screenshot --udid X -o c.jpg                                    # unchanged native path
```

## What's new

| flag | default | accepts |
|---|---|---|
| `--size` | `native` | a preset, `WIDTHxHEIGHT`, or `W:H` — `CaptureSize.parse`, so exactly the shared catalogue |
| `--fit` | `contain` | `contain` / `cover` / `stretch` |
| `--background` | `#ffffff` | `transparent` or `#RRGGBB` |
| `--format` | inferred from `--output`, else `jpg` | `png` / `jpg` / `jpeg` |

An unknown size exits non-zero with the vocabulary's own message rather than guessing. `--quality` reaches JPEG only; PNG is lossless. With `--format` omitted the output extension decides, so `-o shot.png` never silently writes JPEG bytes into a `.png` file.

## New: `CaptureCanvas`

`CaptureSize` decides *where* a frame lands; `CaptureCanvas` (Infrastructure/Screen) moves the pixels — fill the background, draw the frame into the placement's rect, encode PNG or JPEG. Splitting it out is what makes the feature testable: synthetic `CGImage`s in, assertable pixels out, leaving SimulatorKit's framebuffer callback as the only integration-only part of the path.

Two details worth a look in review:

- **The vertical flip.** A `CapturePlacement` counts `drawY` down from the top (the canvas-2D convention the browser half uses); CoreGraphics counts up from the bottom, so the draw rect's origin is mirrored. Skipping that is invisible on a symmetric letterbox and quietly wrong on every odd-pixel or `cover` crop.
- **The framebuffer copy.** Lifting a pixel buffer to a `CGImage` now copies the bytes under the lock. SimulatorKit keeps rendering into that surface until `screen.stop()`, which only lands after the capture returns, and `CGBitmapContextCreateImage` only promises copy-on-write against drawing *through the context* — not against a foreign writer. An aliasing image could be encoded as a torn mix of two frames.

## Compatibility

`ScreenSnapshot.capture` gains `size` / `fit` / `background` / `format`, every one defaulted to "exactly what the framebuffer gave us", so the `Server` and `Render3DCommand` call sites are untouched and byte-identical.

The CLI defaults `--background` to `#ffffff` — matching `capture-settings.js` and `docs/features/capture-size.md` rather than the API default. At `native` size nothing is letterboxed so it never paints; once a size is asked for, a JPEG (no alpha channel) would otherwise flatten the bars to black.

## Tests

TDD throughout — `CaptureCanvasTests` was red on `cannot find 'CaptureCanvas' in scope` before any of `Sources/` was touched.

- `Tests/BaguetteTests/Screen/CaptureCanvasTests.swift` — 14 tests over synthetic `CGImage`s: contain really letterboxes in the requested colour, transparent bars really have `a == 0`, `cover` really crops the middle out of a red/green split, `stretch` fills the corners, a `native` capture hands back the very same object (`out === source`), a lifted frame survives the framebuffer being overwritten, plus PNG/JPEG signatures and format inference.
- `Tests/BaguetteTests/Screen/ScreenSnapshotTests.swift` — the orchestration through `MockScreen` with a host-allocated `IOSurface`: JPEG at the screen's own size, a requested size resizing the capture, PNG, the timeout, and a throwing `start` surfacing its own error.

Full suite: 1519 Swift tests + 218 JS tests green.

## Verified on device

Against a booted iPhone 17 Pro Max (iOS 26.4), with pixels sampled out of the real output:

- `--size appstore-6.9 --format png` → 1290 × 2796 PNG.
- `--size square --background '#101010'` → 2868 × 2868 JPEG, left/right bars sampling exactly `r=16 g=16 b=16`.
- `--size square` (transparent) → bars sampling `a = 0` in the PNG.
- `--size 16:9 --fit cover` → 5099 × 2868 with no background pixel anywhere; the overflow really crops.
- default `-o c.jpg` → 1320 × 2868, the device's native size, unchanged.
- `--size nonsense` / `--fit weird` / `--format gif` → exit 64 with a clear message listing the valid values.

## Not in this PR

`README.md` and `docs/features/screenshot.md` are unit 11's; the exact flag spellings have been handed over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
