### PR TITLE
Sized screenshots and recording in the native view

### DIFF
--- a/Sources/Baguette/Resources/Web/sim-native.html
+++ b/Sources/Baguette/Resources/Web/sim-native.html
@@ -2074,6 +2074,106 @@
     #simNativeView .screens-card { width: auto; left: 12px; right: 12px; }
   }
 
+  /* --- Capture: output size + recording -------------------------------
+     One picked size drives both the Screenshot button and the recorder,
+     in 2D and in 3D. The vocabulary itself lives in
+     Resources/Web/capture/ (docs/features/capture-size.md); this block
+     is only the focus-mode dressing.
+
+     CaptureSizeMenu ships its own stylesheet, written against a generic
+     token set with light-mode fallbacks so it can mount anywhere.
+     Binding those names to the focus-mode palette on the mount host is
+     what makes the chip and its popover follow dark/light with the rest
+     of the bar, without the module needing to know this page exists. */
+  #simNativeView #nativeCaptureSize {
+    display: inline-flex; flex: 0 0 auto;
+    --nv-panel:  var(--nv-page-bg);
+    --nv-border: var(--nv-divider);
+    --nv-btn:    var(--nv-fmt-track-bg);
+    --accent:     var(--nv-accent);
+    --text-muted: var(--nv-text-muted);
+  }
+  /* Match the toolbar's icon buttons rather than the menu's own 26px. */
+  #simNativeView #nativeCaptureSize .cap-size-chip { height: 28px; }
+  /* Gated with the icon strip: a size means nothing without a stream. */
+  #simNativeView[data-power] #nativeCaptureSize {
+    opacity: 0.35; pointer-events: none;
+  }
+
+  /* `.ico-btn` sets `display: inline-flex`, which beats the UA's
+     `[hidden] { display: none }` — the Record button hides itself when
+     the browser has no MediaRecorder, so it needs this to actually go. */
+  #simNativeView .ico-btn[hidden] { display: none; }
+
+  /* Record. The button carries the whole recording state: a red fill, a
+     pulsing glyph, and an elapsed mm:ss readout that exists only while
+     running — the focus bar has no other surface to say "still
+     recording" on. The readout widens the button, which is why
+     `updateRecordButton` re-runs the toolbar's overflow measurement. */
+  #simNativeView #nativeRecordBtn.recording {
+    width: auto; gap: 5px; padding: 0 8px;
+    background: var(--nv-danger); color: #fff;
+  }
+  #simNativeView #nativeRecordBtn.recording svg {
+    animation: nv-rec-pulse 1.2s ease-in-out infinite;
+  }
+  #simNativeView #nativeRecordBtn .rec-timer {
+    display: none;
+    font: 600 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-variant-numeric: tabular-nums;
+  }
+  #simNativeView #nativeRecordBtn.recording .rec-timer { display: inline; }
+  @keyframes nv-rec-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+  /* Finished recordings. A file that lands with no visible link is a
+     file the user loses, and focus mode has no sidebar to hang a
+     gallery off — so the dock is its own small floating card, shown
+     only once something is in it. Bottom-right, clear of the plugin /
+     screens cards at the top and the theme pill on the left. */
+  #simNativeView .rec-dock {
+    position: fixed; bottom: 18px; right: 76px; z-index: 40;
+    width: 236px;
+    display: none; flex-direction: column;
+    background: var(--nv-bar-bg);
+    border: 1px solid var(--nv-bar-border);
+    border-radius: 14px;
+    box-shadow: var(--nv-bar-shadow), var(--nv-bar-inset);
+    backdrop-filter: blur(18px) saturate(1.5);
+    -webkit-backdrop-filter: blur(18px) saturate(1.5);
+    color: var(--nv-text);
+    overflow: hidden;
+  }
+  #simNativeView .rec-dock[data-open] { display: flex; }
+  #simNativeView .rec-dock-head {
+    display: flex; align-items: center; gap: 8px;
+    padding: 7px 6px 7px 12px;
+    border-bottom: 1px solid var(--nv-divider);
+    color: var(--nv-text-muted);
+    font: 700 9px/1 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+    letter-spacing: 0.09em; text-transform: uppercase;
+  }
+  #simNativeView .rec-dock-head .rec-dock-close { margin-left: auto; width: 22px; height: 22px; }
+  #simNativeView .rec-dock-list {
+    display: flex; flex-direction: column; gap: 2px;
+    padding: 6px; max-height: 40vh; overflow-y: auto;
+  }
+  #simNativeView .rec-dock-list a {
+    display: flex; align-items: center; gap: 8px;
+    padding: 6px 8px; border-radius: 8px;
+    color: var(--nv-text); text-decoration: none;
+    font: 500 11px/1.2 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  }
+  #simNativeView .rec-dock-list a:hover { background: var(--nv-btn-hover); }
+  #simNativeView .rec-dock-list a svg { flex: 0 0 auto; color: var(--nv-text-muted); }
+  #simNativeView .rec-dock-list .rec-meta {
+    margin-left: auto; color: var(--nv-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  @media (max-width: 560px) {
+    #simNativeView .rec-dock { right: 12px; left: 12px; width: auto; }
+  }
+
   /* Preview ribbon — only when opened via file:// */
   #simNativeView .preview-banner {
     display: none; position: fixed; top: 10px; right: 10px; z-index: 999;
@@ -2246,6 +2346,26 @@
             <circle cx="12" cy="13" r="3.5"/>
           </svg>
         </button>
+        <!-- Record — the moving-picture sibling of Screenshot, and the
+             other half of what the size chip drives. Captures the live
+             view in the browser (MediaRecorder over a compose canvas,
+             no server round-trip) in whichever mode is showing: 2D
+             records the bezel composite plus the pinch dots, 3D records
+             the server-rendered device frame as it already is. Hidden
+             outright where MediaRecorder doesn't exist — a Record
+             button that can't record is worse than none. -->
+        <button class="ico-btn" id="nativeRecordBtn" title="Record video"
+                aria-label="Start recording" aria-pressed="false"
+                onclick="window.__nativeRecord && window.__nativeRecord()">
+          <!-- Ring around a filled dot — the universal record glyph.
+               The whole mark pulses while a recording is running. -->
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"
+               stroke-linecap="round" stroke-linejoin="round" width="17" height="17">
+            <circle cx="12" cy="12" r="8.5"/>
+            <circle cx="12" cy="12" r="4" fill="currentColor" stroke="none"/>
+          </svg>
+          <span class="rec-timer" id="nativeRecordTimer"></span>
+        </button>
         <button class="ico-btn" title="App switcher"
                 aria-label="Open app switcher"
                 onclick="window.__nativeAppSwitcher && window.__nativeAppSwitcher()">
@@ -2290,6 +2410,17 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"
              stroke-linecap="round" stroke-linejoin="round" width="13" height="13"><polyline points="9 18 15 12 9 6"/></svg>
       </button>
+
+      <!-- Capture output size — the chip that says "App Store 6.9″" /
+           "Square" / "Native" for both Screenshot and Record. Mounted
+           by CaptureSizeMenu (sim-native.js `mountCaptureUI`), so it
+           stays an empty zero-width box until then.
+
+           Deliberately OUTSIDE `#nativeToolScroll`, even though it
+           belongs with the actions at that strip's right end: the strip
+           is an `overflow-x: auto` container, and the popover this chip
+           opens would be clipped at its edge. -->
+      <div id="nativeCaptureSize"></div>
     </div>
   </div>
 
@@ -2504,6 +2635,27 @@
       </button>
     </header>
     <div id="nativeLocationHost"></div>
+  </aside>
+
+  <!-- Recordings dock. A MediaRecorder artifact only exists as a Blob
+       URL in this tab, so if nothing on the page links to it the
+       recording is simply gone. The dock opens itself when the first
+       one lands and lists them newest-first; closing it revokes every
+       URL it was holding, which is what keeps a long session from
+       accumulating video in memory. -->
+  <aside class="rec-dock" id="nativeRecordDock" aria-label="Recordings">
+    <header class="rec-dock-head">
+      <span>Recordings</span>
+      <button class="ico-btn rec-dock-close" title="Clear recordings"
+              aria-label="Clear recordings"
+              onclick="window.__nativeClearRecordings && window.__nativeClearRecordings()">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+             stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="12" height="12">
+          <path d="M6 6 18 18"/><path d="M18 6 6 18"/>
+        </svg>
+      </button>
+    </header>
+    <div class="rec-dock-list" id="nativeRecordList"></div>
   </aside>
 </div>
 

--- a/Sources/Baguette/Resources/Web/sim-native.html
+++ b/Sources/Baguette/Resources/Web/sim-native.html
@@ -332,6 +332,15 @@
        strip already scrolls when it doesn't fit, which is exactly the
        behaviour this hands it. */
     max-width: min(100%, var(--nv-device-max-w));
+    /* `backdrop-filter` makes the bar its own stacking context, so a
+       popover opened inside it (the capture-size chip's) composites at
+       the bar's level no matter how high its own z-index goes. Without
+       a level of its own the bar sits at 0, which puts the popover
+       under the floating cards (z-index 40) and under the device
+       wrapper once `applyOrientation` gives it a transform. 50 clears
+       both; the bar and the cards never overlap geometrically. */
+    position: relative;
+    z-index: 50;
   }
 
   /* `!important` overrides the SDK Bezel's inline `max-height: 70vh`
@@ -2152,7 +2161,23 @@
     font: 700 9px/1 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
     letter-spacing: 0.09em; text-transform: uppercase;
   }
-  #simNativeView .rec-dock-head .rec-dock-close { margin-left: auto; width: 22px; height: 22px; }
+  #simNativeView .rec-dock-head .rec-dock-clear {
+    margin-left: auto; padding: 3px 7px;
+    border: 0; border-radius: 6px; cursor: pointer;
+    background: transparent; color: var(--nv-danger);
+    /* Reset the header's uppercase tracking: this is a control, and
+       shouting it competes with the title beside it. */
+    font: 600 10px/1 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+    letter-spacing: 0; text-transform: none;
+  }
+  #simNativeView .rec-dock-head .rec-dock-clear:hover { background: var(--nv-btn-hover); }
+  #simNativeView .rec-dock-head .rec-dock-close { width: 22px; height: 22px; }
+  /* Why a take ended without producing a file. Sits above the list so
+     "nothing appeared" has an explanation next to where it didn't. */
+  #simNativeView .rec-dock-list .rec-note {
+    margin: 2px 6px 6px; color: var(--nv-text-muted);
+    font: 500 11px/1.35 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  }
   #simNativeView .rec-dock-list {
     display: flex; flex-direction: column; gap: 2px;
     padding: 6px; max-height: 40vh; overflow-y: auto;
@@ -2646,9 +2671,17 @@
   <aside class="rec-dock" id="nativeRecordDock" aria-label="Recordings">
     <header class="rec-dock-head">
       <span>Recordings</span>
-      <button class="ico-btn rec-dock-close" title="Clear recordings"
-              aria-label="Clear recordings"
-              onclick="window.__nativeClearRecordings && window.__nativeClearRecordings()">
+      <!-- Two separate verbs, because they are not the same act. The ✕
+           puts the card away and keeps every file; "Clear" revokes the
+           Blob URLs, which destroys anything not yet downloaded with no
+           undo — so it is spelled out rather than hidden behind the
+           dismiss glyph people click without reading. -->
+      <button class="rec-dock-clear" title="Discard these recordings and free the memory they hold"
+              aria-label="Discard recordings"
+              onclick="window.__nativeClearRecordings && window.__nativeClearRecordings()">Clear</button>
+      <button class="ico-btn rec-dock-close" title="Hide recordings"
+              aria-label="Hide recordings"
+              onclick="window.__nativeHideRecordings && window.__nativeHideRecordings()">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
              stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="12" height="12">
           <path d="M6 6 18 18"/><path d="M18 6 6 18"/>

--- a/Sources/Baguette/Resources/Web/sim-native.js
+++ b/Sources/Baguette/Resources/Web/sim-native.js
@@ -355,6 +355,12 @@
     wireUnload();
     applyStoredTheme();
 
+    // Capture surface — the output-size chip and the Record button.
+    // Deliberately not awaited: the size vocabulary is four small files
+    // and nothing on the stream path needs them, so the device paints
+    // while they arrive.
+    void ensureCaptureModules().then(mountCaptureUI);
+
     // Drag-and-drop: drop an .ipa/.app to install, or an image/video to
     // add to Photos. Dumb sender — POSTs the bytes to `/files`; the
     // Swift side routes by extension. The drop zone + highlight are
@@ -436,6 +442,10 @@
   // to swap formats — the WS protocol is per-connection and the
   // server's makeStream(...) is keyed at session open.
   function startSession(format) {
+    // A recording samples the canvas this session paints into; a
+    // restart (format swap, 3D close, device re-open) leaves it blank
+    // for however long the new socket takes to land its first frame.
+    if (session) cancelRecording('stream restarted');
     if (session) { try { session.stop(); } catch (_) {} session = null; }
     // Same text-frame router as sim-stream.js: hand JSON envelopes
     // to the inspector first, then claim paste_result; anything
@@ -1200,6 +1210,10 @@
     // issue here.
     window.__nativeAppSwitcher = () => sim && sim.pressButton('app-switcher');
     window.__nativeScreenshot = () => downloadSnapshot();
+    // Record is Screenshot's moving-picture sibling: same source, same
+    // picked size, one toggle instead of a one-shot.
+    window.__nativeRecord = () => { void toggleRecording(); };
+    window.__nativeClearRecordings = () => clearRecordings();
     window.__nativeClose = () => {
       // Shutting the window from inside a popup-style URL: try
       // window.close (only works for script-opened tabs) then fall
@@ -1431,6 +1445,13 @@
     const btn = document.getElementById('native3DToggle');
     const open = view && view.getAttribute('data-render3d') === 'open';
     if (!view || !host || !stage || !sim) return;
+    // The canvas being recorded is about to be swapped for the other
+    // mode's, and the two are different surfaces at different sizes.
+    cancelRecording('switched between 2D and 3D');
+    // The bezel switch only makes sense in 2D: the 3D render already
+    // carries the device body, so compositing a second one would draw
+    // the phone twice. `open` is the state we're leaving.
+    if (captureMenu) captureMenu.showFrameToggle = open;
     if (open) {
       view.removeAttribute('data-render3d');
       view.removeAttribute('data-render3d-inspector');
@@ -1490,6 +1511,8 @@
   function wireUnload() {
     window.addEventListener('beforeunload', () => {
       try { hidePowerCard(); } catch (_) { /* ignore */ }
+      try { cancelRecording('page unloading'); } catch (_) { /* ignore */ }
+      try { clearRecordings(); } catch (_) { /* ignore */ }
       try { if (session) session.stop(); } catch (_) { /* ignore */ }
       try { if (carplaySession) carplaySession.stop(); } catch (_) { /* ignore */ }
       try { if (carplayScreen) carplayScreen.detach(); } catch (_) { /* ignore */ }
@@ -1507,33 +1530,398 @@
     });
   }
 
-  // Take a snapshot from the live canvas and trigger a download. We
-  // skip CaptureGallery here — the focus chrome has nowhere to put a
-  // thumbnail strip, and the user just wants the file.
-  function downloadSnapshot() {
+  // --- Capture: one picked size, two verbs, two modes ---------------
+  //
+  // "App Store 6.9″" / "Square" / "16:9" is chosen once, on the chip in
+  // the toolbar, and both Screenshot and Record come out at it — in 2D
+  // and in 3D alike. The vocabulary is shared with the HTTP routes and
+  // the CLI and lives in Resources/Web/capture/; see
+  // docs/features/capture-size.md. Nothing here reimplements any of it.
+  //
+  // Those modules are pulled in at runtime rather than with a <script>
+  // tag, because this page has no <head> of its own: sim.html carries
+  // the page's script tags, and `fetchTemplate` deliberately drops the
+  // ones inside sim-native.html. Anything already on the page (sim.html
+  // loads /recorder.js today) is left alone — the guard is the global
+  // the module hangs itself on, not the URL, so this stays correct
+  // whichever page happens to have loaded it first.
+  const CAPTURE_MODULES = [
+    ['/capture/capture-size.js', () => window.Baguette && window.Baguette._CaptureSize],
+    ['/capture/capture-settings.js', () => window.Baguette && window.Baguette._CaptureSettings],
+    ['/capture/capture-composer.js', () => window.Baguette && window.Baguette._CaptureComposer],
+    ['/capture/capture-size-menu.js', () => window.CaptureSizeMenu],
+    ['/recorder.js', () => window.BrowserRecorder],
+  ];
+
+  let captureMenu = null;   // CaptureSizeMenu — the size chip in the toolbar
+
+  // Recording state, mirroring sim-stream.js's `recordingState`:
+  //   recorder  : BrowserRecorder while a recording is in flight
+  //   active    : true between start() and stop()
+  //   startedAt : ms timestamp behind the mm:ss readout
+  //   timer     : interval handle ticking that readout
+  //   entries   : finished artifacts — Blob URLs we own and must revoke
+  const recordingState = {
+    recorder: null, active: false, startedAt: 0, timer: null, entries: [],
+  };
+
+  let _captureModulesPromise = null;
+  function ensureCaptureModules() {
+    if (_captureModulesPromise) return _captureModulesPromise;
+    _captureModulesPromise = (async () => {
+      for (const [src, present] of CAPTURE_MODULES) {
+        if (present()) continue;
+        await loadScript(src);
+      }
+    })();
+    return _captureModulesPromise;
+  }
+
+  function loadScript(src) {
+    return new Promise((resolve) => {
+      const el = document.createElement('script');
+      el.src = src;
+      el.onload = () => resolve(true);
+      el.onerror = () => { console.warn('[native] failed to load', src); resolve(false); };
+      document.head.appendChild(el);
+    });
+  }
+
+  function mountCaptureUI() {
+    const host = document.getElementById('nativeCaptureSize');
+    if (host && window.CaptureSizeMenu && !captureMenu) {
+      captureMenu = new window.CaptureSizeMenu({
+        storageKey: 'asc.capture.native',
+        // The bezel switch is meaningless in 3D — the rendered frame
+        // already carries the device body. `toggle3D` flips this.
+        showFrameToggle: !is3DOpen(),
+        // The popover shows each preset's resolved pixels, so it has to
+        // be told what the *composite* is — the bezel viewport when the
+        // frame is on, the bare canvas when it isn't.
+        sourceSize: () => compositeSourceSize(),
+        onChange: () => refreshToolbarScroll(),
+      });
+      captureMenu.mount(host);
+    }
+    // A Record button that can't record is worse than no Record button.
+    const btn = document.getElementById('nativeRecordBtn');
+    if (btn) {
+      btn.hidden = !(window.BrowserRecorder && window.BrowserRecorder.isAvailable());
+    }
+    refreshToolbarScroll();
+  }
+
+  function is3DOpen() {
     const view = document.getElementById('simNativeView');
-    if (view && view.getAttribute('data-render3d') === 'open' && render3DPanel) {
-      render3DPanel.download();
+    return !!(view && view.getAttribute('data-render3d') === 'open');
+  }
+
+  function captureSettings() {
+    if (captureMenu) return captureMenu.settings;
+    const CaptureSettings = window.Baguette && window.Baguette._CaptureSettings;
+    return CaptureSettings ? new CaptureSettings() : null;
+  }
+
+  /**
+   * What a capture reads from, in whichever mode is actually showing.
+   *
+   * 3D is bezel-less on purpose: the server-rendered frame already
+   * contains the device body, so compositing a second bezel over it
+   * would draw the phone twice. `frameImg: null, screen: null` is how
+   * both CaptureComposer and BrowserRecorder spell "bare canvas".
+   *
+   * @returns {{canvas, frameImg, screen, overlayHost, mode}|null}
+   */
+  function activeCaptureSource() {
+    if (is3DOpen()) {
+      const canvas = render3DPanel && render3DPanel.canvas;
+      // `data-painted` is Sim3DPanel's own "a frame has landed" flag;
+      // without it the canvas is a blank allocation.
+      if (!canvas || !canvas.width || !canvas.hasAttribute('data-painted')) return null;
+      return {
+        canvas, frameImg: null, screen: null, overlayHost: null, mode: '3d',
+      };
+    }
+    if (!sim || !sim.canvas || !sim.canvas.width) return null;
+    const settings = captureSettings();
+    const withFrame = settings ? settings.withFrame : false;
+    return {
+      canvas: sim.canvas,
+      frameImg: withFrame && sim._bezel ? sim._bezel.frameImg : null,
+      screen: withFrame ? sim.screen.def : null,
+      overlayHost: sim.pinchOverlayContainer,
+      mode: '2d',
+    };
+  }
+
+  /**
+   * How far to supersample the bezel composite.
+   *
+   * The bezel art is authored at layout scale — 474 × 990 points for an
+   * iPhone 17 Pro Max — while the live canvas carries the device's full
+   * 1290 × 2796 framebuffer. Compositing at the bezel's own size would
+   * resample the screen down by ~3x and throw the detail away before
+   * the picked size ever gets a look at it, so the composite is grown
+   * until the screen cutout is 1:1 with the frames arriving and the
+   * bezel is scaled up to meet it: soft chrome around a sharp screen
+   * beats a sharp frame around a thumbnail. Capped so an unusually
+   * large source can't ask for a canvas the browser refuses to
+   * allocate. 1 with no bezel — the canvas is already the composite.
+   */
+  function compositeScale(source) {
+    if (!source || !source.screen || !source.screen.rect) return 1;
+    const width = source.screen.rect.width;
+    if (!(width > 0)) return 1;
+    return Math.min(4, Math.max(1, source.canvas.width / width));
+  }
+
+  /** The composite's size at capture scale, before the picked size. */
+  function compositeSourceSize() {
+    const source = activeCaptureSource();
+    const Composer = window.Baguette && window.Baguette._CaptureComposer;
+    if (!source || !Composer) return null;
+    const natural = Composer.compositeSize(source.frameImg, source.screen, source.canvas);
+    const scale = compositeScale(source);
+    return {
+      width: Math.round(natural.width * scale),
+      height: Math.round(natural.height * scale),
+    };
+  }
+
+  // Take a snapshot and trigger a download, composed at whatever the
+  // size chip says. We skip CaptureGallery here — the focus chrome has
+  // nowhere to put a thumbnail strip, and the user just wants the file.
+  function downloadSnapshot() {
+    const source = activeCaptureSource();
+    if (!source) return;
+    const settings = captureSettings();
+    const Composer = window.Baguette && window.Baguette._CaptureComposer;
+    // The capture modules failed to load: still hand over the frame at
+    // native size rather than doing nothing at all.
+    if (!settings || !Composer) {
+      source.canvas.toBlob((blob) => {
+        if (blob) saveBlob(blob, `${deviceSlug()}-${captureStamp()}.png`);
+      }, 'image/png');
       return;
     }
-    if (!sim || !sim.canvas) return;
-    const w = lastPaintedSize.w || sim.canvas.width;
-    const h = lastPaintedSize.h || sim.canvas.height;
-    if (!w || !h) return;
-    sim.canvas.toBlob((blob) => {
-      if (!blob) return;
-      const stamp = new Date().toISOString().replace(/[:.]/g, '-');
-      const safe = (deviceName || 'simulator').replace(/[^A-Za-z0-9._-]/g, '_');
-      const a = document.createElement('a');
-      a.href = URL.createObjectURL(blob);
-      a.download = `${safe}-${stamp}.png`;
-      document.body.appendChild(a);
-      a.click();
-      requestAnimationFrame(() => {
-        URL.revokeObjectURL(a.href);
-        a.remove();
+
+    const natural = Composer.compositeSize(source.frameImg, source.screen, source.canvas);
+    if (!natural.width || !natural.height) return;
+    const scale = compositeScale(source);
+    const plan = settings.plan(natural.width * scale, natural.height * scale);
+    if (!plan.width || !plan.height) return;
+
+    const out = document.createElement('canvas');
+    out.width = plan.width;
+    out.height = plan.height;
+    const ctx = out.getContext('2d');
+    // A ratio preset only ever grows the canvas, but a fixed App Store
+    // size can ask for a real rescale — take the browser's good
+    // resampler rather than its default nearest-neighbour.
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    Composer.compose(ctx, plan, settings.effectiveBackground, (c) => {
+      // `compose` has already set the transform for a source of
+      // `natural * scale`; `paintComposite` paints at `natural`, so the
+      // supersample factor goes on here.
+      if (scale !== 1) c.scale(scale, scale);
+      Composer.paintComposite(c, {
+        frameImg: source.frameImg,
+        screen: source.screen,
+        sourceCanvas: source.canvas,
       });
+    });
+    out.toBlob((blob) => {
+      if (!blob) return;
+      saveBlob(blob,
+        `${deviceSlug()}-${captureStamp()}-${settings.slug(plan.width, plan.height)}.png`);
     }, 'image/png');
+  }
+
+  // --- Recording ----------------------------------------------------
+
+  function toggleRecording() {
+    if (recordingState.active) return stopRecording();
+    return startRecording();
+  }
+
+  function startRecording() {
+    if (!window.BrowserRecorder || !window.BrowserRecorder.isAvailable()) return;
+    const source = activeCaptureSource();
+    if (!source) return;
+    try {
+      const rec = new window.BrowserRecorder({
+        canvas: source.canvas,
+        // In 3D both of these are null, which BrowserRecorder already
+        // reads as "record the bare canvas" — the same result a
+        // dedicated `bezel: false` option gives, without depending on
+        // it having landed.
+        frameImg: source.frameImg,
+        screen: source.screen,
+        overlayHost: source.overlayHost,
+        // Forward-compatible hint: sizing a recording is the recorder's
+        // job (it owns the compose canvas), and it ignores keys it
+        // doesn't know. Screenshots are sized here, above.
+        settings: captureSettings(),
+        fps: 60,
+      });
+      rec.start();
+      recordingState.recorder = rec;
+      recordingState.active = true;
+      recordingState.startedAt = Date.now();
+      if (recordingState.timer) clearInterval(recordingState.timer);
+      recordingState.timer = setInterval(updateRecordButton, 250);
+      updateRecordButton();
+    } catch (err) {
+      console.warn('[native] recording failed to start:', err);
+      resetRecordingState();
+      updateRecordButton();
+    }
+  }
+
+  async function stopRecording() {
+    const rec = recordingState.recorder;
+    // Optimistic UI: the button leaves the recording state the instant
+    // the user clicks, because MediaRecorder's final chunk can take a
+    // beat to land on a longer take.
+    recordingState.recorder = null;
+    resetRecordingState();
+    updateRecordButton();
+    if (!rec) return;
+    try {
+      const artifact = await rec.stop();
+      if (!artifact || typeof artifact.url !== 'string') return;
+      // Name it after the device and the picked size, the way the
+      // screenshot is — BrowserRecorder only knows a timestamp.
+      const settings = captureSettings();
+      const ext = (artifact.filename || '').split('.').pop() || 'webm';
+      const slug = settings ? `-${settings.size.spec}` : '';
+      artifact.filename = `${deviceSlug()}-${captureStamp()}${slug}.${ext}`;
+      recordingState.entries.unshift(artifact);
+      renderRecordings();
+    } catch (err) {
+      console.warn('[native] recording failed to stop:', err);
+    }
+  }
+
+  /// Drop an in-flight recording on the floor. The source canvas is
+  /// about to stop being the thing the user asked to record — the
+  /// stream restarted, the device changed, or they flipped 2D↔3D — and
+  /// a recorder left running would keep sampling a dead or wrong
+  /// surface.
+  function cancelRecording(reason) {
+    if (!recordingState.recorder && !recordingState.active) return;
+    try {
+      if (recordingState.recorder) recordingState.recorder.cancel();
+    } catch (_) { /* already torn down */ }
+    recordingState.recorder = null;
+    resetRecordingState();
+    updateRecordButton();
+    console.log('[native] recording cancelled:', reason);
+  }
+
+  function resetRecordingState() {
+    recordingState.active = false;
+    recordingState.startedAt = 0;
+    if (recordingState.timer) {
+      clearInterval(recordingState.timer);
+      recordingState.timer = null;
+    }
+  }
+
+  function updateRecordButton() {
+    const btn = document.getElementById('nativeRecordBtn');
+    if (!btn) return;
+    const was = btn.classList.contains('recording');
+    btn.classList.toggle('recording', recordingState.active);
+    btn.setAttribute('aria-pressed', recordingState.active ? 'true' : 'false');
+    btn.title = recordingState.active ? 'Stop recording' : 'Record video';
+    btn.setAttribute('aria-label',
+      recordingState.active ? 'Stop recording' : 'Start recording');
+    const timer = document.getElementById('nativeRecordTimer');
+    if (timer) {
+      timer.textContent = recordingState.active
+        ? formatElapsed((Date.now() - recordingState.startedAt) / 1000)
+        : '';
+    }
+    // The mm:ss readout appears and disappears with the state, which
+    // changes the button's width — and therefore whether the icon strip
+    // overflows. Without a re-measure the scroll chevrons go stale.
+    if (was !== recordingState.active) refreshToolbarScroll();
+  }
+
+  function renderRecordings() {
+    const dock = document.getElementById('nativeRecordDock');
+    const list = document.getElementById('nativeRecordList');
+    if (!dock || !list) return;
+    if (!recordingState.entries.length) {
+      dock.removeAttribute('data-open');
+      list.innerHTML = '';
+      return;
+    }
+    list.innerHTML = recordingState.entries.map((e) => `
+      <a href="${e.url}" download="${escapeAttribute(e.filename)}"
+         title="Download ${escapeAttribute(e.filename)}">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round" width="12" height="12">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+          <polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
+        </svg>
+        <span>${formatElapsed(e.durationSeconds)}</span>
+        <span class="rec-meta">${formatBytes(e.bytes)}</span>
+      </a>`).join('');
+    dock.setAttribute('data-open', '');
+  }
+
+  /// Empty the dock and hand every Blob back to the browser. A recorded
+  /// minute is tens of megabytes held live by its URL; a session that
+  /// records all afternoon and never revokes keeps every one of them.
+  function clearRecordings() {
+    recordingState.entries.forEach((e) => {
+      if (e.url && e.url.startsWith('blob:')) URL.revokeObjectURL(e.url);
+    });
+    recordingState.entries = [];
+    renderRecordings();
+  }
+
+  function formatElapsed(seconds) {
+    const total = Math.max(0, Math.round(Number(seconds) || 0));
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  }
+
+  function formatBytes(bytes) {
+    const n = Number(bytes) || 0;
+    if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`;
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  function escapeAttribute(text) {
+    return String(text == null ? '' : text)
+      .replace(/[&<>"]/g, (c) => (
+        { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]
+      ));
+  }
+
+  function deviceSlug() {
+    return (deviceName || 'simulator').replace(/[^A-Za-z0-9._-]/g, '_');
+  }
+
+  function captureStamp() {
+    return new Date().toISOString().replace(/[:.]/g, '-');
+  }
+
+  function saveBlob(blob, filename) {
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    requestAnimationFrame(() => {
+      URL.revokeObjectURL(a.href);
+      a.remove();
+    });
   }
 
   console.log('[Baguette] sim-native.js active for', udid);

--- a/Sources/Baguette/Resources/Web/sim-native.js
+++ b/Sources/Baguette/Resources/Web/sim-native.js
@@ -1214,6 +1214,7 @@
     // picked size, one toggle instead of a one-shot.
     window.__nativeRecord = () => { void toggleRecording(); };
     window.__nativeClearRecordings = () => clearRecordings();
+    window.__nativeHideRecordings = () => hideRecordings();
     window.__nativeClose = () => {
       // Shutting the window from inside a popup-style URL: try
       // window.close (only works for script-opened tabs) then fall
@@ -1448,10 +1449,8 @@
     // The canvas being recorded is about to be swapped for the other
     // mode's, and the two are different surfaces at different sizes.
     cancelRecording('switched between 2D and 3D');
-    // The bezel switch only makes sense in 2D: the 3D render already
-    // carries the device body, so compositing a second one would draw
-    // the phone twice. `open` is the state we're leaving.
-    if (captureMenu) captureMenu.showFrameToggle = open;
+    // `open` is the state we're LEAVING, so it doubles as "will be 2D".
+    reflect3DCaptureControls(open);
     if (open) {
       view.removeAttribute('data-render3d');
       view.removeAttribute('data-render3d-inspector');
@@ -1487,6 +1486,12 @@
       } else if (render3DPanel) {
         render3DPanel.background = live3DBackground();
         render3DPanel.start();
+      }
+      // The 3D render is produced server-side, so its Save Frame needs
+      // to be told the picked size rather than reading it off a canvas
+      // we hold. Guarded: the panel gained this hook after the chip did.
+      if (render3DPanel && typeof render3DPanel.setCaptureSettings === 'function') {
+        render3DPanel.setCaptureSettings(captureSettings());
       }
     }
   }
@@ -1533,10 +1538,16 @@
   // --- Capture: one picked size, two verbs, two modes ---------------
   //
   // "App Store 6.9″" / "Square" / "16:9" is chosen once, on the chip in
-  // the toolbar, and both Screenshot and Record come out at it — in 2D
-  // and in 3D alike. The vocabulary is shared with the HTTP routes and
-  // the CLI and lives in Resources/Web/capture/; see
+  // the toolbar, and every capture on this page reads it — in 2D and in
+  // 3D alike. The vocabulary is shared with the HTTP routes and the CLI
+  // and lives in Resources/Web/capture/; see
   // docs/features/capture-size.md. Nothing here reimplements any of it.
+  //
+  // Who applies it differs by verb, because who owns the output canvas
+  // differs: a screenshot is composed here, a 3D Save Frame is rendered
+  // server-side from settings handed to Sim3DPanel, and a recording is
+  // sized by BrowserRecorder's own compose canvas — which is why the
+  // recording's filename carries no size slug.
   //
   // Those modules are pulled in at runtime rather than with a <script>
   // tag, because this page has no <head> of its own: sim.html carries
@@ -1563,6 +1574,7 @@
   //   entries   : finished artifacts — Blob URLs we own and must revoke
   const recordingState = {
     recorder: null, active: false, startedAt: 0, timer: null, entries: [],
+    notice: '',   // why the last take ended without producing a file
   };
 
   let _captureModulesPromise = null;
@@ -1592,14 +1604,24 @@
     if (host && window.CaptureSizeMenu && !captureMenu) {
       captureMenu = new window.CaptureSizeMenu({
         storageKey: 'asc.capture.native',
-        // The bezel switch is meaningless in 3D — the rendered frame
-        // already carries the device body. `toggle3D` flips this.
+        // Three controls that only make sense in 2D — see
+        // `reflect3DCaptureControls` for why. `toggle3D` flips them.
         showFrameToggle: !is3DOpen(),
+        showFitToggle: !is3DOpen(),
+        showBackgroundToggle: !is3DOpen(),
         // The popover shows each preset's resolved pixels, so it has to
         // be told what the *composite* is — the bezel viewport when the
         // frame is on, the bare canvas when it isn't.
         sourceSize: () => compositeSourceSize(),
-        onChange: () => refreshToolbarScroll(),
+        onChange: (settings) => {
+          refreshToolbarScroll();
+          // The 3D render is produced server-side, so the size has to
+          // travel with the request rather than being applied to a
+          // canvas we hold.
+          if (render3DPanel && typeof render3DPanel.setCaptureSettings === 'function') {
+            render3DPanel.setCaptureSettings(settings);
+          }
+        },
       });
       captureMenu.mount(host);
     }
@@ -1611,6 +1633,28 @@
     refreshToolbarScroll();
   }
 
+  /**
+   * Show only the picker controls that mean something in the current
+   * mode. All three are read by `_renderPopover` at open time, so
+   * flipping them on the live instance is enough.
+   *
+   * In 3D:
+   *   • bezel — the rendered frame already carries the device body, so
+   *     compositing a second one would draw the phone twice;
+   *   • fit — on the `render-3d.png` route `fit` is the UV placement of
+   *     the app screenshot on the device's screen mesh, not canvas
+   *     placement, so `contain` would letterbox the app *inside* the
+   *     phone's display. Canvas placement there is the camera's job;
+   *   • background — the render fills its own canvas with the scene
+   *     background already.
+   */
+  function reflect3DCaptureControls(twoD) {
+    if (!captureMenu) return;
+    captureMenu.showFrameToggle = twoD;
+    captureMenu.showFitToggle = twoD;
+    captureMenu.showBackgroundToggle = twoD;
+  }
+
   function is3DOpen() {
     const view = document.getElementById('simNativeView');
     return !!(view && view.getAttribute('data-render3d') === 'open');
@@ -1618,8 +1662,13 @@
 
   function captureSettings() {
     if (captureMenu) return captureMenu.settings;
-    const CaptureSettings = window.Baguette && window.Baguette._CaptureSettings;
-    return CaptureSettings ? new CaptureSettings() : null;
+    const B = window.Baguette;
+    // `new CaptureSettings()` dereferences `_CaptureSize` in its own
+    // constructor, and `loadScript` resolves rather than rejects on a
+    // 404 — so a half-loaded vocabulary is reachable, and checking only
+    // the one global would throw right past the fallback below.
+    if (!B || !B._CaptureSettings || !B._CaptureSize) return null;
+    return new B._CaptureSettings();
   }
 
   /**
@@ -1666,13 +1715,23 @@
    * bezel is scaled up to meet it: soft chrome around a sharp screen
    * beats a sharp frame around a thumbnail. Capped so an unusually
    * large source can't ask for a canvas the browser refuses to
-   * allocate. 1 with no bezel — the canvas is already the composite.
+   * allocate.
+   *
+   * 1 whenever the composite ISN'T the bezel viewport. `compositeSize`
+   * reports the viewport only once the bezel <img> has decoded, and
+   * falls back to the framebuffer otherwise — before the image lands,
+   * or after a 404, where `bezel.js` hides the element and leaves
+   * `naturalWidth` at 0. That fallback is already at capture scale, so
+   * scaling it again would allocate ~9x the pixels for an upscaled
+   * blur. Comparing the reported size against the viewport is how we
+   * tell the two apart.
    */
-  function compositeScale(source) {
-    if (!source || !source.screen || !source.screen.rect) return 1;
-    const width = source.screen.rect.width;
-    if (!(width > 0)) return 1;
-    return Math.min(4, Math.max(1, source.canvas.width / width));
+  function compositeScale(source, natural) {
+    const screen = source && source.screen;
+    if (!screen || !screen.rect || !screen.viewport || !natural) return 1;
+    if (natural.width !== screen.viewport.width) return 1;
+    if (!(screen.rect.width > 0)) return 1;
+    return Math.min(4, Math.max(1, source.canvas.width / screen.rect.width));
   }
 
   /** The composite's size at capture scale, before the picked size. */
@@ -1681,7 +1740,7 @@
     const Composer = window.Baguette && window.Baguette._CaptureComposer;
     if (!source || !Composer) return null;
     const natural = Composer.compositeSize(source.frameImg, source.screen, source.canvas);
-    const scale = compositeScale(source);
+    const scale = compositeScale(source, natural);
     return {
       width: Math.round(natural.width * scale),
       height: Math.round(natural.height * scale),
@@ -1707,7 +1766,7 @@
 
     const natural = Composer.compositeSize(source.frameImg, source.screen, source.canvas);
     if (!natural.width || !natural.height) return;
-    const scale = compositeScale(source);
+    const scale = compositeScale(source, natural);
     const plan = settings.plan(natural.width * scale, natural.height * scale);
     if (!plan.width || !plan.height) return;
 
@@ -1768,6 +1827,9 @@
       rec.start();
       recordingState.recorder = rec;
       recordingState.active = true;
+      // Last take's "discarded" line is stale the moment a new one runs.
+      recordingState.notice = '';
+      renderRecordings();
       recordingState.startedAt = Date.now();
       if (recordingState.timer) clearInterval(recordingState.timer);
       recordingState.timer = setInterval(updateRecordButton, 250);
@@ -1791,13 +1853,15 @@
     try {
       const artifact = await rec.stop();
       if (!artifact || typeof artifact.url !== 'string') return;
-      // Name it after the device and the picked size, the way the
-      // screenshot is — BrowserRecorder only knows a timestamp.
-      const settings = captureSettings();
+      // Name it after the device, the way the screenshot is —
+      // BrowserRecorder only knows a timestamp. Deliberately WITHOUT a
+      // size slug: the recorder sizes its own compose canvas, so
+      // stamping the picked size into the name would be a claim about
+      // bytes we didn't produce.
       const ext = (artifact.filename || '').split('.').pop() || 'webm';
-      const slug = settings ? `-${settings.size.spec}` : '';
-      artifact.filename = `${deviceSlug()}-${captureStamp()}${slug}.${ext}`;
+      artifact.filename = `${deviceSlug()}-${captureStamp()}.${ext}`;
       recordingState.entries.unshift(artifact);
+      recordingState.notice = '';
       renderRecordings();
     } catch (err) {
       console.warn('[native] recording failed to stop:', err);
@@ -1818,6 +1882,12 @@
     resetRecordingState();
     updateRecordButton();
     console.log('[native] recording cancelled:', reason);
+    // Say so where the file would have appeared. A format-pill click is
+    // one pixel from the record button and throws the take away; a
+    // button that just stops looking pressed reads as "the click didn't
+    // register", not "your recording is gone".
+    recordingState.notice = `Recording discarded — ${reason}.`;
+    renderRecordings();
   }
 
   function resetRecordingState() {
@@ -1854,12 +1924,15 @@
     const dock = document.getElementById('nativeRecordDock');
     const list = document.getElementById('nativeRecordList');
     if (!dock || !list) return;
-    if (!recordingState.entries.length) {
+    if (!recordingState.entries.length && !recordingState.notice) {
       dock.removeAttribute('data-open');
       list.innerHTML = '';
       return;
     }
-    list.innerHTML = recordingState.entries.map((e) => `
+    const notice = recordingState.notice
+      ? `<p class="rec-note">${escapeAttribute(recordingState.notice)}</p>`
+      : '';
+    list.innerHTML = notice + recordingState.entries.map((e) => `
       <a href="${e.url}" download="${escapeAttribute(e.filename)}"
          title="Download ${escapeAttribute(e.filename)}">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -1876,12 +1949,23 @@
   /// Empty the dock and hand every Blob back to the browser. A recorded
   /// minute is tens of megabytes held live by its URL; a session that
   /// records all afternoon and never revokes keeps every one of them.
+  /// Destructive and unrecoverable, which is why its control is a
+  /// labelled "Clear" and not the ✕ beside it.
   function clearRecordings() {
     recordingState.entries.forEach((e) => {
       if (e.url && e.url.startsWith('blob:')) URL.revokeObjectURL(e.url);
     });
     recordingState.entries = [];
+    recordingState.notice = '';
     renderRecordings();
+  }
+
+  /// Put the dock away without touching what's in it. Reopens itself
+  /// the next time a recording lands.
+  function hideRecordings() {
+    recordingState.notice = '';
+    const dock = document.getElementById('nativeRecordDock');
+    if (dock) dock.removeAttribute('data-open');
   }
 
   function formatElapsed(seconds) {

--- a/Tests/Web/sim-native-style.test.js
+++ b/Tests/Web/sim-native-style.test.js
@@ -155,3 +155,97 @@ test('the focus-mode stylesheet reads no token from outside the --nv-* set', () 
     'change for dark mode — use the --nv-* equivalent'
   );
 });
+
+// ── Capture surface ──────────────────────────────────────────────
+// Focus mode is the screen people actually capture from, so the
+// output-size picker and the Record button have to be reachable there.
+// Both are wired the way every other control in this toolbar is —
+// markup in sim-native.html, a `window.__nativeXxx` indirection in
+// sim-native.js — and both are easy to half-land (a button with no
+// handler, a handler with no button). These pin the pairing.
+
+const SCRIPT = path.join(path.dirname(TEMPLATE), 'sim-native.js');
+
+/** The `#simNativeView` markup, with the `<style>` blocks taken out. */
+function markup(html) {
+  return html.replace(/<style[^>]*>[\s\S]*?<\/style>/g, '');
+}
+
+test('the toolbar mounts the capture-size picker', () => {
+  const html = markup(fs.readFileSync(TEMPLATE, 'utf8'));
+  assert.match(
+    html, /id="nativeCaptureSize"/,
+    'CaptureSizeMenu needs a host element in the toolbar to mount into'
+  );
+});
+
+test('the capture-size host sits outside the scrolling icon strip', () => {
+  const html = markup(fs.readFileSync(TEMPLATE, 'utf8'));
+  const strip =
+    /<div class="tb-scroll" id="nativeToolScroll">([\s\S]*?)<!-- \/\.tb-scroll -->/
+      .exec(html);
+  assert.ok(strip, 'the icon strip is no longer delimited as expected');
+  assert.ok(
+    !/id="nativeCaptureSize"/.test(strip[1]),
+    'the strip is an `overflow-x: auto` container, so a popover mounted ' +
+    'inside it is clipped at the strip\'s edge'
+  );
+});
+
+test('the toolbar carries a Record button wired to __nativeRecord', () => {
+  const html = markup(fs.readFileSync(TEMPLATE, 'utf8'));
+  const button = /<button[^>]*id="nativeRecordBtn"[\s\S]*?<\/button>/.exec(html);
+  assert.ok(button, 'no #nativeRecordBtn in the toolbar');
+  assert.match(button[0], /window\.__nativeRecord/);
+  assert.match(button[0], /aria-label=/);
+  assert.match(button[0], /class="ico-btn/);
+});
+
+test('the Record button lives in the action group beside Screenshot', () => {
+  const html = markup(fs.readFileSync(TEMPLATE, 'utf8'));
+  const actions =
+    /<div class="tb-actions">([\s\S]*?)<!-- \/\.tb-scroll -->/.exec(html);
+  assert.ok(actions, 'the .tb-actions group is no longer delimited as expected');
+  assert.match(actions[1], /id="nativeRecordBtn"/);
+  assert.match(actions[1], /__nativeScreenshot/);
+});
+
+test('the recording state is styled from the focus-mode palette', () => {
+  const css = styleBlocks(fs.readFileSync(TEMPLATE, 'utf8'));
+  assert.match(
+    css, /#nativeRecordBtn\.recording/,
+    'a recording with no visible affordance is a recording the user ' +
+    'forgets is running'
+  );
+});
+
+test('sim-native.js loads the capture vocabulary and the recorder', () => {
+  const src = fs.readFileSync(SCRIPT, 'utf8');
+  for (const module of [
+    '/capture/capture-size.js',
+    '/capture/capture-settings.js',
+    '/capture/capture-composer.js',
+    '/capture/capture-size-menu.js',
+    '/recorder.js',
+  ]) {
+    assert.ok(
+      src.includes(module),
+      `${module} is never loaded — focus mode can't reach it, because ` +
+      'the template\'s own <script> tags are dropped by fetchTemplate'
+    );
+  }
+});
+
+test('sim-native.js answers every toolbar indirection the template calls', () => {
+  const html = markup(fs.readFileSync(TEMPLATE, 'utf8'));
+  const src = fs.readFileSync(SCRIPT, 'utf8');
+  const called = new Set(
+    [...html.matchAll(/window\.(__native[A-Za-z0-9]+)/g)].map((m) => m[1])
+  );
+  const missing = [...called].filter((name) => !src.includes(`window.${name} =`));
+  assert.deepEqual(
+    missing, [],
+    'the template calls these but sim-native.js never assigns them, so ' +
+    'the button is inert'
+  );
+});


### PR DESCRIPTION
Unit 3 of the capture-size feature: the focus-mode toolbar at
`/simulators/<udid>` — the screen people actually capture from.

Before this it could do exactly one thing: dump the raw canvas as a PNG.
No bezel, no choice of size, and no way to record at all.

## What's here

- **A size chip** (`CaptureSizeMenu`, `asc.capture.native`) at the right
  end of the toolbar. Mounted *outside* `#nativeToolScroll` on purpose —
  that strip is an `overflow-x: auto` container and would clip the
  popover — and its generic tokens are bound to the `--nv-*` palette on
  the host so chip and popover follow the theme.
- **Screenshot honours it.** Composes through `CaptureComposer` at the
  picked size, bezel underneath when the picker says so, filename
  `<device>-<stamp>-<settings.slug(w,h)>.png`.
- **A Record button** beside Screenshot: `BrowserRecorder` over the
  active canvas, red with a pulsing glyph and an elapsed `mm:ss` readout
  while running, hidden outright where `MediaRecorder` doesn't exist.
  Finished takes land in a small Recordings dock; its Blob URLs are
  revoked on Clear and on unload.
- **Both work in 2D and 3D.** 3D is bezel-less (the render already
  carries the device body) and hides the bezel / fit / background
  controls, per unit 4's contract — on `render-3d.png`, `fit` is the UV
  placement of the screenshot on the screen mesh, not canvas placement.
  An in-flight recording is cancelled when the mode flips, the stream
  restarts, or the page unloads, and the dock says why.

## Two decisions worth a look

**The composite is supersampled.** The bezel art is authored at layout
scale (474 × 990 for an iPhone 17 Pro Max) while the live canvas carries
the full 1290 × 2796 framebuffer, so compositing at the bezel's own size
resamples the screen down ~3x before the picked size ever sees it. The
composite is grown until the screen cutout is 1:1 with the arriving
frames — soft chrome around a sharp screen beats a sharp frame around a
thumbnail. It falls back to 1x whenever `compositeSize` reports the
framebuffer rather than the viewport (bezel not yet decoded, or 404'd).

**Recordings carry no size slug in their filename.** `BrowserRecorder`
sizes its own compose canvas from `composeSize(...)`, so a recording is
currently the bezel composite's size regardless of the chip. The settings
value is passed through to the recorder for whenever it learns to size
itself; until then, naming the file after a size this page didn't produce
would be a lie. Flagging for unit 1.

## Scripts are loaded at runtime, not with a `<script>` tag

`sim.html` owns this page's script tags and `fetchTemplate` deliberately
drops the ones inside `sim-native.html`, so the four capture modules are
pulled in from `sim-native.js`. The guard is the global each module hangs
itself on, so nothing double-loads if another page already brought it in.

## Review round

`/code-review high` found six things, all fixed in `eadbb93c`: the
supersample gate above, the recording filename, a `captureSettings()`
guard that checked one global but dereferenced two, a cancellation that
was console-only, a dock ✕ that revoked Blob URLs (now split into
"Clear" and dismiss), and `.top-bar`'s `backdrop-filter` stacking context
burying the popover under the floating cards and the rotated device.

## Verified end to end

Chrome against a booted iPhone 17 Pro Max (iOS 26.4), both themes:

- Toolbar reads `… Home · Screenshot · Record · App switcher · Shake ·
  [Native ⌄]`; the Record glyph matches the existing icon weight
  (`stroke-width="1.6"`, 17×17) and the chip sits at 28px to match the
  icon buttons.
- Popover shows resolved pixels per preset (`Native 1428×2984`,
  `Square 2984×2984`, …) — that's the supersample in effect.
- Picked Square, hit Screenshot: file is
  `iPhone_17_Pro_Max-…-square-2984x2984.png`, genuinely 2984 × 2984,
  phone centred on white with the bezel composited.
- Recorded ~20 s in 2D: button goes red with `00:04` ticking, dock opens
  with `00:24 · 653 KB`.
- Toggled 3D (needs `BAGUETTE_3D_MODEL_DIR`): popover drops the Fit /
  Background / Include-bezel rows and reports the 3D canvas
  (`Native 1084×832`). Screenshot gives a square 1084 × 1084 render with
  no double bezel; Record produces a 251 KB artifact.
- Switching 2D↔3D mid-recording cancels it and the dock shows
  "Recording discarded — switched between 2D and 3D." with the earlier
  take intact.
- Dark mode: popover paints on the dark panel with the right text and
  accent, and sits above the device — the stacking fix.
- Console clean apart from a pre-existing `/favicon.ico` 404 and headless
  Chromium's H.264 decoder notes.

`make test-web`: 230 pass. `Tests/Web/touch-gesture-source.test.js` has
one failure that reproduces on a clean `origin/main` checkout — not from
this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
