### PR TITLE
docs: document the shared capture-size vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,67 @@ For releases prior to this changelog, see the
 
 ### Added
 
+- **One output size for every capture — `--size appstore-6.9`, and the
+  same words in the UI.** Screenshots and recordings, 2D and 3D, browser
+  and CLI, now share one vocabulary: the App Store submission sizes
+  (`appstore-6.9`, `appstore-6.5`, `appstore-ipad-13`), the common ratios
+  (`square`, `16:9`, `9:16`, `4:3`, `4:5`), plus `1920x1080` and any bare
+  `W:H`. Pick "App Store 6.9″" from the toolbar chip once and reproduce
+  exactly those pixels in CI with `--size appstore-6.9`.
+
+  A ratio **grows** rather than crops: `square` on a 1290 × 2796 phone
+  gives a 2796 × 2796 canvas with the whole phone centred, not a
+  1290 × 1290 cut through the middle of the screen. Cropping the device
+  out of a marketing shot is the one thing nobody asking for a square
+  wanted. `--fit` (`contain` / `cover` / `stretch`) and `--background`
+  say what fills the rest. Unknown sizes are rejected — baguette never
+  substitutes a nearby one.
+
+  See [`docs/features/capture-size.md`](docs/features/capture-size.md).
+
+- **`baguette record` — video straight from the CLI.** A booted simulator,
+  an `--output`, and either `--duration` or `Ctrl-C`; the file is flushed
+  and playable either way. Takes `--size` / `--fit` / `--fps` /
+  `--bitrate`, writes `.mp4` or `.mov` (the extension picks the
+  container).
+
+  `docs/features/recording.md` has argued for a while that server-side
+  recording was tried and rejected, and that argument still stands *for
+  the live stream* — a recorder attaching mid-stream never sees the
+  SPS/PPS the encoder emitted on its first IDR, and an N+1th
+  VideoToolbox session stutters every farm tile. Neither applies to a
+  standalone CLI run: it owns the encode from frame one and has no
+  competing viewer. So the design that was wrong as a passenger is the
+  right one on its own, and it is wired into nothing — no route, no WS
+  verb.
+
+- **PNG screenshots, and a bezelled one.** `baguette screenshot
+  --format png` (inferred from a `.png --output`, so `-o shot.png` can
+  never quietly hold JPEG bytes), plus `GET …/screenshot.png` and
+  `GET …/screenshot-bezel.png` — the frame composited inside its
+  DeviceKit chrome, which previously meant opening a browser and
+  cropping. All three routes take `?size=&fit=&background=`;
+  `screenshot.jpg` with no new parameters returns byte-identical output
+  to before.
+
+- **A size chip on every capture surface**, and a Record button where
+  there wasn't one. The focus-mode view had only ever had Screenshot; it
+  now records too, in both 2D and 3D — dropping the bezel in 3D, since
+  the rendered frame already contains a device. The legacy stream
+  sidebar and the device-farm focus pane get the same chip, each
+  remembering its own selection, and it drives Capture and Record alike:
+  a screenshot and a clip taken a second apart come out at the same
+  dimensions. Saved files are named for what they are —
+  `…-appstore-6.9-1290x2796.png`.
+
+- **The browser's 3D export is now lossless.** It used to save
+  `toDataURL()` of the decoded video canvas — a ~960 px H.264 or MJPEG
+  frame. It now asks the server to re-render the same pose at the picked
+  size, so `appstore-6.9` really is 1290 × 2796 instead of an upscale of
+  a video still. `render-3d --size` and the route's `"size"` field take
+  preset names as well as literal pixels, and the live 3D stream accepts
+  `size=`.
+
 - **Deep links — `baguette openurl <url>` and `baguette schemes`.** Opens a link
   on a booted simulator, and lists the URL schemes its apps registered (ranked:
   an app's own scheme before its reverse-DNS and `exp+` aliases). Unlike

--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ open http://localhost:8421/farm
 `/simulators` lists every simulator on the machine with Boot / Shutdown
 buttons; click any booted device to open its focus-mode page —
 full-window live stream, DeviceKit-sourced bezel, top toolbar with
-Camera / Accessibility / Logs / Home / Screenshot / App-switcher
-controls, and a sidebar-view jump button.
+Camera / Accessibility / Logs / Home / Screenshot / Record /
+App-switcher controls, an output-size chip, and a sidebar-view jump
+button.
 
 `/farm` is the multi-device control surface. See
 [Device farm](#device-farm) below.
@@ -161,6 +162,11 @@ Headless from the terminal works too:
 baguette list
 baguette boot --udid <UDID>
 baguette tap --udid <UDID> --x 219 --y 478 --width 438 --height 954
+
+# an App Store-sized screenshot, and a 10-second clip at the same size
+baguette screenshot --udid <UDID> --size appstore-6.9 -o hero.png
+baguette record     --udid <UDID> --size appstore-6.9 --duration 10 \
+                    --output demo.mp4
 ```
 
 ## Build from source
@@ -205,14 +211,30 @@ baguette <command> [options]
                                              device reads "unknown" — a state,
                                              not an error.
 
-  # Frames + screenshots
+  # Frames, screenshots + video. --size speaks one shared vocabulary
+  # (presets like appstore-6.9 / square / 16:9, plus WIDTHxHEIGHT and
+  # W:H) — see docs/features/capture-size.md. NB render-3d's --fit
+  # places the screenshot on the device MESH, not on the canvas.
   stream     --udid <UDID> [--fps 60] [--format mjpeg|avcc]
                                              Stream frames on stdout
-  screenshot --udid <UDID> [--output <path>] [--quality 0.85] [--scale 1]
-                                             One-shot JPEG (defaults to stdout)
+  screenshot --udid <UDID> [--output <path>] [--format png|jpg]
+             [--quality 0.85] [--scale 1]
+             [--size native] [--fit contain] [--background '#ffffff']
+                                             One frame (defaults to stdout;
+                                             --format is inferred from the
+                                             --output extension)
+  record     --udid <UDID> --output <file.mp4|file.mov>
+             [--size native] [--fit contain] [--background '#ffffff']
+             [--fps 30] [--duration <sec>] [--bitrate 8000000]
+                                             Record H.264 video until --duration
+                                             elapses or ^C; either way the file
+                                             is flushed and playable. --output
+                                             is required (no stdout) and its
+                                             extension picks the container.
   render-3d  (--udid <UDID> | --screen <image> --device <model-id>)
              [--variant <set>=<choice>] [--rotation X,Y,Z]
-             [--size WIDTHxHEIGHT] [--output <path>]
+             [--size <spec>] [--fit cover] [--background transparent]
+             [--screen-glass] [--output <path>]
                                              Render a screenshot on a 3D device
                                              model as PNG
 
@@ -302,6 +324,36 @@ baguette <command> [options]
   press --udid … --button <name> [--duration <sec>]
 ```
 
+## Capture size — one vocabulary
+
+Screenshots and recordings, 2D and 3D, browser and CLI, all take the
+same output size. Say it once and get the same pixels wherever you
+say it:
+
+| spec | resolves to |
+|---|---|
+| `native` *(default)* | the source's own dimensions |
+| `appstore-6.9` / `appstore-6.5` / `appstore-ipad-13` | Apple's submission sizes |
+| `square` / `16:9` / `9:16` / `4:3` / `4:5` | a ratio, resolved against the source |
+| `1920x1080` | exact pixels |
+| `3:2` | any other ratio |
+
+```bash
+baguette screenshot --udid <UDID> --size appstore-6.9 -o hero.png
+baguette record     --udid <UDID> --size square --duration 10 -o clip.mp4
+baguette render-3d  --udid <UDID> --size square -o device.png
+curl -o shot.png 'localhost:8421/simulators/<UDID>/screenshot.png?size=square'
+```
+
+`--fit` (`contain` / `cover` / `stretch`) says what happens when the
+aspects disagree, and `--background` fills the letterbox. A ratio
+**grows** the source rather than cropping it — `square` on a phone
+gives you the whole phone centred in a square, not a square cut out of
+the middle. Unknown sizes are rejected, never approximated.
+
+Full details, including why the ratio maths works that way, in
+[`docs/features/capture-size.md`](docs/features/capture-size.md).
+
 ## `baguette serve` — the web UI
 
 ```bash
@@ -352,7 +404,9 @@ rejected.
 | `GET`  | `/simulators/:udid/definition.json`        | SDK bootstrap: identity + screen rect + bezel image URLs + per-button envelope/box/transform |
 | `GET`  | `/simulators/:udid/chrome.json`            | DeviceKit bezel layout       |
 | `GET`  | `/simulators/:udid/bezel.png`              | rasterized bezel PNG         |
-| `GET`  | `/simulators/:udid/screenshot.jpg`         | one-shot JPEG (`?quality=&scale=`) |
+| `GET`  | `/simulators/:udid/screenshot.jpg`         | one-shot JPEG (`?quality=&scale=&size=&fit=&background=`) |
+| `GET`  | `/simulators/:udid/screenshot.png`         | the same frame, lossless |
+| `GET`  | `/simulators/:udid/screenshot-bezel.png`   | the frame composited inside its DeviceKit bezel (`&buttons=`) |
 | `GET`  | `/simulators/:udid/interface.json`         | appearance + contrast + content size |
 | `POST` | `/simulators/:udid/interface`              | set any subset; answers with the resulting state |
 | `GET`  | `/simulators/:udid/describe-ui.json`       | accessibility tree over HTTP (`?x=&y=` hit-tests a point) |
@@ -662,6 +716,9 @@ feature lives in one place across both layers.
 │   │   │                             Scroll / Pinch / Pan / Key / TypeText /
 │   │   │                             Keyboard / DeviceEdge / GesturePhase
 │   │   ├── Screen/                   Screen (frame source)
+│   │   ├── Capture/                  CaptureSize + CaptureFit +
+│   │   │                             CapturePlacement — one output-size
+│   │   │                             vocabulary for every capture surface
 │   │   ├── Stream/                   Stream + StreamConfig / StreamFormat
 │   │   │                             + Envelope (MJPEG / AVCC framing)
 │   │   ├── Chrome/                   Chromes aggregate + DeviceChrome /
@@ -753,6 +810,12 @@ feature lives in one place across both layers.
 │       ├── frame-decoder.js          MJPEG / AVCC strategy
 │       ├── stream-session.js         WebSocket + paint loop
 │       ├── capture-gallery.js        screenshot fetch + thumbs
+│       ├── capture/                  the shared output-size vocabulary
+│       │   ├── capture-size.js       presets + placement maths (mirrors
+│       │   │                         Domain/Capture/CaptureSize.swift)
+│       │   ├── capture-settings.js   the user's selection, persisted
+│       │   ├── capture-composer.js   bezel / screen / overlay painter
+│       │   └── capture-size-menu.js  the toolbar picker
 │       ├── baguette/                 JS SDK — Baguette.use({…}) entry,
 │       │   ├── baguette.js           transport.js (the only wire-format
 │       │   ├── transport.js          owner), simulator.js, parts/<name>.js

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ rejected.
 | `GET`  | `/simulators/:udid/chrome.json`            | DeviceKit bezel layout       |
 | `GET`  | `/simulators/:udid/bezel.png`              | rasterized bezel PNG         |
 | `GET`  | `/simulators/:udid/screenshot.jpg`         | one-shot JPEG (`?quality=&scale=&size=&fit=&background=`) |
-| `GET`  | `/simulators/:udid/screenshot.png`         | the same frame, lossless |
+| `GET`  | `/simulators/:udid/screenshot.png`         | the same frame, in a lossless container |
 | `GET`  | `/simulators/:udid/screenshot-bezel.png`   | the frame composited inside its DeviceKit bezel (`&buttons=`) |
 | `GET`  | `/simulators/:udid/interface.json`         | appearance + contrast + content size |
 | `POST` | `/simulators/:udid/interface`              | set any subset; answers with the resulting state |

--- a/docs/features/3d-rendering.md
+++ b/docs/features/3d-rendering.md
@@ -68,7 +68,7 @@ baguette render-3d \
   --udid 5A1B… \
   --variant finish=space-black \
   --rotation=-30,45,30 \
-  --size 1200x1200 \
+  --size appstore-6.9 \
   --output device.png
 ```
 
@@ -93,7 +93,7 @@ with `--screen` and inferred from the simulator when `--udid` is used.
 | `--device` | inferred | Installed model definition ID |
 | `--variant <set>=<choice>` | definition defaults | Repeatable model variant selection |
 | `--rotation X,Y,Z` | `0,0,0` | Device rotation in degrees |
-| `--size WIDTHxHEIGHT` | source dimensions | Output pixel size |
+| `--size <spec>` | source dimensions | Output size: a preset, `WIDTHxHEIGHT`, or `W:H` |
 | `--fit cover\|contain\|stretch` | `cover` | Screenshot placement on the screen surface |
 | `--background transparent\|#RRGGBB` | `transparent` | Output canvas |
 | `--screen-glass` | off | Composite a reflective cover glass over the screen |
@@ -101,6 +101,40 @@ with `--screen` and inferred from the simulator when `--udid` is used.
 
 Unknown devices, model IDs, variant sets, and variant choices fail explicitly.
 Baguette never substitutes a visually similar model.
+
+### `--size` speaks the shared capture vocabulary
+
+`--size` used to be literal pixels only. It now takes anything
+[`capture-size.md`](capture-size.md) defines — the preset
+names (`appstore-6.9`, `square`, `16:9`, …), `WIDTHxHEIGHT` exactly as
+before, or a bare ratio like `3:2`. The default is unchanged: omit it
+and you get the captured screenshot's own pixel size, which is what
+`native` means.
+
+Two consequences specific to 3D:
+
+- **Ratios resolve against the captured screen, not the rendered
+  device.** `--size square` on a 1290 × 2796 capture asks for a
+  2796 × 2796 canvas, then the device is framed inside it. The camera
+  fits the model to whatever canvas comes out, so a square request
+  gives you a squarely-framed device rather than a tall device with
+  bars.
+- **Nothing downscales.** As everywhere else in the vocabulary, a
+  ratio grows the binding axis. Use an explicit `WIDTHxHEIGHT` when
+  you want a bounded output.
+
+Unknown values fail the same way they always did — non-zero exit,
+`invalid --size`, no substitution. There are no new error codes here.
+
+**`--fit` here is a different axis from `--fit` everywhere else.** On
+`screenshot` and `record`, fit says how the frame sits inside the
+output canvas. On `render-3d` it says how the *screenshot* sits on the
+device's screen surface — a UV placement on the mesh, not a canvas
+placement. That is why its default is `cover` rather than `contain`:
+an app screenshot letterboxed inside a phone display would look like a
+bug. The name is shared because the three modes mean the same thing
+(fill and crop / fit and pad / distort); the surface they act on is
+not.
 
 ## HTTP
 
@@ -119,15 +153,25 @@ Content-Type: application/json
   "variants": {
     "finish": "space-black"
   },
-  "size": {
-    "width": 1200,
-    "height": 1200
-  },
+  "size": "appstore-6.9",
   "fit": "cover",
   "background": "transparent",
   "screenGlass": false
 }
 ```
+
+`"size"` accepts either a string spec — `"appstore-6.9"`, `"square"`,
+`"1200x900"`, `"3:2"` — or the original object form:
+
+```json
+{ "size": { "width": 1200, "height": 900 } }
+```
+
+Both are supported and the object form is unchanged, so anything
+already POSTing to this route keeps working. Omitting `"size"` gives
+the captured screen's own dimensions. A bad spec is a `400` with the
+existing `invalid 3D render options` message; the string form did not
+introduce a new error branch.
 
 The response is `image/png`. Defaults are the same as the CLI. Error branches:
 
@@ -162,10 +206,26 @@ Initial render configuration is supplied as public query parameters:
 &variant=finish:deep-blue
 &width=1200
 &height=1200
+&size=square
 &fit=cover
 &background=%23eef1f5
 &screenGlass=true
 ```
+
+`size=` is optional and takes the same vocabulary as everywhere else.
+It composes with — rather than replaces — `width=` / `height=`, which
+still work exactly as before: the requested `width`×`height` (default
+960 × 960) is the *source box* the size resolves against, and the
+result is then rounded up to even dimensions for the H.264 4:2:0
+path. So `?size=appstore-6.9` yields 1290 × 2796, and
+`?width=1280&height=720&size=square` yields 1280 × 1280.
+
+That layering matters because the browser is already choosing
+`width` / `height` from the CSS size of the stage (clamped 480–1600
+per side, hard-capped at 4096). `size=` shapes that box; it does not
+lift the bound. Asking a live stream for a 2796-px-tall App Store
+canvas is legal and expensive — the one-shot PNG route is the better
+tool for a submission-sized asset.
 
 `variant` is repeatable. The server validates model, variant, rotation, output
 size, fit, and background before subscribing to the simulator screen.
@@ -225,6 +285,13 @@ Definitions are resolved in precedence order:
 
 An ID found in a higher-precedence directory replaces the same ID below it.
 Two definitions at the same precedence that match one simulator are an error.
+
+The third entry is the one that surprises people: "bundled definitions" means
+the SPM resource bundle, which sits beside the binary in `.build/`. `build.sh`
+copies only the binary to `./Baguette`, so a release build has no bundle to
+read and nothing creates the application-support directory either — a fresh
+`./Baguette render-3d` 404s until `BAGUETTE_3D_MODEL_DIR` points somewhere.
+`swift run` is unaffected. See Known limits.
 
 The asset block may contain `file`, or `downloadURL` plus a required SHA-256,
 or both. A local file wins. Downloaded assets are staged to a temporary name,
@@ -386,6 +453,57 @@ without a separate card, border, radius, or stage shadow. MJPEG and H.264
 frames are opaque, so the browser sends the current light or dark page color
 as the render background and reconnects the 3D stream when the theme changes.
 
+### Exporting a PNG from the browser
+
+The inspector's export button used to call `toDataURL()` on the canvas
+the decoder paints into. That canvas is the *decoded video frame*: it
+is whatever size the live stream negotiated (clamped to 1600 px a
+side) and it has already been through JPEG or H.264. It was exactly
+the picture on screen, which is the right thing for a preview and the
+wrong thing for a marketing asset.
+
+Export now POSTs to `/simulators/:udid/render-3d.png` with the current
+pose, variant selection, and glass setting, plus the picked capture
+size, and saves the PNG that comes back. Same scene, same camera,
+rendered fresh at full resolution with no codec in the path — the live
+stream becomes a preview of the export rather than its source. On a
+booted iPhone 17 Pro Max that is 1320 × 2868 at native and a true
+1290 × 2796 at `appstore-6.9`, where the old path could only ever hand
+back something around 960 px and upscale.
+
+Four details of the request are worth knowing:
+
+- **`fit` is always sent as `cover`**, never the toolbar's fit. On this
+  route `fit` places the screenshot on the device *mesh* (see above),
+  so forwarding the picker's `contain` would letterbox the app inside
+  the phone's display.
+- **`size` is omitted for `native`**, and for a ratio preset when the
+  stream size isn't known yet — the server then renders at the screen's
+  own pixels. A resolved size is *not* subject to the live stream's
+  480–1600 clamp; that bound belongs to the socket, not to the route.
+- **Zoom is not sent.** `DeviceRenderOptions` has no zoom field, so the
+  export always frames at 1×. The panel warns in the console when the
+  live zoom differs, rather than silently saving a differently-framed
+  image.
+- **A failure still saves something.** If the route is missing or
+  answers non-2xx, the panel logs `[3d] lossless render failed, saving
+  the live frame instead` and falls back to `toDataURL` of the live
+  canvas, named `<model-id>-live-3d.png` so the file itself says which
+  path produced it. Concurrent saves are ignored while one is in
+  flight.
+
+The saved file carries the size slug like every other capture (see
+[`capture-size.md`](capture-size.md)):
+`iphone-17-pro-max-3d-appstore-6.9-1290x2796.png`, with the dimensions
+read from what actually came back rather than what was asked for. The
+bezel toggle is suppressed while 3D is open — the frame already
+contains a device, so wrapping it in DeviceKit chrome would draw a
+phone around a phone.
+
+Recording the 3D stage is the same story with the same reasoning
+inverted: a recording *is* the decoded stream, so it stays browser-side
+and simply turns the bezel off. See [`recording.md`](recording.md).
+
 The 3D stage follows an explicit two-mode interaction model:
 
 - **Pose** (default): drag rotates the persistent model, Option-drag or the
@@ -466,11 +584,45 @@ image for every live farm tile is too expensive and adds no control value.
 
 - Live 3D supports the existing MJPEG and H.264/AVCC stream formats. AVCC
   requires browser WebCodecs support, matching the normal focused stream.
+- The live stream's dimensions are still bounded by what the browser asks
+  for (480–1600 per side from the UI, 4096 hard cap). `size=` shapes that
+  box; it does not lift the bound. Submission-sized output comes from the
+  one-shot PNG route, not from the stream.
+- Browser PNG export is a server round-trip, so it costs a fresh render and
+  fails the way the route fails (a 4xx/5xx surfaces as an export error)
+  rather than always producing *something* the way `toDataURL` did.
 - Interact mode maps clicks through the projected screen quad (a flat
   rectangle), not a full ray cast against the GPU mesh — correct for the
   planar displays every model authors so far, but two-finger pinch/pan and
   the Option-hover preview still assume a 1:1 canvas crop and drift from the
   true screen position away from Front.
+- **Zoom is lost when you save.** `DeviceRenderOptions` carries no zoom
+  field, so the one-shot render always frames the device at 1× even when
+  the live view is dollied in. The panel logs a console warning rather than
+  quietly handing you a differently-framed image. Fixing it needs a new
+  wire field plus camera work on the render path; it is deliberately out of
+  this release.
+- **A release binary can't find the models on its own.** Definitions resolve
+  from `BAGUETTE_3D_MODEL_DIR`, then
+  `~/Library/Application Support/com.tddworks.baguette/3d-models`, then
+  bundled definitions — but a `./Baguette` built by `build.sh` has no
+  resource bundle beside it and nothing creates the application-support
+  directory, so `render-3d` 404s until you set `BAGUETTE_3D_MODEL_DIR`
+  yourself:
+
+  ```bash
+  BAGUETTE_3D_MODEL_DIR=Sources/Baguette/Resources/Models3D \
+    ./Baguette render-3d --udid 5A1B… -o device.png
+  ```
+
+  `swift run` picks the bundle up; the copied release binary does not.
+  This has cost more than one person an hour.
+- **`fit` is not `CaptureFit` here.** On this route `fit` is
+  `DeviceScreenFit` — the UV placement of the app screenshot on the device's
+  screen *mesh*. Forwarding a capture-size picker's canvas fit into a 3D
+  render letterboxes the app inside the phone's display. Canvas placement
+  in 3D is the camera's job, and there is no knob for it, which is why the
+  picker hides the control while 3D is open.
 - Model definitions depend on opaque node/material names that Apple may change
   when replacing an asset at the same URL; SHA-256 verification prevents an
   unnoticed replacement.

--- a/docs/features/capture-size.md
+++ b/docs/features/capture-size.md
@@ -100,9 +100,12 @@ background, and there is no screenshot behind it to protect.
 Two traps behind that, both from the same root — **most image and
 video formats carry no alpha**:
 
-- **JPEG.** A transparent letterbox in a `.jpg` flattens to *black*,
-  not to white. Pass a hex colour, or ask for PNG. Nothing warns you;
-  format and background are independent flags.
+- **JPEG.** A `.jpg` cannot carry a transparent letterbox, so it mats
+  *white* rather than honouring the request — an unmatted transparent
+  canvas flattens to black on encode, and a black border is not what
+  anyone meant by "transparent". Ask for PNG when you want the mat
+  genuinely absent. Nothing warns you; format and background are
+  independent flags.
 - **MP4.** `baguette record --background transparent` is rejected at
   argument-parse time rather than silently flattened, so you learn
   about it before the ten-second take rather than after.

--- a/docs/features/capture-size.md
+++ b/docs/features/capture-size.md
@@ -10,6 +10,30 @@ recordings in [`recording.md`](recording.md), and the 3D device
 render in [`3d-rendering.md`](3d-rendering.md). This doc is scoped to
 the size vocabulary itself.
 
+## Why
+
+Before this existed, every capture surface invented its own answer to
+"how big?". `baguette screenshot` had `--scale`, an integer divisor.
+`render-3d` had `--size WIDTHxHEIGHT`, literal pixels only. The
+browser's screenshot gallery saved whatever the canvas happened to be,
+and the recorder saved whatever the bezel viewport happened to be.
+None of them could say "App Store 6.9-inch", which is the size people
+actually need, and none of them agreed with each other.
+
+Three things fall out of having one vocabulary:
+
+- **A preset is a preset everywhere.** Pick `appstore-6.9` in the
+  toolbar, then reproduce the exact same pixels in CI with
+  `--size appstore-6.9`. No conversion table in the user's head.
+- **One geometry implementation, twice.** Swift and JS both derive the
+  canvas and the draw rect from the same rules, and the paired test
+  suites assert the same numbers, so a browser capture and a CLI
+  capture of the same frame land on the same bytes-worth of layout.
+- **Sizes compose with the other capture choices.** Fit, background,
+  and "with or without the device bezel" are the same three follow-up
+  questions whatever produced the frame, so they travel together as
+  one value rather than as four loose arguments per call site.
+
 ## The presets
 
 | spec | label | resolves to |
@@ -60,10 +84,28 @@ entirely — 1290 × 2796 is 1290 × 2796 whatever you point it at.
 | `cover` | scale to fill, let the overflow crop |
 | `stretch` | distort to fill exactly |
 
-`background` is `transparent` or `#RRGGBB` (default `#ffffff`). It
-only ever shows through under `contain`, so at `native` size the
-effective background is always `transparent` — a PNG of a transparent
-3D render doesn't silently gain a white mat.
+`background` is `transparent` (`none` is accepted too) or `#RRGGBB`
+with the `#` optional. It only ever shows through under `contain`, so
+at `native` size the effective background is always `transparent` — a
+PNG of a transparent 3D render doesn't silently gain a white mat.
+
+`#ffffff` is the default on every capture surface — the browser
+picker, the HTTP routes, `baguette screenshot`, `baguette record`. A
+capture with a letterbox is usually a finished artefact, and a
+marketing shot on a checkerboard is not what anyone meant.
+`baguette render-3d` is the one exception, defaulting to
+`transparent`: its whole point is a device you can drop onto your own
+background, and there is no screenshot behind it to protect.
+
+Two traps behind that, both from the same root — **most image and
+video formats carry no alpha**:
+
+- **JPEG.** A transparent letterbox in a `.jpg` flattens to *black*,
+  not to white. Pass a hex colour, or ask for PNG. Nothing warns you;
+  format and background are independent flags.
+- **MP4.** `baguette record --background transparent` is rejected at
+  argument-parse time rather than silently flattened, so you learn
+  about it before the ten-second take rather than after.
 
 ## Placement
 
@@ -71,12 +113,80 @@ Both implementations return the same placement value: the canvas
 size, plus where the source lands inside it.
 
 ```
-plan(source, fit) → { width, height, drawX, drawY, drawWidth, drawHeight }
+Swift   plan(source:fit:) → CapturePlacement
+                            { width, height, drawX, drawY,
+                              drawWidth, drawHeight }
+
+JS      plan(sourceW, sourceH, fit)
+                          → { width, height, drawX, drawY,
+                              drawW, drawH,
+                              sourceWidth, sourceHeight }
 ```
+
+Same numbers, two spellings — the abbreviated `drawW` / `drawH` are
+what canvas code reads, and the JS plan additionally carries the
+source box it was computed from so a painter can recover the scale
+without being handed the source size a second time (that is exactly
+what `CaptureComposer.compose` does). Don't "unify" the field names
+without changing both test suites; they assert the spellings.
 
 Under `cover` the draw origin goes **negative** — that overflow is
 the crop. `isIdentity(for:)` (Swift) reports the "nothing to do" case
-so callers can keep the original bytes instead of resampling.
+so callers can keep the original bytes instead of resampling: a
+native-size JPEG is passed through untouched rather than decoded,
+redrawn, and re-encoded at a slightly different quality.
+
+## Who speaks it
+
+| surface | how the size is said |
+|---|---|
+| `baguette screenshot` | `--size` / `--fit` / `--background` |
+| `baguette record` | `--size` / `--fit` / `--background` (hex only) |
+| `baguette render-3d` | `--size` / `--background` (`--fit` is a *different* axis — see below) |
+| `GET …/screenshot.{jpg,png}` | `?size=&fit=&background=` |
+| `GET …/screenshot-bezel.png` | `?size=&fit=&background=` |
+| `POST …/render-3d.png` | `"size"` / `"background"` in the body (`"fit"` is the mesh axis) |
+| `WS …/stream.3d.<fmt>` | `size=` (or explicit `width=&height=`) |
+| toolbar picker | `CaptureSizeMenu`, persisted per surface |
+| browser capture / record | `CaptureSettings` → `toQuery()` / `plan()` |
+
+`CaptureSettings.toQuery()` produces exactly the `?size=&fit=&background=`
+triple the routes take, and returns **nothing at all** for `native` —
+a native capture asks for no query parameters, so an old server and a
+new page still agree on the default case.
+
+**One name, two axes: `fit` on `render-3d`.** Everywhere else, fit
+says how a frame sits inside the output canvas. On the 3D render it
+says how the *screenshot* sits on the device's screen surface — a UV
+placement on the mesh. Hence its default is `cover` there and
+`contain` here: an app screenshot letterboxed inside a phone display
+would read as a bug. The three mode names mean the same thing in both
+places (fill and crop / fit and pad / distort); what they act on
+differs, so a UI must not forward its canvas fit into a 3D render
+request. See [`3d-rendering.md`](3d-rendering.md).
+
+## Filenames
+
+A saved capture is named for what it is, so a folder of marketing
+shots sorts and greps sensibly:
+
+```
+iPhone_17_Pro-2026-08-18T10-31-02-appstore-6.9-1290x2796.png
+iPhone_17_Pro-2026-08-18T10-31-02-1206x2622.mp4       ← native
+```
+
+`CaptureSettings.slug(width, height)` is the fragment: the resolved
+dimensions on their own at `native`, prefixed with the size spec
+otherwise. It sanitises anything outside `[A-Za-z0-9._-]` to a hyphen,
+so `16:9` lands as `16-9-4971x2796`.
+
+That colon is worth a sentence, because it looks harmless. A colon is
+perfectly legal in an HFS+ filename — the OS stores it — but the
+Finder *renders* it as a slash, so `16:9-4971x2796.png` appears in
+Downloads as `16/9-4971x2796.png` and reads like a path. Sanitising in
+`slug()`, the single place both screenshots and recordings name their
+files, is what keeps the two surfaces identical without each growing
+its own private swap.
 
 ## Where it lives
 
@@ -84,12 +194,21 @@ so callers can keep the original bytes instead of resampling.
 Sources/Baguette/
 ├── Domain/Capture/
 │   └── CaptureSize.swift            CaptureSize, CaptureFit, CapturePlacement
+├── Infrastructure/Screen/
+│   └── CaptureCanvas.swift          the CoreGraphics half — allocate, fill
+│                                    the background, draw at the planned rect
 └── Resources/Web/capture/
     ├── capture-size.js              window.Baguette._CaptureSize
     ├── capture-settings.js          window.Baguette._CaptureSettings
     ├── capture-composer.js          window.Baguette._CaptureComposer
     └── capture-size-menu.js         window.CaptureSizeMenu  (the picker)
 ```
+
+`CaptureCanvas` and `CaptureComposer` are the same job in two
+runtimes: take a `CapturePlacement`, allocate the target, fill the
+background, draw the source where the plan says. Neither one decides
+anything — all the decisions were made by `CaptureSize.plan`, which is
+why the decisions are the part that's unit-tested.
 
 `CaptureSettings` bundles the four things a user picks — size, fit,
 background, and whether to composite the device bezel — into one
@@ -102,6 +221,41 @@ bezel → clipped screen → overlay at natural size, and `compose` maps a
 source-coordinate paint into the target canvas with the background
 filled. Both `CaptureGallery` and `BrowserRecorder` had their own copy
 of that rounded-rect clip before this existed.
+
+## Hiding controls a surface can't honour
+
+`CaptureSizeMenu` takes three flags, all defaulting to shown:
+
+| flag | hidden when |
+|---|---|
+| `showFrameToggle` | the source already contains the device (the 3D stage) |
+| `showFitToggle` | canvas fit isn't the caller's to set — see the `fit` note above |
+| `showBackgroundToggle` | the render fills its own canvas, so a mat never shows |
+
+The 3D view hides all three. All three are read at **render** time
+rather than captured in the constructor, so a caller flips them on the
+instance when the view switches 2D ↔ 3D and reopens the popover — no
+rebuilding the menu, no losing the current selection.
+
+Offering a control a surface will ignore is worse than not offering
+it: a user who sets `fit: contain` for a 3D render and watches nothing
+change has learned something false about the feature.
+
+## Loading the browser half
+
+The four `capture/*.js` files are plain IIFEs like the rest of
+`Resources/Web/`, so any page that captures or records has to include
+them **before** the module that uses them:
+
+```html
+<script src="/capture/capture-size.js"></script>
+<script src="/capture/capture-settings.js"></script>
+<script src="/capture/capture-composer.js"></script>
+<script src="/capture/capture-size-menu.js"></script>
+```
+
+`recorder.js` and `capture-gallery.js` both depend on the first three
+and fail loudly — not silently at native size — when they're missing.
 
 ## Testing
 
@@ -123,3 +277,27 @@ integration-only — same bar as `sim-native.js` and `farm-focus.js`.
   produces a very wide canvas (4971 × 2796 from a 1290 × 2796 source).
   That is deliberate — use an explicit `WIDTHxHEIGHT` when you want a
   bounded output.
+- **The size is a canvas, not a resample budget.** A `contain` plan of
+  a fixed preset larger than the source upscales the source to fit;
+  nothing sharpens it. `appstore-6.9` off a 1206 × 2622 simulator is a
+  genuine 1290 × 2796 file made of interpolated pixels. Capture at the
+  device's native resolution if you need real detail.
+- **A video canvas is rounded up to even dimensions.** H.264 4:2:0
+  chroma subsampling requires it, so `baguette record` grows the
+  planned canvas by up to one pixel per axis and re-centres the frame.
+  A recording and a screenshot at the same preset can therefore differ
+  by a pixel; the recording is never stretched to hide it.
+- **A recording's size is locked when it starts.** `captureStream`
+  binds to the compose canvas' backing store, so the canvas can't be
+  resized mid-recording; if the live stream reconfigures its scale
+  part-way through, later frames are re-planned into the box that was
+  frozen at Record. Changing the picker takes effect on the next
+  recording, not the current one.
+- **The bezel toggle is only meaningful where a bezel exists.** It
+  composites DeviceKit chrome around the screen; on a surface whose
+  source is already a rendered device (the 3D stage) there is nothing
+  to wrap, and the toggle is suppressed rather than silently ignored.
+- **Presets are a snapshot of Apple's requirements.** `appstore-6.9`
+  and friends are the submission sizes as of writing. When Apple
+  changes them, the preset changes with them — pin an explicit
+  `WIDTHxHEIGHT` if you need a size that never moves.

--- a/docs/features/recording.md
+++ b/docs/features/recording.md
@@ -259,10 +259,12 @@ Recorded 152 frames · 5.03s · 2796×2796 → /tmp/r.mp4
   even width and height, so the planned canvas is rounded **up** and
   the frame re-centred inside it. It is never stretched to fit — a
   half-pixel of letterbox is cheaper than a distorted recording.
-- **`transparent` is rejected, not silently flattened.** MP4 has no
+- **`transparent` is rejected, not silently substituted.** MP4 has no
   alpha channel. `--background` takes `#RRGGBB` and nothing else, so
-  you find out at argument-parse time rather than by discovering a
-  black mat in the finished file.
+  you find out at argument-parse time rather than by discovering a mat
+  you didn't choose in the finished file. (The screenshot routes make
+  the opposite call and quietly mat white — a still is cheap to redo,
+  a ten-second take is not.)
 
 ### Pacing: an idle simulator records nothing
 

--- a/docs/features/recording.md
+++ b/docs/features/recording.md
@@ -1,11 +1,23 @@
 # Recording
 
-Browser-side capture of the live view (bezel + screen + pinch overlay)
-to a WebM/MP4 file. One button in the stream sidebar (and the device-
-farm focus pane) toggles it on; clicking again stops, the file shows
-up as a download link in the sidebar list.
+Video capture of a simulator, from two places that answer two
+different questions:
 
-The recording reuses what the live view already has on the page —
+- **In the browser** — capture of the live view exactly as you see it
+  (bezel + screen + pinch overlay) to a WebM/MP4 file. One button in
+  the stream sidebar, the native view's toolbar, and the device-farm
+  focus pane toggles it on; clicking again stops, and the file shows
+  up as a download link in the sidebar list.
+- **`baguette record`** — a headless CLI verb that writes H.264 video
+  (`.mp4` or `.mov`) of the raw framebuffer, for CI and scripted
+  capture where no browser is involved.
+
+Both take an output size from the shared vocabulary in
+[`capture-size.md`](capture-size.md), so `--size appstore-6.9` on the
+command line and "App Store 6.9″" in the toolbar picker mean the same
+pixels.
+
+The browser recorder reuses what the live view already has on the page —
 the bezel `<img>` the Baguette SDK loaded, the screen geometry from
 the SDK's `SimulatorDefinition.screen` (viewport / rect / clipRadius),
 the live decoded canvas StreamSession is painting, and PinchOverlay's
@@ -27,25 +39,45 @@ Two requests pushed for it:
   static screenshot strip.
 - **Demos / asset capture** — the same device-farm sessions used for
   reviews wanted a one-click "save the last minute" affordance.
+- **A specific output size** — an App Store preview clip and a
+  bug-report GIF are not the same file. Once screenshots grew a size
+  picker it made no sense for the recorder beside it to keep saving
+  "whatever the bezel viewport happened to be".
 
-The constraint was strict: don't disturb the live stream. The streaming
-pipeline already runs N hardware H.264 sessions in parallel under the
-device farm (one per booted simulator). Adding a server-side recorder
-spawned another VT compression session and pushed every device's
-frame-delivery off cadence — fixed by moving the whole recording
-client-side.
+For the browser recorder the constraint was strict: don't disturb the
+live stream. The streaming pipeline already runs N hardware H.264
+sessions in parallel under the device farm (one per booted simulator).
+Adding a server-side recorder spawned another VT compression session
+and pushed every device's frame-delivery off cadence — fixed by moving
+that recording client-side.
+
+`baguette record` came later and answers a different need: a build
+script that wants a video artefact has no page to click Record on, and
+no live stream to protect. The rest of this doc keeps the two apart
+carefully, because the reasoning that rules server-side encode *out*
+for one rules it *in* for the other.
 
 ## Surface
 
 ```
 GET /recorder.js                    — BrowserRecorder module
+GET /capture/capture-size.js        — the size vocabulary it plans with
+GET /capture/capture-settings.js    — the user's selection, as one value
+GET /capture/capture-composer.js    — the bezel/screen/overlay painter
+
+baguette record --udid <UDID> --output clip.mp4|clip.mov
+                [--size …] [--fit …] [--background '#ffffff']
+                [--fps 30] [--duration 10] [--bitrate 8000000]
 ```
 
-No new server endpoints. The bezel image and screen geometry the
-recorder uses are the same `/simulators/:udid/bezel.png` (the bare
-variant via `?buttons=false`) and `/simulators/:udid/definition.json`
-the SDK already fetches; the recorder doesn't refetch them — it
-reuses the references the SDK's `Bezel` part already holds.
+The browser recorder adds **no** server endpoints. The bezel image and
+screen geometry it uses are the same `/simulators/:udid/bezel.png`
+(the bare variant via `?buttons=false`) and
+`/simulators/:udid/definition.json` the SDK already fetches; the
+recorder doesn't refetch them — it reuses the references the SDK's
+`Bezel` part already holds. The `capture/*.js` trio must be loaded
+before `/recorder.js` is used; the recorder throws a clear error at
+`start()` rather than silently falling back to native size.
 
 ## Pipeline
 
@@ -57,14 +89,18 @@ Live view (DOM, untouched while idle)
    ── Record pressed ──────────────────────────────────────
    ↓
 BrowserRecorder.start()
-   1. allocate compose canvas at screen.viewport size
-   2. start rAF compose loop:
-        clearRect
-        drawImage(frameImg)                     ← bezel under
-        clip(roundRect screen.rect, clipRadius)
-          drawImage(sourceCanvas, screen.rect)  ← live frames
-          paintOverlayDots(overlayHost)         ← pinch dots
-   3. compose.captureStream(60) → MediaRecorder
+   1. natural size = CaptureComposer.compositeSize(frameImg, screen, canvas)
+        bezel on  → screen.viewport      bezel off → the source canvas
+   2. plan = settings.plan(natural.width, natural.height)
+      allocate compose canvas at plan.width × plan.height   ← TARGET size
+   3. start rAF compose loop:
+        CaptureComposer.compose(ctx, plan, background, (c) =>
+          CaptureComposer.paintComposite(c, {
+            frameImg,        ← bezel under
+            sourceCanvas,    ← live frames, clipped to the screen radius
+            onOverlay,       ← pinch dots, inside that clip
+          }))
+   4. compose.captureStream(fps) → MediaRecorder
 
    ── Stop pressed ───────────────────────────────────────
    ↓
@@ -73,11 +109,38 @@ BrowserRecorder.stop()
    2. cancel rAF loop, drop compose canvas
    3. blob = new Blob(chunks)
    4. return { url, blob, filename, mimeType, durationSeconds, bytes }
+        filename carries the size slug:
+          <device>-<stamp>-1206x2622.mp4               ← native
+          <device>-<stamp>-appstore-6.9-1290x2796.mp4
 ```
 
 When idle (no recording in flight) **nothing extra runs**. No paint
 loop, no compose canvas, no extra references held. The live view is
 exactly as it always was.
+
+## Output size
+
+The recorder plans against a `CaptureSettings` — the same value the
+toolbar's size chip edits and the screenshot gallery reads. See
+[`capture-size.md`](capture-size.md) for the preset table and the
+placement maths; the recorder-specific parts are:
+
+- **The compose canvas is allocated at the target size**, not at
+  natural size with a resize afterwards. `CaptureComposer.compose`
+  sets the transform so `paintComposite` keeps drawing in the source's
+  own coordinates, letterboxed into the target box.
+- **The size is locked at `start()`.** `captureStream` binds to the
+  compose canvas' backing store, so the canvas can never be resized
+  mid-recording — a MediaRecorder whose source canvas changes
+  dimensions produces a broken file. If the live stream reconfigures
+  its scale part-way through, later frames are re-planned against the
+  box that was frozen at Record and letterboxed into it. Changing the
+  picker takes effect on the *next* recording.
+- **The filename carries the slug**, so a folder of clips says what
+  each one is: `iPhone_17_Pro-<stamp>-appstore-6.9-1290x2796.mp4`.
+  `CaptureSettings.slug()` sanitises the spec, so a ratio lands as
+  `16-9-4971x2796` — a colon is legal in an HFS+ filename but the
+  Finder draws it as a slash.
 
 ## Why a compose canvas, not a DOM-element capture?
 
@@ -99,9 +162,12 @@ natively and GPU-accelerated. The dots are 4 lines of "read
 reduces to drawing each layer manually — which is what the compose
 loop does.
 
-## Why not server-side?
+## Why the browser records the live view
 
-Earlier server-side iterations didn't pan out:
+Earlier attempts to record **the live stream** server-side didn't pan
+out. This argument is about the live-stream and device-farm case, and
+it is still correct — see the next section for why `baguette record`
+is not the same situation.
 
 1. **`ffmpeg -c copy` tap into AVCC** — `H264Encoder` emits SPS/PPS
    only on the first IDR; a recorder attaching mid-stream never saw
@@ -117,6 +183,132 @@ Earlier server-side iterations didn't pan out:
 Browser-side sidesteps both: zero new server-side encode, the
 recording matches what the user sees post-bezel, post-overlay.
 
+## Why `baguette record` is a different question
+
+Both objections above are about **a recorder attaching to a stream
+that is already running for someone else**. Neither one holds for a
+standalone CLI invocation, and it's worth being precise about why,
+because the two answers otherwise look like the doc contradicting
+itself:
+
+| | recording the live stream | `baguette record` |
+|---|---|---|
+| SPS/PPS | encoder is already past its first IDR; a late attacher never sees the parameter sets | owns the encode from frame one, so it *emits* the first IDR |
+| VT sessions | adds an N+1th session to N already running for the farm | the only session; there is no live stream competing |
+| Pacing | must not disturb a viewer's cadence | nobody is watching; it sets its own fps |
+| Composition | should match what the user sees (bezel, overlays) | there is no view — the raw framebuffer is the truth |
+
+So the rejected design ("parallel `Screen` subscription +
+`AVAssetWriter`") is exactly the design `baguette record` uses. It was
+never wrong; it was wrong *as a passenger on a busy farm*. Run it on
+its own and it is the frame-perfect, format-agnostic path the earlier
+note called it.
+
+The practical rule that falls out: **don't run `baguette record`
+against a device whose stream a browser is also watching** if you care
+about that browser's smoothness. You'll get a good recording and a
+choppier live view, which is the N+1 problem back again — just now
+opted into deliberately rather than imposed on every farm tile.
+
+## `baguette record` — the CLI
+
+```bash
+baguette record --udid 5A1B… --output demo.mp4 --duration 10
+baguette record --udid 5A1B… --output hero.mp4 --size appstore-6.9
+baguette record --udid 5A1B… --output demo.mov --fps 60   # ^C to stop
+```
+
+It subscribes to the simulator's `Screen` — in parallel with nothing
+else — and feeds surfaces to `AVAssetWriter` as H.264 (High profile,
+a keyframe every 2 s).
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--udid` | — | The booted simulator to record |
+| `--output`, `-o` | — | **Required.** `.mp4` or `.mov` |
+| `--size` | `native` | Output size, from [`capture-size.md`](capture-size.md) |
+| `--fit` | `contain` | How the frame sits in that size |
+| `--background` | `#ffffff` | Letterbox colour — hex only |
+| `--fps` | `30` | 1–120 |
+| `--duration` | — | Stop after N seconds; omit to run until SIGINT |
+| `--bitrate` | `8000000` | Target bits per second |
+
+There is no `--format`: the container is the `--output` extension, and
+an unrecognised one is a validation error (`Unknown recording
+container 'webm'. Expected one of: mp4 | mov`) rather than a file that
+plays nowhere. There is no stdout path either — `AVAssetWriter` needs
+a seekable destination, and a video is not a thing you pipe.
+
+**Stopping.** `--duration` elapsing and SIGINT (`Ctrl-C`) do the same
+thing, whichever comes first: flush the writer and close the file. An
+interrupted recording is a playable file, not a truncated one. (`kill
+-9` is not, and can't be.) On success one line goes to **stderr**, so
+`--output` stays the only thing that touches your data:
+
+```
+Recorded 152 frames · 5.03s · 2796×2796 → /tmp/r.mp4
+```
+
+### Three things that differ from a screenshot
+
+- **The size resolves against the first frame.** The simulator's own
+  frame dimensions aren't known until SimulatorKit delivers one, so a
+  ratio preset can't be planned before recording starts. It resolves
+  once, on frame one, and holds for the take.
+- **Even dimensions, always.** H.264 4:2:0 chroma subsampling wants
+  even width and height, so the planned canvas is rounded **up** and
+  the frame re-centred inside it. It is never stretched to fit — a
+  half-pixel of letterbox is cheaper than a distorted recording.
+- **`transparent` is rejected, not silently flattened.** MP4 has no
+  alpha channel. `--background` takes `#RRGGBB` and nothing else, so
+  you find out at argument-parse time rather than by discovering a
+  black mat in the finished file.
+
+### Pacing: an idle simulator records nothing
+
+SimulatorKit fires the framebuffer callback **on a frame change**, not
+on a clock. `--fps` is therefore a ceiling enforced by *dropping*
+frames that arrive too close together — never by duplicating the last
+one to fill a gap. A simulator sitting on a static screen delivers no
+frames at all, so a quiet stretch mid-recording costs nothing: the
+last committed frame simply stays on screen for as long as the picture
+didn't change.
+
+The sharp edge is the degenerate case. A device nobody drives at all
+delivers *zero* frames, and there is no such thing as a video of no
+frames — so the command exits non-zero with
+
+```
+No frames captured — the simulator screen never changed.
+Drive some input while recording.
+```
+
+rather than writing ten seconds of a still image. This is the same
+quiescence that makes `screenshot` need a 2-second timeout; here it
+surfaces as an error you can act on instead of a hang.
+
+### Where it lives
+
+```
+Sources/Baguette/
+├── Domain/Recording/          RecordingPlan / FrameCadence /
+│                              RecordingFormat / RecordingError /
+│                              RecordingSummary / ScreenRecorder
+│                              + the @Mockable `Reel` collaborator
+└── Infrastructure/Recording/  AVAssetWriterReel.swift
+```
+
+The usual split: `ScreenRecorder` owns the conversational lifecycle
+(start / accept frame / pace / finish) against `any Reel` and is
+driven by `MockReel` in `Tests/BaguetteTests/Recording/`; only the
+`AVAssetWriter` calls are integration-only. `Reel` is named for what
+it is — the thing frames are committed to — not for the pattern it
+implements.
+
+Nothing about this is wired into `baguette serve`: no route, no WS
+verb. Server-side encode happens here and only here, for the reason
+in the previous section.
+
 ## BrowserRecorder
 
 ```js
@@ -125,6 +317,8 @@ const rec = new BrowserRecorder({
   frameImg,      // sim._bezel.frameImg — already loaded
   screen,        // sim.screen.def — SDK SimulatorDefinition.screen
   overlayHost,   // sim.pinchOverlayContainer — already in DOM
+  settings,      // CaptureSettings — size + fit + background + bezel
+  bezel: true,   // false → the source canvas already IS the device
   fps: 60,
 });
 rec.start();
@@ -137,6 +331,15 @@ Constructor takes references; nothing is fetched. `start()` allocates
 the compose canvas, kicks off the paint loop, and spins up
 `MediaRecorder` over `compose.captureStream(fps)`. `stop()` awaits the
 final chunk, releases the compose canvas, and returns the artifact.
+
+`settings` is the preferred way to say what you want. Loose
+`captureSize` / `fit` / `background` options are read only when
+`settings` is absent, so the older call sites kept working while the
+picker was rolled out surface by surface. `bezel` defaults to
+`settings.withFrame` — the picker's "Include bezel" checkbox and the
+recorder agree without the caller wiring them together — and an
+explicit `bezel` wins over both. Pass nothing but `canvas` and you get
+the historical behaviour: native size, bezel on.
 
 ### MIME type probing
 
@@ -154,26 +357,39 @@ through to `''` lets the browser pick its own default.
 
 ### Per-frame paint
 
+The layering lives in `CaptureComposer`, not here:
+
 ```js
-ctx.clearRect(0, 0, cw, ch);
-if (useBezel) {
-  ctx.drawImage(frameImg, 0, 0, cw, ch);          // bezel under
-  ctx.save();
-  roundRectPath(ctx, s.x, s.y, s.width, s.height, r);
-  ctx.clip();
-  ctx.drawImage(sourceCanvas, s.x, s.y, s.width, s.height);
-  paintOverlayDots(ctx, s);                        // dots inside clip
-  ctx.restore();
-} else {
-  ctx.drawImage(sourceCanvas, 0, 0, cw, ch);
-  paintOverlayDots(ctx, { x: 0, y: 0, width: cw, height: ch });
-}
+CaptureComposer.compose(ctx, plan, background, (c) => {
+  CaptureComposer.paintComposite(c, {
+    frameImg, screen, sourceCanvas,
+    onOverlay: (c2, rect) => paintOverlayDots(c2, rect),
+  });
+});
 ```
+
+`compose` clears, fills the background, and sets the transform;
+`paintComposite` draws bezel → clipped screen → overlay. With no
+bezel (or no chrome layout available) `paintComposite` degrades to
+drawing the source canvas at the full rect, overlay included.
+
+The degradation is per-layer, not all-or-nothing: a bezel that has
+decoded still paints when the source canvas hasn't produced a frame
+yet, and only the screen layer and its overlay are skipped. Pressing
+Record in the first moments of a stream therefore opens on the device
+chrome with a dark screen — which is what the live view shows too —
+rather than on an empty canvas.
 
 DeviceKit composite PDFs have an opaque dark "off-glass" tint in the
 screen rect (designed to sit UNDER live content). Bezel goes first;
 screen on top — same z-order the live DOM uses (`screenArea` z-index
 2, frameImg z-index 1).
+
+That painter is shared, and that was the point of extracting it:
+`CaptureGallery` and `BrowserRecorder` each carried their own copy of
+this z-order and their own hand-rolled rounded-rect path. Two copies
+of a clip path is two chances for a screenshot and a recording of the
+same device to disagree about where the screen ends.
 
 ### Pinch overlay copy
 
@@ -212,6 +428,23 @@ the browser's VT/VPx encoder uses (typically hardware). The live
 view stays untouched — DOM bezel, DOM PinchOverlay, current paint
 cadence.
 
+## Recording the 3D stage
+
+The 3D viewport (see [`3d-rendering.md`](3d-rendering.md)) paints a
+canvas like every other stream — `Sim3DPanel` shares `StreamSession`
+with the 2D path — so recording it needs no new machinery. It needs
+one thing turned **off**: the frames already contain a photorealistic
+device, so wrapping them in a DeviceKit bezel would draw a phone
+around a phone.
+
+That's the `bezel: false` case — equivalently, handing the recorder no
+`frameImg` and no `screen`, since a composite with no chrome to draw
+degrades to the same thing. With it, the natural size is the source
+canvas rather than the bezel viewport, `paintComposite` skips the
+bezel and the screen clip entirely, and the size vocabulary applies
+unchanged: `square` on a 1200 × 1200 3D canvas is still a square, it
+is just a square with a rendered iPhone in it.
+
 ## Lifecycle on the page
 
 ### `sim-stream.js`
@@ -231,6 +464,28 @@ the artifact onto `entries`. `stopStream` cancels any in-flight
 recording and revokes Blob URLs to keep long sessions from leaking
 memory.
 
+The sidebar's Capture and Record controls share one size picker
+between them — the selection is a property of "what I want out of this
+device", not of which button produced it, so a screenshot and a clip
+taken a second apart come out at the same dimensions.
+
+### `sim-native.js`
+
+The native (focus-mode) view had no Record button at all until the
+size vocabulary landed; screenshots were its only capture. It now
+carries both, side by side in the toolbar: a size chip mounted by
+`CaptureSizeMenu` (persisted under its own storage key, so the native
+view and the legacy sidebar remember separate selections) and a
+Record button that shows an elapsed `mm:ss` readout while running.
+Finished clips collect in a dock whose rows are download links; closing
+it revokes the Blob URLs.
+
+The button is hidden outright when `MediaRecorder` is unavailable
+rather than rendered and failing on click. An in-flight recording is
+cancelled on the transitions that invalidate its source canvas —
+flipping 2D↔3D, a stream restart (a codec swap reallocates the
+canvas), and page unload.
+
 ### `farm-focus.js`
 
 The focus pane gets a recorder context closure from FarmApp:
@@ -249,7 +504,9 @@ this.focus.show(device, tile, {
 
 Re-evaluated on each Record press so a re-focus mid-session can't
 strand the recorder on a stale tile. The focus pane owns its own
-`recording` state slot.
+`recording` state slot, and its own size picker — the farm's focus
+pane is where marketing captures actually get taken, so it gets the
+same chip as the single-device views rather than inheriting a global.
 
 ## Frontend module layout
 
@@ -259,6 +516,11 @@ Resources/Web/
 ├── stream-session.js     decode + paint loop (unchanged)
 ├── frame-decoder.js      MJPEG / AVCC decoders (unchanged)
 ├── capture-gallery.js    one-shot screenshot composite (SDK shape)
+├── capture/              the shared size vocabulary
+│   ├── capture-size.js       presets + placement maths
+│   ├── capture-settings.js   the user's selection, persisted
+│   ├── capture-composer.js   bezel/screen/overlay painter
+│   └── capture-size-menu.js  the toolbar picker
 ├── baguette/             Baguette SDK
 │   ├── parts/bezel.js    bezel chrome for the live view
 │   ├── parts/screen.js   screen + PointerInterpreter + PinchOverlay
@@ -270,9 +532,11 @@ Resources/Web/
     └── …
 ```
 
-`recorder.js` is loaded by both `sim.html` and `farm/farm.html` via
-`<script src="/recorder.js">` — same pattern as the other shared
-modules.
+`recorder.js` is loaded by `sim.html`, `sim-native.html`, and
+`farm/farm.html` via `<script src="/recorder.js">` — same pattern as
+the other shared modules. Each of those pages loads the `capture/`
+trio first; `recorder.js` needs `CaptureSize`, `CaptureSettings`, and
+`CaptureComposer` on `window.Baguette` before `start()`.
 
 ## Browser support
 
@@ -285,14 +549,20 @@ modules.
 
 ## Testing approach
 
-The recorder is a small JS module wired into two orchestrators
-(`sim-stream.js`, `farm-focus.js`). It's exercised manually via the
-live UI today; a future iteration could add a thin offscreen-canvas
-test (`puppeteer + headless captureStream` works) — not yet in the
-repo.
+The recorder itself is a small JS module wired into three
+orchestrators (`sim-stream.js`, `sim-native.js`, `farm-focus.js`) and
+is exercised manually via the live UI; a future iteration could add a
+thin offscreen-canvas test (`puppeteer + headless captureStream`
+works) — not yet in the repo. What *is* unit-tested is everything it
+delegates to: `Tests/Web/capture-size.test.js`,
+`capture-settings.test.js`, and `capture-composer.test.js` cover the
+placement maths, the persisted selection, and the paint geometry, so
+"the recording came out the wrong size" is a covered failure even
+though "the recording came out" isn't.
 
-There are no Swift Testing suites for recording: the server isn't
-involved.
+`baguette record` splits the same way the other Infrastructure
+adapters do: the frame pacing and size planning are unit-covered,
+and the irreducible `AVAssetWriter` calls stay integration-only.
 
 ## Known limits
 
@@ -303,20 +573,38 @@ involved.
   PinchOverlay today, so single taps don't show in the recording.
   Extending PinchOverlay to render a brief auto-fading dot for taps
   is a small follow-up; the recorder picks them up automatically.
-- **Long recordings live in RAM.** The Blob accumulates `chunks` until
-  Stop. Multi-minute recordings at 1080p are fine; multi-hour ones
-  are not.
+- **Long recordings live in RAM** *(browser only)*. The Blob
+  accumulates `chunks` until Stop. Multi-minute recordings at 1080p
+  are fine; multi-hour ones are not. `baguette record` writes through
+  `AVAssetWriter` to the output path as it goes and has no such
+  ceiling.
+- **The size is fixed for the whole clip.** Both recorders decide the
+  output box when they start and letterbox every later frame into it.
+  Rotating the device mid-recording therefore letterboxes rather than
+  resizing the file — which is the right answer for a video container,
+  but it does mean a portrait→landscape clip is framed for whichever
+  came first.
+- **`baguette record` records the framebuffer, not the view.** No
+  bezel, no pinch overlay, no cursor — those are browser-side layers.
+  If you want the composite, record in the browser.
+- **Running both at once costs the live view.** A CLI recording of a
+  device a browser is streaming reintroduces the N+1 VideoToolbox
+  problem for that device. It works; the live view gets choppier.
 
 ## Extension points
 
 - **More overlays.** The compose loop is one function per layer;
   adding a frame counter, a watermark, or a region highlight is one
   `ctx.draw…` call away.
-- **Bezel toggle on the recorder.** Today the recorder uses bezel
-  whenever `frameImg` and a chrome layout are passed. A "record
-  without bezel" toggle is a one-line condition in
-  `BrowserRecorder._paint`.
-- **CLI-issued record trigger.** The browser is the recorder, but a
-  WS verb the page listens for (`{type:"record"}` → click the button)
-  would let `baguette serve` start recordings remotely without user
-  interaction.
+- **Audio.** The one genuinely missing track.
+- **Bezel on the CLI path.** `baguette record` could composite the
+  DeviceKit chrome server-side the way `screenshot-bezel.png` does —
+  the artwork and the layout are already available to the process; it
+  is a per-frame draw the recorder currently doesn't do.
+- **Remote record trigger.** The browser recorder is still only
+  startable by a human clicking Record. A WS verb the page listens
+  for (`{type:"record"}` → click the button) would let a script drive
+  a *composited* recording, which `baguette record` deliberately
+  doesn't produce.
+- **Frame-accurate trimming.** Both paths give you the whole take;
+  neither trims. `--duration` is a stop condition, not an edit.

--- a/docs/features/screenshot.md
+++ b/docs/features/screenshot.md
@@ -115,17 +115,19 @@ native | appstore-6.9 | appstore-6.5 | appstore-ipad-13 | square |
 
 ### Picking the format
 
-`--format` takes `png` or `jpg` (`jpeg` is accepted as an alias). It
-is **inferred from `--output` when you don't say**: an output path
-ending in `.png` writes PNG, everything else — including stdout —
-writes JPEG. An explicit `--format` always wins. This exists so
+`--format` takes `png` or `jpg`. It is **inferred from `--output` when
+you don't say**: an output path ending in `.png` writes PNG,
+everything else — including stdout — writes JPEG. An explicit `--format` always wins. This exists so
 `-o hero.png` can't quietly produce a file full of JPEG bytes under a
 `.png` name, which is the kind of thing that surfaces three tools
 later as "your PNG is corrupt".
 
-Over HTTP the extension *is* the format: `screenshot.jpg` and
-`screenshot.png` are two routes, not one route with a parameter, so
-an `<img src>` and a `curl -O` both get the right thing for free.
+`jpeg` is accepted as a CLI alias for `jpg`. Over HTTP there is no
+such latitude: the extension *is* the format, and `screenshot.jpg` /
+`screenshot.png` are two literal routes rather than one route with a
+parameter — so an `<img src>` and a `curl -O` both get the right thing
+for free, and `screenshot.jpeg` is a 404 rather than a third spelling
+to keep alive.
 
 ## Pipeline
 
@@ -252,9 +254,12 @@ finished artefact and a marketing shot on a checkerboard is not what
 anyone meant. `transparent` is one word away when you want to
 composite it yourself.
 
-Then mind the format: **JPEG has no alpha channel**, so
-`--background transparent --format jpg` composites the letterbox onto
-**black**, not white. Ask for PNG whenever you ask for transparency.
+Then mind the format: **JPEG has no alpha channel**, so a `.jpg` can't
+honour `transparent` at all. It mats **white** instead — an unmatted
+transparent canvas flattens to black on encode, and a black border
+around a marketing shot is not what "transparent" was asking for.
+`.png` honours it properly, so ask for PNG whenever you ask for
+transparency.
 
 ## The bezel route
 
@@ -276,8 +281,8 @@ a distorted screenshot inside a correct bezel looks broken in a way a
 1-pixel crop does not.
 
 It is PNG-only, and that is not an oversight: the device body has
-transparent corners, and a JPEG of it would be a phone on a black
-rectangle. `?size=` / `?fit=` / `?background=` then apply to the
+rounded, transparent corners, and JPEG has nowhere to put them —
+every composite would arrive already flattened onto a rectangle. `?size=` / `?fit=` / `?background=` then apply to the
 composited image, so `?size=square&background=ffffff` gives you the
 bezelled device centred on a white square — which is the actual
 marketing shot, in one GET, without a browser.
@@ -402,14 +407,14 @@ integration-only.
   unchanged frame is not guaranteed byte-identical. Removing the round
   trip means teaching the capture helper to hand back a `CGImage`
   rather than `Data`; it hasn't landed.
-- **`transparent` is a PNG-only answer.** JPEG has no alpha; a
-  transparent background composites onto black there. Nothing warns
-  you — the flags are independent.
+- **`transparent` is a PNG-only answer.** JPEG has no alpha, so a
+  `.jpg` quietly mats white instead of honouring it. Nothing warns
+  you — format and background are independent flags.
 - **No bezel on the JPEG routes, and no bezel on the CLI.**
   `screenshot-bezel` is PNG only — DeviceKit chrome has rounded
-  corners and therefore alpha, and a JPEG of it would be a phone on a
-  black rectangle. And there is no `--bezel` flag: the composite is an
-  HTTP route, so a shell script wanting one reaches for `curl`.
+  corners and therefore alpha, which JPEG cannot carry. And there is
+  no `--bezel` flag: the composite is an HTTP route, so a shell script
+  wanting one reaches for `curl`.
 - **Bezel composite needs chrome for the device.** Devices with no
   DeviceKit artwork can't be composited; the route 404s rather than
   falling back to a plain rectangle.

--- a/docs/features/screenshot.md
+++ b/docs/features/screenshot.md
@@ -5,7 +5,8 @@ whatever size you asked for. Entry points that share one capture path:
 
 - `GET /simulators/:udid/screenshot.jpg` — served by `baguette serve`,
   returns `image/jpeg` bytes.
-- `GET /simulators/:udid/screenshot.png` — the same frame, lossless.
+- `GET /simulators/:udid/screenshot.png` — the same frame, in a
+  lossless container.
 - `GET /simulators/:udid/screenshot-bezel.png` — the frame composited
   inside the device's DeviceKit bezel.
 - `baguette screenshot --udid <UDID>` — CLI; writes to `--output` or
@@ -43,7 +44,8 @@ Three later requests reshaped it:
 - **A lossless container.** JPEG is the right default for a dashboard
   thumbnail and the wrong one for anything that gets composited,
   annotated, or re-saved: every round trip through it adds another
-  layer of 8×8 block artefacts. PNG stops the bleeding.
+  layer of 8×8 block artefacts. PNG stops the *further* bleeding — see
+  the known limit about the one JPEG hop still in the capture path.
 - **A size that means something.** `--scale 2` answers "half of
   whatever the device is", which nobody's App Store submission asks
   for. `--size appstore-6.9` answers the question people actually
@@ -202,7 +204,7 @@ producing, not of the stream you're watching.
 | Knob        | CLI flag       | URL param      | Default    | What it changes |
 |-------------|----------------|----------------|------------|-----------------|
 | Format      | `--format`     | the route path | inferred from `--output`, else `jpg` | `png` is lossless; over HTTP the extension *is* the format |
-| Quality     | `--quality`    | `?quality=`    | `0.85`     | JPEG lossy compression (0.0 – 1.0) — see below for PNG |
+| Quality     | `--quality`    | `?quality=`    | `0.85` on `.jpg`, `1.0` on the PNG routes | JPEG lossy compression (0.0 – 1.0) — see below for PNG |
 | Scale       | `--scale`      | `?scale=`      | `1`        | Integer downscale divisor (1 = native, 2 = half, …) |
 | Size        | `--size`       | `?size=`       | `native`   | Output canvas — a preset, `WIDTHxHEIGHT`, or `W:H` |
 | Fit         | `--fit`        | `?fit=`        | `contain`  | `contain` letterboxes, `cover` crops, `stretch` distorts |
@@ -214,11 +216,15 @@ Both `quality` and `scale` are clamped to sane minima — `scale` is
 floored at `1`, `quality` is whatever `kCGImageDestinationLossyCompressionQuality`
 clamps it to (effectively `[0, 1]`).
 
-`--quality` has no effect on a PNG from the CLI — PNG is lossless, so
-there is nothing to trade. The HTTP PNG routes still accept
-`?quality=`, where it governs the intermediate capture rather than the
-delivered file; pass `quality=1` if you are diffing PNGs and want to
-be sure nothing lossy happened upstream of the encoder.
+`--quality` has no effect on a PNG from the CLI. The HTTP PNG routes
+do still accept `?quality=`, but it governs the **JPEG intermediate**
+the capture pipeline produces, not the delivered PNG: `ScreenSnapshot`
+encodes JPEG unconditionally, and the PNG routes decode that back to a
+`CGImage` before re-encoding. It defaults to `1.0` there (against
+`0.85` on `screenshot.jpg`), so a PNG is near-lossless out of the box
+— but not bit-exact. Lowering `?quality=` on a `.png` request degrades
+the image *inside* a lossless container, which is the sort of thing
+worth knowing before you do it by accident.
 
 The preset table lives in [`capture-size.md`](capture-size.md) and is
 not duplicated here — there is one catalogue, and this is one of its
@@ -275,6 +281,16 @@ rectangle. `?size=` / `?fit=` / `?background=` then apply to the
 composited image, so `?size=square&background=ffffff` gives you the
 bezelled device centred on a white square — which is the actual
 marketing shot, in one GET, without a browser.
+
+**The composite is sized off the framebuffer, not off the chrome.**
+DeviceKit geometry is in 1× points; the captured frame is in device
+pixels. Sizing the canvas from the chrome would throw away most of the
+capture, so it goes the other way — the canvas takes the capture's
+resolution and the chrome is resampled up to meet it. An iPhone 17 Pro
+Max asked for `screenshot-bezel.png` with no parameters comes back at
+1483 × 2984, not the chrome's ~494 × 995. It never drops below 1×
+either, so a heavy `?scale=` shrinks the screen content but not the
+bezel around it.
 
 A device with no DeviceKit artwork gets a `404`, not an invented grey
 rectangle. See [`chrome-bezel.md`](chrome-bezel.md) for which devices
@@ -379,6 +395,13 @@ integration-only.
   on a portrait device produces a very wide image. Use an explicit
   `WIDTHxHEIGHT` when you want a bounded output, or `--fit cover` when
   you genuinely do want the crop.
+- **PNG is not bit-exact.** `ScreenSnapshot` encodes JPEG
+  unconditionally, so the PNG routes decode that intermediate and
+  re-encode it losslessly. At the default `?quality=1.0` the loss is
+  negligible, but a golden-image diff of two captures of the *same*
+  unchanged frame is not guaranteed byte-identical. Removing the round
+  trip means teaching the capture helper to hand back a `CGImage`
+  rather than `Data`; it hasn't landed.
 - **`transparent` is a PNG-only answer.** JPEG has no alpha; a
   transparent background composites onto black there. Nothing warns
   you — the flags are independent.
@@ -415,6 +438,10 @@ integration-only.
   same composite the route does; the reason it doesn't exist yet is
   that the chrome rasterization currently lives on the server side of
   the split, not that it's hard.
+- **A JPEG-free PNG path.** `ScreenSnapshot` returns encoded `Data`,
+  which forces the JPEG hop above. Returning a `CGImage` and letting
+  each caller choose its encoder would make `screenshot.png` genuinely
+  bit-exact and would save the bezel route a decode as well.
 - **WebP / AVIF.** The `CGImageDestination` switch is a one-line
   format string; smaller payloads at the same visual quality matter
   for thumbnail-heavy pages like `/farm`.

--- a/docs/features/screenshot.md
+++ b/docs/features/screenshot.md
@@ -1,12 +1,20 @@
 # Screenshot
 
-One-shot JPEG of the simulator's framebuffer. Two entry points share
-the same capture path:
+One-shot image of the simulator's framebuffer, in JPEG or PNG, at
+whatever size you asked for. Entry points that share one capture path:
 
 - `GET /simulators/:udid/screenshot.jpg` — served by `baguette serve`,
   returns `image/jpeg` bytes.
+- `GET /simulators/:udid/screenshot.png` — the same frame, lossless.
+- `GET /simulators/:udid/screenshot-bezel.png` — the frame composited
+  inside the device's DeviceKit bezel.
 - `baguette screenshot --udid <UDID>` — CLI; writes to `--output` or
   stdout.
+
+Every one of them takes an output size from the shared vocabulary in
+[`capture-size.md`](capture-size.md) — `--size appstore-6.9` on the
+CLI, `?size=appstore-6.9` on the routes, the toolbar picker in the
+browser, all the same pixels.
 
 If you want the live recording-and-overlays story instead, read
 [`recording.md`](recording.md). This doc is scoped to single-frame
@@ -30,19 +38,49 @@ plain HTTP fetch:
 The endpoint name and content-type match what every browser already
 expects from an `<img>` tag — no new client code path on the page.
 
+Three later requests reshaped it:
+
+- **A lossless container.** JPEG is the right default for a dashboard
+  thumbnail and the wrong one for anything that gets composited,
+  annotated, or re-saved: every round trip through it adds another
+  layer of 8×8 block artefacts. PNG stops the bleeding.
+- **A size that means something.** `--scale 2` answers "half of
+  whatever the device is", which nobody's App Store submission asks
+  for. `--size appstore-6.9` answers the question people actually
+  have.
+- **The bezel, without a browser.** The device-farm wall composites
+  DeviceKit chrome around each tile, and that composite is what people
+  want to paste into a PR. Getting it used to mean opening a page,
+  taking a screenshot, and cropping it.
+
 ## Surface
 
 ```
-GET /simulators/:udid/screenshot.jpg[?quality=0.85][?scale=1]
-                                                    │
-                                                    ▼
-   200 image/jpeg                                ScreenSnapshot.capture
+GET /simulators/:udid/screenshot.jpg         ─┐
+GET /simulators/:udid/screenshot.png          ├─ ?quality= &scale= &size=
+GET /simulators/:udid/screenshot-bezel.png   ─┘   &fit= &background=
+                        (…and ?buttons=)          │
+                                                  ▼
+   200 image/jpeg | image/png                  ScreenSnapshot.capture
+   400 application/json   {"ok":false,"error":"Unknown size '…'. …"}
    404 application/json   {"ok":false,"error":"unknown udid: <udid>"}
+   404 application/json   {"ok":false,"error":"no bezel for udid <udid>"}
    500 application/json   {"ok":false,"error":"<details>"}
 ```
 
+All three routes take the same five parameters. `?buttons=` is the
+bezel route's own — it matches `bezel.png`'s existing meaning, `false`
+giving the bare device body without the button overshoot.
+
+**`GET screenshot.jpg` with no new parameters returns exactly what it
+returned before.** The size plan comes back as identity, nothing is
+redrawn, and the bytes are not re-encoded. Every dashboard already
+pointing an `<img>` at that URL is unaffected.
+
 ```
-baguette screenshot --udid <UDID> [--output <path>] [--quality 0.85] [--scale 1]
+baguette screenshot --udid <UDID> [--output <path>] [--format png|jpg]
+                    [--quality 0.85] [--scale 1]
+                    [--size native] [--fit contain] [--background '#ffffff']
 ```
 
 `--output` defaults to stdout, so it composes with redirection:
@@ -51,7 +89,41 @@ baguette screenshot --udid <UDID> [--output <path>] [--quality 0.85] [--scale 1]
 baguette screenshot --udid 5A1B… > shot.jpg
 baguette screenshot --udid 5A1B… --output /tmp/shot.jpg
 baguette screenshot --udid 5A1B… --quality 0.6 --scale 2 > thumb.jpg
+
+# a submission-sized asset, letterboxed on white (the default)
+baguette screenshot --udid 5A1B… --size appstore-6.9 --output hero.png
+
+# the same, with no mat at all — PNG, because JPEG has no alpha
+baguette screenshot --udid 5A1B… --size appstore-6.9 \
+                    --background transparent --output hero-alpha.png
+
+# a square social crop — cover fills the canvas and lets the edges go
+baguette screenshot --udid 5A1B… --size square --fit cover -o square.jpg
 ```
+
+An unknown `--size` / `?size=` is an error, never a near-miss
+substitution — the whole point of naming a submission size is that it
+is exact. The message names the whole catalogue:
+
+```
+Unknown size 'appstore6.9'. Expected WIDTHxHEIGHT, W:H, or one of:
+native | appstore-6.9 | appstore-6.5 | appstore-ipad-13 | square |
+16:9 | 9:16 | 4:3 | 4:5
+```
+
+### Picking the format
+
+`--format` takes `png` or `jpg` (`jpeg` is accepted as an alias). It
+is **inferred from `--output` when you don't say**: an output path
+ending in `.png` writes PNG, everything else — including stdout —
+writes JPEG. An explicit `--format` always wins. This exists so
+`-o hero.png` can't quietly produce a file full of JPEG bytes under a
+`.png` name, which is the kind of thing that surfaces three tools
+later as "your PNG is corrupt".
+
+Over HTTP the extension *is* the format: `screenshot.jpg` and
+`screenshot.png` are two routes, not one route with a parameter, so
+an `<img src>` and a `curl -O` both get the right thing for free.
 
 ## Pipeline
 
@@ -64,8 +136,13 @@ ScreenSnapshot.capture(screen, quality, scale, timeout)
                                       start() throws → propagate error
    3. if scale ≥ 2: Scaler.downscale → CVPixelBuffer
       else:         use IOSurface zero-copy
-   4. JPEGEncoder.encode → Data
-   5. defer { screen.stop() }
+   4. size ≠ native → CaptureCanvas
+        placement = size.plan(source, fit)
+        if placement.isIdentity(for: source) → skip, keep the bytes
+        else CoreGraphics: fill background, draw at the plan's rect
+   5. bezel route → composite DeviceKit chrome around it first
+   6. JPEGEncoder / PNGEncoder → Data
+   7. defer { screen.stop() }
 ```
 
 The `SnapshotSession` actor-of-sorts (`@unchecked Sendable` holder)
@@ -74,9 +151,28 @@ producers race for the flag — the timeout timer, the frame callback,
 and the `screen.start()` throw path — and only the first wins, so the
 continuation can never resume twice.
 
-The same helper drives both the HTTP route and the CLI; quality / scale
-defaults match between them (`0.85`, `1`) so tooling that calls one
-sees the same bytes as tooling that calls the other.
+The same helper drives both the HTTP routes and the CLI; quality /
+scale / size / fit / background defaults match between them so tooling
+that calls one sees the same bytes as tooling that calls the other.
+
+`CaptureCanvas` is the CoreGraphics half of the size vocabulary: given
+a `CapturePlacement` from `CaptureSize.plan`, it allocates the target
+bitmap, fills the background, and draws the source at the planned
+rect. Under `cover` the planned origin is negative, so the draw simply
+overflows the context and the overflow is the crop — no separate crop
+path. `contain` letterboxes onto the background colour, `stretch`
+draws to the full canvas.
+
+The identity check earns its keep: at `--size native` (the default)
+the placement is a no-op, `CaptureCanvas` is skipped entirely, and the
+encoded bytes are exactly what they were before any of this existed.
+A frame is never decoded and re-encoded just to be told it was already
+the right size.
+
+`--scale` and `--size` compose in that order: scale reduces what came
+off the framebuffer, then the size vocabulary resolves against the
+*scaled* frame. `--scale 2 --size square` squares up the half-size
+frame; it does not square up the device and then halve it.
 
 ## Why a separate path, not "stream + read one frame"?
 
@@ -92,23 +188,120 @@ Three reasons:
    SimulatorKit hands over.
 3. **No live-stream interference.** A snapshot grabbed via the WS
    `snapshot` verb shares the live encoder pacing (`StreamConfig.fps`,
-   `scale`). The HTTP screenshot ignores both — `?scale=` and
-   `?quality=` only affect the returned JPEG, never the live stream.
+   `scale`). The HTTP screenshot ignores both — `?scale=`, `?quality=`,
+   and `?size=` only affect the returned image, never the live stream.
 
 `?quality` and `?scale` mirror the WS knobs deliberately so callers
-can pick the same trade-off they're used to from the streaming path.
+can pick the same trade-off they're used to from the streaming path;
+`?size` / `?fit` / `?background` mirror the CLI flags and the browser
+picker instead, because a size is a property of the artefact you're
+producing, not of the stream you're watching.
 
 ## Tunables
 
-| Knob        | CLI flag       | URL param   | Default | What it changes |
-|-------------|----------------|-------------|---------|-----------------|
-| Quality     | `--quality`    | `?quality=` | `0.85`  | JPEG lossy compression (0.0 – 1.0) |
-| Scale       | `--scale`      | `?scale=`   | `1`     | Integer downscale divisor (1 = native, 2 = half, …) |
-| Output path | `--output, -o` | —           | stdout  | CLI only |
+| Knob        | CLI flag       | URL param      | Default    | What it changes |
+|-------------|----------------|----------------|------------|-----------------|
+| Format      | `--format`     | the route path | inferred from `--output`, else `jpg` | `png` is lossless; over HTTP the extension *is* the format |
+| Quality     | `--quality`    | `?quality=`    | `0.85`     | JPEG lossy compression (0.0 – 1.0) — see below for PNG |
+| Scale       | `--scale`      | `?scale=`      | `1`        | Integer downscale divisor (1 = native, 2 = half, …) |
+| Size        | `--size`       | `?size=`       | `native`   | Output canvas — a preset, `WIDTHxHEIGHT`, or `W:H` |
+| Fit         | `--fit`        | `?fit=`        | `contain`  | `contain` letterboxes, `cover` crops, `stretch` distorts |
+| Background  | `--background` | `?background=` | `#ffffff`  | Letterbox colour, or `transparent` |
+| Buttons     | —              | `?buttons=`    | `true`     | Bezel route only: `false` drops the button overshoot |
+| Output path | `--output, -o` | —              | stdout     | CLI only |
 
 Both `quality` and `scale` are clamped to sane minima — `scale` is
 floored at `1`, `quality` is whatever `kCGImageDestinationLossyCompressionQuality`
 clamps it to (effectively `[0, 1]`).
+
+`--quality` has no effect on a PNG from the CLI — PNG is lossless, so
+there is nothing to trade. The HTTP PNG routes still accept
+`?quality=`, where it governs the intermediate capture rather than the
+delivered file; pass `quality=1` if you are diffing PNGs and want to
+be sure nothing lossy happened upstream of the encoder.
+
+The preset table lives in [`capture-size.md`](capture-size.md) and is
+not duplicated here — there is one catalogue, and this is one of its
+consumers.
+
+`fit` and `background` are inert at `size=native`, because there is no
+spare canvas for them to act on. That is not a special case in the
+code — the placement simply comes back as identity — but it is worth
+knowing before you file a bug about `--background` doing nothing.
+
+`--background` takes `transparent` (or `none`), or a hex colour with
+the `#` optional — `--background ffffff` and `--background '#ffffff'`
+are the same thing, which saves one round of shell-quoting grief. The
+value is trimmed and lowercased before validation, so `--fit CONTAIN`
+and `--background ' TRANSPARENT '` are accepted too.
+
+Over HTTP the `#` is optional for a different reason than on the CLI:
+a literal `#` starts the URL fragment and never reaches the server at
+all, so `?background=ffffff` is the spelling that actually works
+unescaped. `%23ffffff` works too.
+
+White is the default on every surface — the CLI flag, the routes, and
+the browser picker — because a capture with a letterbox is usually a
+finished artefact and a marketing shot on a checkerboard is not what
+anyone meant. `transparent` is one word away when you want to
+composite it yourself.
+
+Then mind the format: **JPEG has no alpha channel**, so
+`--background transparent --format jpg` composites the letterbox onto
+**black**, not white. Ask for PNG whenever you ask for transparency.
+
+## The bezel route
+
+`screenshot-bezel.png` composites the DeviceKit chrome the farm wall
+and the live view already draw:
+
+```
+DeviceChrome composite       ← underneath
+   clip(innerCornerRadius)
+     framebuffer, cover-fitted into the cutout
+```
+
+Same z-order as everywhere else in baguette, for the same reason: the
+composite artwork paints an opaque dark "off-glass" tint inside the
+screen rect, authored to sit *under* live content. The framebuffer is
+**cover**-fitted into the cutout, so a device whose capture aspect
+doesn't quite match its chrome crops a hair rather than stretching —
+a distorted screenshot inside a correct bezel looks broken in a way a
+1-pixel crop does not.
+
+It is PNG-only, and that is not an oversight: the device body has
+transparent corners, and a JPEG of it would be a phone on a black
+rectangle. `?size=` / `?fit=` / `?background=` then apply to the
+composited image, so `?size=square&background=ffffff` gives you the
+bezelled device centred on a white square — which is the actual
+marketing shot, in one GET, without a browser.
+
+A device with no DeviceKit artwork gets a `404`, not an invented grey
+rectangle. See [`chrome-bezel.md`](chrome-bezel.md) for which devices
+ship chrome.
+
+
+## In the browser
+
+Every capture surface in the web UI — the legacy stream sidebar, the
+focus-mode toolbar, and the device-farm focus pane — mounts the same
+size chip (`CaptureSizeMenu`) beside its Screenshot button, and each
+remembers its own selection in `localStorage`. A capture then takes
+one of two routes to a file:
+
+- **`CaptureGallery`** fetches the screenshot over HTTP and forwards
+  the picker's `?size=&fit=&background=` verbatim, so the server does
+  the resize. Each thumbnail records the dimensions it actually came
+  back at, and the download filename carries the size slug.
+- **The composite path** paints locally through `CaptureComposer` when
+  the bezel is wanted, because the bezel image is already decoded on
+  the page and re-fetching it server-side would be slower and no more
+  correct.
+
+Both end up at the same pixels, because both plan through the same
+`CaptureSize`. The picker's "Include bezel" checkbox is what chooses
+between them; it is hidden on surfaces where a bezel is meaningless
+(the 3D stage already contains a device).
 
 ## Timeouts and errors
 
@@ -127,31 +320,80 @@ real failure modes it guards against:
 The HTTP layer translates everything to `application/json` error
 envelopes; the CLI exits non-zero with the underlying message logged.
 
+A malformed `size` / `fit` / `background` is a **client** error, not a
+capture failure — it's rejected before the framebuffer is touched, so
+a typo costs a 400 rather than a two-second timeout, and each message
+names the whole accepted set:
+
+```
+Unknown size 'nonsense'. Expected WIDTHxHEIGHT, W:H, or one of:
+  native | appstore-6.9 | appstore-6.5 | appstore-ipad-13 | square |
+  16:9 | 9:16 | 4:3 | 4:5
+Unknown fit 'squish'. Expected one of: contain | cover | stretch
+Unknown background 'chartreuse'. Expected 'transparent' or #RRGGBB
+```
+
+The CLI prints the same sentences and exits non-zero.
+
+`screenshot-bezel.png` has one failure mode the flat routes don't: a
+device with no DeviceKit chrome, which answers `404 no bezel for udid
+<udid>`. Baguette does not invent a generic rectangle to wrap it in.
+
 ## Files
 
 ```
 Sources/Baguette/
+├── Domain/
+│   └── Capture/
+│       └── CaptureSize.swift             size vocabulary + placement
 ├── Infrastructure/
-│   └── Screen/
-│       └── ScreenSnapshot.swift         capture helper (this doc)
-├── Infrastructure/
+│   ├── Screen/
+│   │   ├── ScreenSnapshot.swift          capture helper (this doc)
+│   │   └── CaptureCanvas.swift           CoreGraphics letterbox / crop
 │   └── Server/
-│       └── Server.swift                  /screenshot.jpg route
+│       └── Server.swift                  screenshot.{jpg,png} +
+│                                         screenshot-bezel.png routes
 └── App/
     ├── Commands/
     │   └── ScreenshotCommand.swift       baguette screenshot
     └── RootCommand.swift                 registers ScreenshotCommand
 ```
 
+The split follows the usual rule: the *what* — which canvas, where the
+source lands, whether there is anything to do at all — is pure Domain
+and unit-covered in `Tests/BaguetteTests/Capture/CaptureSizeTests.swift`.
+Only the CoreGraphics and `CGImageDestination` calls are
+integration-only.
+
 ## Known limits
 
-- **No PNG.** Only JPEG. Browsers care about the extension; switching
-  to `screenshot.png` would mean wiring `CGImageDestination` to
-  `public.png` and a new route — easy, just not built.
-- **No bezel composite.** The endpoint returns the raw simulator
-  framebuffer. Compositing the DeviceKit bezel around it is a browser-
-  side concern (`bezel.png` + the JPEG layered in CSS / canvas) — same
-  trade-off the live stream makes.
+- **A size is a canvas, not a resampler.** `--size appstore-6.9` off a
+  1206 × 2622 device produces a genuine 1290 × 2796 file of upscaled
+  pixels. Nothing sharpens it. If you need real detail at a submission
+  size, capture from a device whose native resolution is at least that
+  large.
+- **Ratios grow, they never crop.** `--size square` on a phone gives a
+  tall square with the phone centred, not a square cut out of the
+  middle of the screen. That is the whole point (see
+  [`capture-size.md`](capture-size.md)), but it does mean `--size 16:9`
+  on a portrait device produces a very wide image. Use an explicit
+  `WIDTHxHEIGHT` when you want a bounded output, or `--fit cover` when
+  you genuinely do want the crop.
+- **`transparent` is a PNG-only answer.** JPEG has no alpha; a
+  transparent background composites onto black there. Nothing warns
+  you — the flags are independent.
+- **No bezel on the JPEG routes, and no bezel on the CLI.**
+  `screenshot-bezel` is PNG only — DeviceKit chrome has rounded
+  corners and therefore alpha, and a JPEG of it would be a phone on a
+  black rectangle. And there is no `--bezel` flag: the composite is an
+  HTTP route, so a shell script wanting one reaches for `curl`.
+- **Bezel composite needs chrome for the device.** Devices with no
+  DeviceKit artwork can't be composited; the route 404s rather than
+  falling back to a plain rectangle.
+- **The bezel cutout cover-fits.** A capture whose aspect doesn't match
+  the chrome's screen rect loses a sliver at two edges rather than
+  distorting. Normally invisible; worth knowing if you are diffing
+  bezelled captures pixel-for-pixel.
 - **Synchronous on the request thread.** A request that has to wait
   the full 2 s for the timeout pins one Hummingbird request task. Not
   a problem at human-scale request rates; would matter under heavy
@@ -161,11 +403,18 @@ Sources/Baguette/
 
 - **Region capture.** A `?rect=x,y,w,h` query param + a one-line
   `CGImage.cropping(to:)` would let dashboards grab just the status
-  bar or a known UI region without a server-side composite step.
-- **Bezel-composite variant.** A `screenshot-bezel.jpg` route layering
-  `JPEGEncoder` over the rasterized DeviceKit composite would mirror
-  what the device-farm wall already shows — useful for marketing
-  capture without spinning up a browser.
+  bar or a known UI region without a server-side composite step. Note
+  this is a genuinely different axis from `?size=`: one selects part
+  of the source, the other shapes the destination.
+- **A bezelled JPEG, on an opaque background.** The bezel route is PNG
+  because chrome has alpha — but a solid `?background=` already
+  flattens it. Honouring the bezel composite on `screenshot.jpg` when
+  a solid background is given would give thumbnail-heavy pages a
+  cheaper bezelled image than PNG.
+- **A bezel on the CLI.** `baguette screenshot --bezel` would want the
+  same composite the route does; the reason it doesn't exist yet is
+  that the chrome rasterization currently lives on the server side of
+  the split, not that it's hard.
 - **WebP / AVIF.** The `CGImageDestination` switch is a one-line
   format string; smaller payloads at the same visual quality matter
   for thumbnail-heavy pages like `/farm`.


### PR DESCRIPTION
Documentation for the shared capture-size feature (Unit 11). No code
changes — nothing under `Sources/` or `Tests/` is touched.

## What changed

**`docs/features/screenshot.md`** — `--size` / `--fit` / `--background`
/ `--format`, the `?size=&fit=&background=` parameters, and the new
`screenshot.png` and `screenshot-bezel.png` routes. The "No PNG" and
"No bezel composite" known limits and the "Bezel-composite variant"
extension point are removed: all three shipped. They are replaced by
the limits that are now true (a size is a canvas, not a resampler;
ratios grow instead of cropping; transparency is a PNG-only answer;
the bezel cutout cover-fits).

**`docs/features/recording.md`** — browser-side sizing, the bezel-less
3D path, and `baguette record`. The doc's existing argument against
server-side recording is kept and **scoped**, not deleted: it was
always an argument about attaching to a stream already running for
someone else. A standalone CLI owns the encode from frame one and has
no competing viewer, so the design rejected as a passenger is the
right one on its own. There is a table making the difference explicit
so a future reader doesn't read the two sections as a contradiction.

**`docs/features/3d-rendering.md`** — `--size` and the route's `"size"`
field take preset names (the object form still parses), the live
stream accepts `size=`, and browser export is now a server re-render
rather than a `toDataURL` of the decoded video canvas. Three known
limits land with it: zoom is lost on save; a release binary can't find
its models without `BAGUETTE_3D_MODEL_DIR`; and `fit` on this route is
`DeviceScreenFit` — the screenshot's UV placement on the device mesh,
not `CaptureFit`'s canvas placement. Same three case names, different
axis, and it is called out in `capture-size.md` too.

**`docs/features/capture-size.md`** — stays the single home of the
preset table, extended with what the sibling units settled: who speaks
the vocabulary, the two `plan` spellings (Swift `drawWidth`, JS
`drawW` + the source box), filename slugs and the Finder colon
problem, the background defaults, and the picker's hideable controls.

**`README.md`** — `record` in the CLI reference, the new screenshot
flags, `screenshot.png` / `screenshot-bezel.png` in the route table, a
short "Capture size — one vocabulary" section pointing at the feature
doc, and `Domain/Capture/` + `Resources/Web/capture/` in the source
tree.

**`CHANGELOG.md`** — user-facing entries under `[Unreleased] / Added`,
matching the existing format.

## Verification

Every flag name, route spelling, default, and error message was
confirmed against the implementing units rather than guessed. Both
suites run clean: `swift test` (1500 tests, 194 suites) and
`make test-web` (223 tests). All relative doc links resolve.

Nothing is left hedged. The one open question — whether the PNG routes
carry a JPEG intermediate — was confirmed: they do, so `screenshot.png`
is documented as near-lossless rather than bit-exact, with the known
limit and the extension point that would remove the hop both written
down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
