### PR TITLE
feat: sized screenshots, PNG output, and a server-side bezel composite

### DIFF
--- a/Sources/Baguette/Infrastructure/Server/Server.swift
+++ b/Sources/Baguette/Infrastructure/Server/Server.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import HTTPTypes
 import Hummingbird
@@ -25,7 +26,10 @@ import NIOCore
 ///   GET  /simulators/:udid/chrome.json      → chrome layout JSON
 ///   GET  /simulators/:udid/bezel.png        → composite PNG
 ///   POST /simulators/:udid/input            → gesture     (TODO)
-///   GET  /simulators/:udid/screenshot.jpg   → JPEG (?quality=&scale=)
+///   GET  /simulators/:udid/screenshot.jpg   → JPEG (?quality=&scale=&size=&fit=&background=)
+///   GET  /simulators/:udid/screenshot.png   → PNG  (same query knobs)
+///   GET  /simulators/:udid/screenshot-bezel.png → PNG composited into the
+///                                             device chrome (+ ?buttons=)
 ///   WS   /simulators/:udid/stream?format=   → frames      (TODO)
 ///   WS   /simulators/:udid/stream.3d.:format → live 3D AVCC/MJPEG frames
 ///   GET  /<file>.{html,js,css}              → static UI asset
@@ -411,16 +415,66 @@ struct Server: Sendable {
             )
         }
 
-        // One-shot JPEG of the current framebuffer. Spins up Screen,
+        // One-shot still of the current framebuffer. Spins up Screen,
         // awaits one IOSurface, encodes, and tears down — `?quality=`
-        // and `?scale=` mirror the WS stream knobs for parity.
-        router.get("/simulators/:udid/screenshot.jpg") { [simulators] r, _ in
+        // and `?scale=` mirror the WS stream knobs for parity, while
+        // `?size=` / `?fit=` / `?background=` speak the shared capture
+        // vocabulary (`CaptureSize`) so "App Store 6.9" means the same
+        // pixels here, in the toolbar picker, and on the CLI.
+        //
+        // Two extensions, one handler. A browser picks its decoder off
+        // the URL extension and nothing else, so `.png` has to be its
+        // own route rather than a `?format=` knob hung off `.jpg` —
+        // that's the entire reason the second registration exists.
+        for format in Self.CaptureImageFormat.allCases {
+            router.get("/simulators/:udid/screenshot.\(format.pathExtension)") {
+                [simulators] r, _ in
+                if let rejected = rejectUntrustedBrowser(r) { return rejected }
+                let options: Self.CaptureOptions
+                do {
+                    options = try Self.captureOptions(query: r)
+                } catch let error as Self.CaptureQueryError {
+                    return errorJSON(error.message, status: .badRequest)
+                }
+                return await Self.screenshot(
+                    udid: Self.udidParam(r),
+                    quality: r.uri.queryParameters.get("quality").flatMap(Double.init)
+                        ?? format.defaultQuality,
+                    scale: r.uri.queryParameters.get("scale").flatMap(Int.init) ?? 1,
+                    format: format,
+                    options: options,
+                    simulators: simulators
+                )
+            }
+        }
+
+        // The same still, composited into the device's DeviceKit
+        // chrome server-side. `bezel.png` + the framebuffer layered in
+        // CSS is what the browser does; this route exists for everyone
+        // who isn't a browser — `curl` in a marketing script, a CI job
+        // producing App Store shots, the device-farm wall's own
+        // thumbnails. `?buttons=` matches `bezel.png`'s bare/rest
+        // variants; `?size=` / `?fit=` / `?background=` are the same
+        // knobs as the bare screenshot, applied to the composite.
+        router.get("/simulators/:udid/screenshot-bezel.png") {
+            [simulators, chromes] r, _ in
             if let rejected = rejectUntrustedBrowser(r) { return rejected }
-            return await Self.screenshotJPEG(
+            let options: Self.CaptureOptions
+            do {
+                options = try Self.captureOptions(query: r)
+            } catch let error as Self.CaptureQueryError {
+                return errorJSON(error.message, status: .badRequest)
+            }
+            return await Self.screenshotBezelPNG(
                 udid: Self.udidParam(r),
-                quality: r.uri.queryParameters.get("quality").flatMap(Double.init) ?? 0.85,
+                quality: r.uri.queryParameters.get("quality").flatMap(Double.init)
+                    ?? Self.CaptureImageFormat.png.defaultQuality,
                 scale: r.uri.queryParameters.get("scale").flatMap(Int.init) ?? 1,
-                simulators: simulators
+                withButtons: r.uri.queryParameters.get("buttons")
+                    .map { $0.lowercased() != "false" } ?? true,
+                options: options,
+                simulators: simulators,
+                chromes: chromes
             )
         }
 
@@ -1381,29 +1435,509 @@ struct Server: Sendable {
         return RenderDimensions(width: width, height: height)
     }
 
-    private static func screenshotJPEG(
+    // MARK: - sized captures
+
+    /// The encodings the screenshot routes serve. `jpeg` is what
+    /// `ScreenSnapshot` already hands back, so it stays the source
+    /// format everything else is measured against.
+    enum CaptureImageFormat: String, Sendable, Equatable, CaseIterable {
+        case jpeg
+        case png
+
+        /// What the URL ends in. `.jpg`, not `.jpeg` — that's the
+        /// extension the route has always published and the one every
+        /// `<img src>` in the tree already points at.
+        var pathExtension: String {
+            switch self {
+            case .jpeg: return "jpg"
+            case .png:  return "png"
+            }
+        }
+
+        var contentType: String {
+            switch self {
+            case .jpeg: return "image/jpeg"
+            case .png:  return "image/png"
+            }
+        }
+
+        /// Uniform type identifier for `CGImageDestination`.
+        var utType: String {
+            switch self {
+            case .jpeg: return "public.jpeg"
+            case .png:  return "public.png"
+            }
+        }
+
+        /// What `?quality=` defaults to on a route serving this format.
+        ///
+        /// `0.85` for JPEG is the historical default, shared with the
+        /// CLI. PNG asks for `1.0` instead because `ScreenSnapshot`
+        /// only ever hands back JPEG: a PNG still is a JPEG round-trip
+        /// whether the caller wanted one or not, and capturing at
+        /// full quality is what keeps that intermediate from showing
+        /// up as ringing in something the extension promises is
+        /// lossless. It is still not bit-exact — see
+        /// `docs/features/screenshot.md`.
+        var defaultQuality: Double {
+            switch self {
+            case .jpeg: return 0.85
+            case .png:  return 1.0
+            }
+        }
+    }
+
+    /// The `?size=&fit=&background=` trio every capture route accepts —
+    /// the HTTP spelling of the vocabulary `CaptureSize` defines, the
+    /// toolbar picker speaks, and `baguette screenshot --size` parses.
+    /// One value so the routes can't drift apart on defaults.
+    ///
+    /// **`fit` here is `CaptureFit`, NOT `DeviceScreenFit`.** The two
+    /// enums sit a few hundred lines apart in this file, spell the
+    /// same three cases (`contain` / `cover` / `stretch`), and mean
+    /// entirely different things: `CaptureFit` places the source
+    /// image inside the output *canvas*; `DeviceScreenFit` (the
+    /// `render-3d.png` body) places the app screenshot onto the 3D
+    /// device's screen *mesh*. They are not interchangeable and must
+    /// not be merged.
+    struct CaptureOptions: Equatable, Sendable {
+        let size: CaptureSize
+        let fit: CaptureFit
+        let background: DeviceRenderBackground
+
+        /// Today's behaviour, exactly: whatever the framebuffer
+        /// already is. `contain` and the white mat only ever show up
+        /// once a non-native size is asked for, so the default plan is
+        /// an identity by construction and the original bytes survive.
+        static let `default` = CaptureOptions(
+            size: .native, fit: .contain, background: .color("#ffffff")
+        )
+    }
+
+    /// A query value baguette refuses to guess at. Rejecting beats
+    /// substituting: a marketing shot silently served at the wrong
+    /// size is worse than a 400 the caller can read.
+    enum CaptureQueryError: Error, Equatable {
+        case unknownSize(String)
+        case unknownFit(String)
+        case unknownBackground(String)
+
+        var message: String {
+            switch self {
+            case .unknownSize(let spec):
+                // Reuse the domain's wording so the CLI, the browser,
+                // and the route all name the same catalogue.
+                return CaptureSizeError.unknownSize(spec).message
+            case .unknownFit(let spec):
+                return "Unknown fit '\(spec)'. Expected one of: "
+                    + CaptureFit.allCases.map(\.rawValue).joined(separator: " | ")
+            case .unknownBackground(let spec):
+                return "Unknown background '\(spec)'. Expected 'transparent' or #RRGGBB"
+            }
+        }
+    }
+
+    /// Lift `?size=` / `?fit=` / `?background=` off a request. Kept
+    /// separate from the string-taking overload below so the route
+    /// closures stay one-liners and the parsing stays unit-testable
+    /// without a `Request`.
+    ///
+    /// No `removingPercentEncoding` here — Hummingbird's `URI` already
+    /// percent-decodes query values, and decoding twice turns a value
+    /// containing a literal `%` into `nil`, which would silently fall
+    /// back to the default instead of the 400 this surface promises.
+    static func captureOptions(query request: Request) throws -> CaptureOptions {
+        func value(_ key: String) -> String? {
+            request.uri.queryParameters.get(key)
+        }
+        return try captureOptions(
+            size: value("size"), fit: value("fit"), background: value("background")
+        )
+    }
+
+    static func captureOptions(
+        size: String?,
+        fit: String?,
+        background: String?
+    ) throws -> CaptureOptions {
+        let resolvedSize: CaptureSize
+        if let size, !size.isEmpty {
+            guard let parsed = try? CaptureSize.parse(size) else {
+                throw CaptureQueryError.unknownSize(size)
+            }
+            resolvedSize = parsed
+        } else {
+            resolvedSize = .native
+        }
+
+        let resolvedFit: CaptureFit
+        if let fit, !fit.isEmpty {
+            guard let parsed = CaptureFit(rawValue: fit.lowercased()) else {
+                throw CaptureQueryError.unknownFit(fit)
+            }
+            resolvedFit = parsed
+        } else {
+            resolvedFit = .contain
+        }
+
+        return CaptureOptions(
+            size: resolvedSize,
+            fit: resolvedFit,
+            background: try captureBackground(background)
+        )
+    }
+
+    private static func captureBackground(
+        _ raw: String?
+    ) throws -> DeviceRenderBackground {
+        guard let raw, !raw.isEmpty else { return .color("#ffffff") }
+        let text = raw.trimmingCharacters(in: .whitespaces).lowercased()
+        if text == "transparent" { return .transparent }
+        // A literal `#` opens the fragment in a URL, so a hand-written
+        // `curl '…?background=#ffffff'` never delivers the hash to us.
+        // Accept both spellings and normalise to the `#RRGGBB` the
+        // render layer already speaks.
+        let digits = text.hasPrefix("#") ? String(text.dropFirst()) : text
+        guard digits.count == 6,
+              digits.allSatisfy({ $0.isASCII && $0.isHexDigit }) else {
+            throw CaptureQueryError.unknownBackground(raw)
+        }
+        return .color("#\(digits)")
+    }
+
+    /// What happened to the captured bytes on the way out.
+    enum CaptureOutcome: Equatable {
+        /// The capture already is what was asked for. The route hands
+        /// the bytes straight through, so the default `screenshot.jpg`
+        /// stays byte-for-byte what it has always been.
+        case unchanged
+        case encoded(Data)
+        case failed
+    }
+
+    /// Re-encode a captured framebuffer onto the canvas `options` asks
+    /// for.
+    ///
+    /// NOTE: the resize lives here rather than inside
+    /// `ScreenSnapshot.capture` deliberately — `--size` is landing on
+    /// that helper in parallel, and this route surface has to be
+    /// mergeable on its own. Once the capture helper carries the same
+    /// knobs, this collapses into it and the duplication goes away.
+    static func recapture(
+        _ image: Data,
+        sourceFormat: CaptureImageFormat,
+        format: CaptureImageFormat,
+        options: CaptureOptions,
+        quality: Double
+    ) -> CaptureOutcome {
+        if sourceFormat == format, options.size.isNative {
+            return .unchanged
+        }
+        guard let source = decodeImage(image),
+              let bytes = encodeCapture(
+                  source, options: options, format: format, quality: quality
+              ) else {
+            return .failed
+        }
+        return .encoded(bytes)
+    }
+
+    /// Where the framebuffer lands inside a rasterized bezel.
+    ///
+    /// The geometry is `DeviceChrome`'s, read through the same
+    /// `buttonMargins` shift `DeviceChromeAssets.layoutJSON` publishes
+    /// to the browser — server-side and browser-side composites have
+    /// to agree on the cutout, or the two renderings of one device
+    /// stop matching.
+    struct BezelPlacement: Equatable, Sendable {
+        let bezel: ChromeImage
+        let screen: Rect
+        let cornerRadius: Double
+    }
+
+    static func bezelPlacement(
+        assets: DeviceChromeAssets,
+        withButtons: Bool
+    ) -> BezelPlacement {
+        // `chrome.screenInsets` are measured against the *bare* device
+        // body; the merged canvas grew by `buttonMargins` around it,
+        // so only the merged variant shifts.
+        let base = assets.chrome.screenRect(in: assets.bareComposite.size)
+        let offset = withButtons
+            ? Point(x: assets.buttonMargins.left, y: assets.buttonMargins.top)
+            : Point(x: 0, y: 0)
+        return BezelPlacement(
+            bezel: withButtons ? assets.composite : assets.bareComposite,
+            screen: Rect(
+                origin: Point(
+                    x: base.origin.x + offset.x,
+                    y: base.origin.y + offset.y
+                ),
+                size: base.size
+            ),
+            cornerRadius: assets.chrome.innerCornerRadius
+        )
+    }
+
+    /// Composite the framebuffer into the device's chrome: bezel
+    /// underneath, screen on top, clipped to the screen's inner corner
+    /// radius.
+    ///
+    /// The Z-order is not a preference. Apple's DeviceKit composite
+    /// paints an opaque dark "off glass" into the screen cutout,
+    /// authored to sit UNDER live content — draw the screen first and
+    /// the off-glass buries it.
+    ///
+    /// Always PNG: the device body has transparent corners and the
+    /// mat around it may be transparent too.
+    static func bezelCapture(
+        screenImage: Data,
+        assets: DeviceChromeAssets,
+        withButtons: Bool,
+        options: CaptureOptions
+    ) -> Data? {
+        let placement = bezelPlacement(assets: assets, withButtons: withButtons)
+        guard placement.screen.size.width > 0, placement.screen.size.height > 0,
+              let bezel = decodeImage(placement.bezel.data),
+              let screen = decodeImage(screenImage) else {
+            return nil
+        }
+        // DeviceKit chrome geometry is in 1× points; the framebuffer
+        // arrives in device pixels (a 6.9" phone captures ~1290 px
+        // into a ~430 pt cutout). Compositing at the chrome's own
+        // scale would throw that 3× away before `?size=` upscales the
+        // remains back — exactly the App Store case this route exists
+        // for. So the canvas is sized off the *framebuffer*, and the
+        // chrome is what gets resampled. Never below 1×: a heavily
+        // `?scale=`d capture must not shrink the bezel with it.
+        let scale = max(1, Double(screen.width) / placement.screen.size.width)
+        let width = Int((placement.bezel.size.width * scale).rounded())
+        let height = Int((placement.bezel.size.height * scale).rounded())
+        guard width > 0, height > 0,
+              let context = bitmapContext(width: width, height: height) else {
+            return nil
+        }
+        context.interpolationQuality = .high
+        context.draw(bezel, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        // CoreGraphics is bottom-up; chrome geometry is top-left.
+        let cutout = CGRect(
+            x: placement.screen.origin.x * scale,
+            y: Double(height)
+                - (placement.screen.origin.y + placement.screen.size.height) * scale,
+            width: placement.screen.size.width * scale,
+            height: placement.screen.size.height * scale
+        )
+        context.saveGState()
+        // The corner radius is chrome geometry too, so it rides the
+        // same scale as the cutout it rounds.
+        let radius = placement.cornerRadius * scale
+        context.addPath(CGPath(
+            roundedRect: cutout,
+            cornerWidth: min(radius, cutout.width / 2),
+            cornerHeight: min(radius, cutout.height / 2),
+            transform: nil
+        ))
+        context.clip()
+        // Cover-fit inside the cutout via the same placement maths the
+        // rest of the vocabulary uses, so a framebuffer whose aspect
+        // doesn't match the chrome (rotated device, odd `?scale=`)
+        // crops instead of distorting.
+        let inner = CaptureSize(
+            spec: "cutout",
+            label: "cutout",
+            kind: .fixed(RenderDimensions(
+                width: Int(cutout.width.rounded()),
+                height: Int(cutout.height.rounded())
+            ))
+        ).plan(
+            source: RenderDimensions(width: screen.width, height: screen.height),
+            fit: .cover
+        )
+        context.draw(screen, in: CGRect(
+            x: cutout.minX + Double(inner.drawX),
+            y: cutout.maxY - Double(inner.drawY) - Double(inner.drawHeight),
+            width: Double(inner.drawWidth),
+            height: Double(inner.drawHeight)
+        ))
+        context.restoreGState()
+
+        guard let composed = context.makeImage() else { return nil }
+        return encodeCapture(composed, options: options, format: .png, quality: 1)
+    }
+
+    private static func decodeImage(_ data: Data) -> CGImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            return nil
+        }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    /// Redraw `source` onto the canvas `options` asks for, then encode.
+    /// The placement maths belongs to `CapturePlacement` — shared with
+    /// the browser composer and the CLI so one size means one thing.
+    private static func encodeCapture(
+        _ source: CGImage,
+        options: CaptureOptions,
+        format: CaptureImageFormat,
+        quality: Double
+    ) -> Data? {
+        let sourceSize = RenderDimensions(width: source.width, height: source.height)
+        let placement = options.size.plan(source: sourceSize, fit: options.fit)
+        guard placement.width > 0, placement.height > 0 else { return nil }
+        let image: CGImage
+        if placement.isIdentity(for: sourceSize) {
+            image = source
+        } else {
+            // JPEG carries no alpha, so an un-matted transparent
+            // canvas flattens to *black* on encode — a mat nobody
+            // asked for. Fall back to the white default rather than
+            // shipping a black-bordered marketing shot.
+            let background: DeviceRenderBackground =
+                (format == .jpeg && options.background == .transparent)
+                    ? .color("#ffffff")
+                    : options.background
+            guard let drawn = draw(
+                source, into: placement, background: background
+            ) else { return nil }
+            image = drawn
+        }
+        return encode(image, format: format, quality: quality)
+    }
+
+    private static func draw(
+        _ source: CGImage,
+        into placement: CapturePlacement,
+        background: DeviceRenderBackground
+    ) -> CGImage? {
+        guard let context = bitmapContext(
+            width: placement.width, height: placement.height
+        ) else { return nil }
+        if case .color(let hex) = background {
+            let color = HexColor(hex)
+            context.setFillColor(
+                red: color.red, green: color.green, blue: color.blue, alpha: 1
+            )
+            context.fill(CGRect(
+                x: 0, y: 0, width: placement.width, height: placement.height
+            ))
+        }
+        context.interpolationQuality = .high
+        // `CapturePlacement` is top-left origin; CoreGraphics is not.
+        context.draw(source, in: CGRect(
+            x: placement.drawX,
+            y: placement.height - placement.drawY - placement.drawHeight,
+            width: placement.drawWidth,
+            height: placement.drawHeight
+        ))
+        return context.makeImage()
+    }
+
+    private static func bitmapContext(width: Int, height: Int) -> CGContext? {
+        CGContext(
+            data: nil, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                | CGBitmapInfo.byteOrder32Little.rawValue
+        )
+    }
+
+    private static func encode(
+        _ image: CGImage,
+        format: CaptureImageFormat,
+        quality: Double
+    ) -> Data? {
+        let out = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            out, format.utType as CFString, 1, nil
+        ) else { return nil }
+        let properties: CFDictionary? = format == .jpeg
+            ? [kCGImageDestinationLossyCompressionQuality: quality] as CFDictionary
+            : nil
+        CGImageDestinationAddImage(destination, image, properties)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return out as Data
+    }
+
+    private static func screenshot(
         udid: String,
         quality: Double,
         scale: Int,
+        format: CaptureImageFormat,
+        options: CaptureOptions,
         simulators: any Simulators
     ) async -> Response {
         guard !udid.isEmpty, let sim = simulators.find(udid: udid) else {
             return errorJSON("unknown udid: \(udid)", status: .notFound)
         }
+        let captured: Data
         do {
-            let bytes = try await ScreenSnapshot.capture(
+            captured = try await ScreenSnapshot.capture(
                 screen: sim.screen(),
                 quality: quality,
                 scale: max(1, scale)
             )
-            return Response(
-                status: .ok,
-                headers: [.contentType: "image/jpeg", .cacheControl: "no-cache"],
-                body: .init(byteBuffer: ByteBuffer(data: bytes))
+        } catch {
+            return errorJSON(String(describing: error), status: .internalServerError)
+        }
+        let bytes: Data
+        switch recapture(
+            captured, sourceFormat: .jpeg, format: format,
+            options: options, quality: quality
+        ) {
+        case .unchanged:
+            bytes = captured
+        case .encoded(let encoded):
+            bytes = encoded
+        case .failed:
+            return errorJSON("capture encoding failed", status: .internalServerError)
+        }
+        return Response(
+            status: .ok,
+            headers: [.contentType: format.contentType, .cacheControl: "no-cache"],
+            body: .init(byteBuffer: ByteBuffer(data: bytes))
+        )
+    }
+
+    private static func screenshotBezelPNG(
+        udid: String,
+        quality: Double,
+        scale: Int,
+        withButtons: Bool,
+        options: CaptureOptions,
+        simulators: any Simulators,
+        chromes: any Chromes
+    ) async -> Response {
+        guard !udid.isEmpty, let sim = simulators.find(udid: udid) else {
+            return errorJSON("unknown udid: \(udid)", status: .notFound)
+        }
+        guard let assets = sim.chrome(in: chromes) else {
+            return errorJSON("no bezel for udid \(udid)", status: .notFound)
+        }
+        let captured: Data
+        do {
+            captured = try await ScreenSnapshot.capture(
+                screen: sim.screen(),
+                quality: quality,
+                scale: max(1, scale)
             )
         } catch {
             return errorJSON(String(describing: error), status: .internalServerError)
         }
+        guard let bytes = bezelCapture(
+            screenImage: captured,
+            assets: assets,
+            withButtons: withButtons,
+            options: options
+        ) else {
+            return errorJSON("bezel composite failed", status: .internalServerError)
+        }
+        return Response(
+            status: .ok,
+            headers: [.contentType: "image/png", .cacheControl: "no-cache"],
+            body: .init(byteBuffer: ByteBuffer(data: bytes))
+        )
     }
 
     private static func bezelPNG(

--- a/Tests/BaguetteTests/Server/ScreenshotRouteTests.swift
+++ b/Tests/BaguetteTests/Server/ScreenshotRouteTests.swift
@@ -1,0 +1,361 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Mockable
+import Testing
+@testable import Baguette
+
+/// Handler-level tests for the sized screenshot routes.
+///
+/// Same split as `BezelRoutesTests`: we drive the *internal* helpers
+/// that turn a query string into a `CaptureOptions`, re-encode a
+/// captured framebuffer onto the canvas the user asked for, and
+/// composite the DeviceKit bezel around it — never the Hummingbird
+/// `Response` builders that wrap them. No booted simulator is needed;
+/// the "framebuffer" is a solid-colour bitmap this suite renders.
+@Suite("Server sized screenshot routes")
+struct ScreenshotRouteTests {
+
+    // MARK: - ?size= / ?fit= / ?background=
+
+    @Test func `a screenshot with no knobs set is the native framebuffer on a white mat`() throws {
+        let options = try Server.captureOptions(size: nil, fit: nil, background: nil)
+
+        #expect(options.size == CaptureSize.native)
+        #expect(options.fit == .contain)
+        #expect(options.background == .color("#ffffff"))
+    }
+
+    @Test func `a screenshot resolves an App Store preset by the name the picker shows`() throws {
+        let options = try Server.captureOptions(
+            size: "appstore-6.9", fit: "cover", background: "transparent"
+        )
+
+        #expect(options.size.kind == .fixed(RenderDimensions(width: 1290, height: 2796)))
+        #expect(options.fit == .cover)
+        #expect(options.background == .transparent)
+    }
+
+    @Test func `a screenshot rejects a size baguette doesn't know rather than falling back to native`() {
+        #expect(throws: Server.CaptureQueryError.unknownSize("nonsense")) {
+            _ = try Server.captureOptions(size: "nonsense", fit: nil, background: nil)
+        }
+        #expect(
+            Server.CaptureQueryError.unknownSize("nonsense").message
+                == CaptureSizeError.unknownSize("nonsense").message
+        )
+    }
+
+    @Test func `a screenshot rejects a fit baguette doesn't know`() {
+        #expect(throws: Server.CaptureQueryError.unknownFit("squish")) {
+            _ = try Server.captureOptions(size: "square", fit: "squish", background: nil)
+        }
+        #expect(
+            Server.CaptureQueryError.unknownFit("squish").message.contains("contain")
+        )
+    }
+
+    @Test func `a screenshot accepts a hash-less hex background because a URL eats the hash`() throws {
+        let bare = try Server.captureOptions(size: nil, fit: nil, background: "ff8800")
+        let hashed = try Server.captureOptions(size: nil, fit: nil, background: "#ff8800")
+
+        #expect(bare.background == .color("#ff8800"))
+        #expect(hashed.background == .color("#ff8800"))
+    }
+
+    @Test func `a screenshot rejects a background that isn't a colour`() {
+        #expect(throws: Server.CaptureQueryError.unknownBackground("chartreuse")) {
+            _ = try Server.captureOptions(size: nil, fit: nil, background: "chartreuse")
+        }
+    }
+
+    // MARK: - re-encoding the framebuffer
+
+    @Test func `a native jpeg screenshot hands back the captured bytes untouched`() throws {
+        let captured = Self.solid(width: 100, height: 200, rgb: (1, 0, 0), format: .jpeg)
+
+        let outcome = Server.recapture(
+            captured, sourceFormat: .jpeg, format: .jpeg,
+            options: .default, quality: 0.85
+        )
+
+        #expect(outcome == .unchanged)
+    }
+
+    @Test func `an App Store preset comes out at exactly the submission pixel size`() throws {
+        let captured = Self.solid(width: 100, height: 200, rgb: (1, 0, 0), format: .jpeg)
+        let options = try Server.captureOptions(size: "appstore-6.9", fit: nil, background: nil)
+
+        let bytes = try #require(Self.encoded(Server.recapture(
+            captured, sourceFormat: .jpeg, format: .png,
+            options: options, quality: 0.85
+        )))
+
+        #expect(Self.dimensions(bytes) == RenderDimensions(width: 1290, height: 2796))
+    }
+
+    @Test func `a square grows the canvas so the whole frame still fits, matted on the background`() throws {
+        let captured = Self.solid(width: 100, height: 200, rgb: (1, 0, 0), format: .png)
+        let options = try Server.captureOptions(size: "square", fit: "contain", background: "00ff00")
+
+        let bytes = try #require(Self.encoded(Server.recapture(
+            captured, sourceFormat: .png, format: .png,
+            options: options, quality: 0.85
+        )))
+
+        #expect(Self.dimensions(bytes) == RenderDimensions(width: 200, height: 200))
+        // The tall frame is centred, so the top-left corner is mat.
+        let corner = Self.pixel(bytes, x: 0, y: 0)
+        #expect(corner[0] < 40 && corner[1] > 200 && corner[2] < 40)
+    }
+
+    @Test func `cover fills the square by letting the overflow crop`() throws {
+        let captured = Self.solid(width: 100, height: 200, rgb: (1, 0, 0), format: .png)
+        let options = try Server.captureOptions(size: "square", fit: "cover", background: "00ff00")
+
+        let bytes = try #require(Self.encoded(Server.recapture(
+            captured, sourceFormat: .png, format: .png,
+            options: options, quality: 0.85
+        )))
+
+        #expect(Self.dimensions(bytes) == RenderDimensions(width: 200, height: 200))
+        // Nothing is matted — the frame is scaled up until it covers.
+        let corner = Self.pixel(bytes, x: 0, y: 0)
+        #expect(corner[0] > 200 && corner[1] < 40 && corner[2] < 40)
+    }
+
+    @Test func `a png screenshot re-encodes the captured jpeg as png`() throws {
+        let captured = Self.solid(width: 100, height: 200, rgb: (1, 0, 0), format: .jpeg)
+
+        let bytes = try #require(Self.encoded(Server.recapture(
+            captured, sourceFormat: .jpeg, format: .png,
+            options: .default, quality: 0.85
+        )))
+
+        #expect(bytes.starts(with: [0x89, 0x50, 0x4e, 0x47]))
+        #expect(Self.dimensions(bytes) == RenderDimensions(width: 100, height: 200))
+    }
+
+    @Test func `each screenshot extension names the content type browsers decode by`() {
+        #expect(Server.CaptureImageFormat.jpeg.contentType == "image/jpeg")
+        #expect(Server.CaptureImageFormat.png.contentType == "image/png")
+    }
+
+    @Test func `a png screenshot captures at full quality so its one lossy step is invisible`() {
+        // `ScreenSnapshot` only speaks JPEG, so a PNG still is a JPEG
+        // round-trip whether the caller wanted one or not. Capturing
+        // at 1.0 keeps that intermediate from showing up as ringing
+        // in something the extension promises is lossless.
+        #expect(Server.CaptureImageFormat.jpeg.defaultQuality == 0.85)
+        #expect(Server.CaptureImageFormat.png.defaultQuality == 1.0)
+    }
+
+    @Test func `a jpeg screenshot mats a transparent background white because jpeg has no alpha`() throws {
+        let captured = Self.solid(width: 100, height: 200, rgb: (1, 0, 0), format: .png)
+        let options = try Server.captureOptions(
+            size: "square", fit: "contain", background: "transparent"
+        )
+
+        let bytes = try #require(Self.encoded(Server.recapture(
+            captured, sourceFormat: .png, format: .jpeg,
+            options: options, quality: 1
+        )))
+
+        // Left un-matted the alpha would flatten to black on encode.
+        let corner = Self.pixel(bytes, x: 0, y: 0)
+        #expect(corner[0] > 240 && corner[1] > 240 && corner[2] > 240)
+    }
+
+    @Test func `an unreadable framebuffer fails rather than serving zero bytes`() {
+        let outcome = Server.recapture(
+            Data("not an image".utf8), sourceFormat: .jpeg, format: .png,
+            options: .default, quality: 0.85
+        )
+        #expect(outcome == .failed)
+    }
+
+    // MARK: - bezel composite
+
+    @Test func `the bezel composite drops the framebuffer into the chrome's screen cutout`() throws {
+        let assets = Self.chromeAssets()
+        let placement = Server.bezelPlacement(assets: assets, withButtons: true)
+
+        #expect(placement.bezel.size == Size(width: 120, height: 200))
+        #expect(placement.screen == Rect(
+            origin: Point(x: 20, y: 10),
+            size: Size(width: 80, height: 180)
+        ))
+        // outerCornerRadius 20 minus one bezel width (10).
+        #expect(placement.cornerRadius == 10)
+    }
+
+    @Test func `the bare bezel composite drops the button overshoot from the canvas`() throws {
+        let assets = Self.chromeAssets()
+        let placement = Server.bezelPlacement(assets: assets, withButtons: false)
+
+        #expect(placement.bezel.size == Size(width: 100, height: 200))
+        #expect(placement.screen == Rect(
+            origin: Point(x: 10, y: 10),
+            size: Size(width: 80, height: 180)
+        ))
+    }
+
+    @Test func `a bezel screenshot comes out at the chrome's own composite size by default`() throws {
+        let bytes = try #require(Server.bezelCapture(
+            screenImage: Self.solid(width: 80, height: 180, rgb: (1, 0, 0), format: .jpeg),
+            assets: Self.chromeAssets(),
+            withButtons: true,
+            options: .default
+        ))
+
+        #expect(Self.dimensions(bytes) == RenderDimensions(width: 120, height: 200))
+        // The screen sits ON TOP of the bezel's opaque off-glass.
+        let centre = Self.pixel(bytes, x: 60, y: 100)
+        #expect(centre[0] > 200 && centre[1] < 40 && centre[2] < 40)
+    }
+
+    @Test func `a bezel screenshot keeps the framebuffer at the resolution it was captured at`() throws {
+        // Chrome geometry is 1× points; the framebuffer is device
+        // pixels. Sizing the composite off the chrome would throw ~3×
+        // of a real phone's capture away before `?size=` ever upscales
+        // it back — exactly the App Store case this route is for.
+        let bytes = try #require(Server.bezelCapture(
+            screenImage: Self.solid(width: 240, height: 540, rgb: (1, 0, 0), format: .png),
+            assets: Self.chromeAssets(),
+            withButtons: true,
+            options: .default
+        ))
+
+        // 240 px into an 80 pt cutout is 3×, so the 120 × 200 pt
+        // chrome comes out at 360 × 600.
+        #expect(Self.dimensions(bytes) == RenderDimensions(width: 360, height: 600))
+    }
+
+    @Test func `a bezel screenshot never downsamples the chrome below its own resolution`() throws {
+        // A framebuffer smaller than the cutout (a heavy `?scale=`)
+        // must not shrink the bezel with it — the chrome is already
+        // at its authored size.
+        let bytes = try #require(Server.bezelCapture(
+            screenImage: Self.solid(width: 40, height: 90, rgb: (1, 0, 0), format: .png),
+            assets: Self.chromeAssets(),
+            withButtons: true,
+            options: .default
+        ))
+
+        #expect(Self.dimensions(bytes) == RenderDimensions(width: 120, height: 200))
+    }
+
+    @Test func `a bezel screenshot honours the same size vocabulary as the bare one`() throws {
+        let options = try Server.captureOptions(size: "appstore-6.9", fit: nil, background: nil)
+        let bytes = try #require(Server.bezelCapture(
+            screenImage: Self.solid(width: 80, height: 180, rgb: (1, 0, 0), format: .jpeg),
+            assets: Self.chromeAssets(),
+            withButtons: true,
+            options: options
+        ))
+
+        #expect(Self.dimensions(bytes) == RenderDimensions(width: 1290, height: 2796))
+    }
+
+    @Test func `a bezel screenshot fails when the framebuffer can't be decoded`() {
+        #expect(Server.bezelCapture(
+            screenImage: Data("not an image".utf8),
+            assets: Self.chromeAssets(),
+            withButtons: true,
+            options: .default
+        ) == nil)
+    }
+}
+
+// MARK: - fixtures
+
+private extension ScreenshotRouteTests {
+
+    /// A chrome whose merged composite is 10px wider on each side than
+    /// the bare device body — the button overshoot — with a 10px bezel
+    /// carved around an 80 × 180 screen.
+    static func chromeAssets() -> DeviceChromeAssets {
+        let chrome = DeviceChrome(
+            identifier: "phone-test",
+            screenInsets: Insets(top: 10, left: 10, bottom: 10, right: 10),
+            outerCornerRadius: 20,
+            buttons: [],
+            compositeImageName: "PhoneComposite",
+            devicePadding: Insets(top: 0, left: 10, bottom: 0, right: 10)
+        )
+        return DeviceChromeAssets(
+            chrome: chrome,
+            composite: ChromeImage(
+                data: solid(width: 120, height: 200, rgb: (0, 0, 0), format: .png),
+                size: Size(width: 120, height: 200)
+            ),
+            bareComposite: ChromeImage(
+                data: solid(width: 100, height: 200, rgb: (0, 0, 0), format: .png),
+                size: Size(width: 100, height: 200)
+            ),
+            buttonImages: [:],
+            buttonMargins: Insets(top: 0, left: 10, bottom: 0, right: 10)
+        )
+    }
+
+    static func encoded(_ outcome: Server.CaptureOutcome) -> Data? {
+        if case .encoded(let data) = outcome { return data }
+        return nil
+    }
+
+    static func solid(
+        width: Int, height: Int,
+        rgb: (Double, Double, Double),
+        format: Server.CaptureImageFormat
+    ) -> Data {
+        let context = CGContext(
+            data: nil, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                | CGBitmapInfo.byteOrder32Little.rawValue
+        )!
+        context.setFillColor(red: rgb.0, green: rgb.1, blue: rgb.2, alpha: 1)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        let image = context.makeImage()!
+        let out = NSMutableData()
+        let destination = CGImageDestinationCreateWithData(
+            out, format.utType as CFString, 1, nil
+        )!
+        CGImageDestinationAddImage(destination, image, nil)
+        _ = CGImageDestinationFinalize(destination)
+        return out as Data
+    }
+
+    static func dimensions(_ data: Data) -> RenderDimensions? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
+                as? [CFString: Any],
+              let width = properties[kCGImagePropertyPixelWidth] as? Int,
+              let height = properties[kCGImagePropertyPixelHeight] as? Int
+        else { return nil }
+        return RenderDimensions(width: width, height: height)
+    }
+
+    /// RGBA of one pixel, addressed top-left-origin like the rest of
+    /// the chrome geometry (CoreGraphics is bottom-up).
+    static func pixel(_ data: Data, x: Int, y: Int) -> [UInt8] {
+        let source = CGImageSourceCreateWithData(data as CFData, nil)!
+        let image = CGImageSourceCreateImageAtIndex(source, 0, nil)!
+        var bytes = [UInt8](repeating: 0, count: 4)
+        bytes.withUnsafeMutableBytes { buffer in
+            let context = CGContext(
+                data: buffer.baseAddress, width: 1, height: 1,
+                bitsPerComponent: 8, bytesPerRow: 4,
+                space: CGColorSpace(name: CGColorSpace.sRGB)!,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )!
+            context.translateBy(x: CGFloat(-x), y: CGFloat(-(image.height - 1 - y)))
+            context.draw(
+                image,
+                in: CGRect(x: 0, y: 0, width: image.width, height: image.height)
+            )
+        }
+        return bytes
+    }
+}


### PR DESCRIPTION
Unit 8 of the capture-size feature: the HTTP screenshot surface now speaks the shared `CaptureSize` vocabulary landed in `fd369359`.

## Routes

| Route | Status |
|---|---|
| `GET /simulators/:udid/screenshot.jpg` | extended |
| `GET /simulators/:udid/screenshot.png` | **new** |
| `GET /simulators/:udid/screenshot-bezel.png` | **new** |

All three accept `?quality=`, `?scale=`, `?size=`, `?fit=`, `?background=`. `screenshot-bezel.png` also takes `?buttons=true|false`, matching `bezel.png`'s bare/rest variants.

`.png` is its own route rather than a `?format=` knob on `.jpg` because a browser picks its decoder off the URL extension and nothing else — that's the entire reason the second registration exists.

## Behaviour

- `?size=` accepts any preset (`appstore-6.9`, `square`, `16:9`, …), `WIDTHxHEIGHT`, or `W:H`. Unknown values are a **400** in the existing `{"ok":false,"error":"…"}` envelope, quoting `CaptureSizeError.message` verbatim. Rejecting beats substituting — a marketing shot silently served at the wrong size is worse than an error the caller can read. Same for `?fit=` and `?background=`.
- `?background=` takes `transparent` or `#RRGGBB`, **and** a hash-less `ffffff`: a literal `#` opens the URL fragment, so a hand-written `curl` never delivers the hash.
- **Defaults are byte-for-byte unchanged.** A native plan is an identity, so `GET screenshot.jpg` with no new params returns the captured bytes without so much as a decode.

## The bezel composite

Composites Apple's rasterized DeviceKit chrome around the framebuffer server-side, for everyone who isn't a browser — `curl` in a marketing script, a CI job producing App Store shots. Two details that aren't preferences:

- **Z-order.** The DeviceKit composite paints an opaque dark "off glass" into the screen cutout, authored to sit *under* live content. Bezel first, screen on top, clipped to `DeviceChrome.innerCornerRadius`.
- **Scale.** Chrome geometry is 1x points; the framebuffer is device pixels. The canvas is sized off the *framebuffer* and the chrome is what gets resampled. Sizing it the other way would throw ~3x of a real phone's capture away before `?size=` upscaled the remains back — exactly the case this route exists for. Never below 1x, so a heavy `?scale=` can't shrink the bezel.

Reuses `DeviceChrome.screenRect(in:)` / `innerCornerRadius` and the existing rasterized composites; no chrome code was touched.

## Two lossy-path fixes surfaced by review

- PNG routes default `?quality=` to **1.0** (JPEG stays 0.85). `ScreenSnapshot` only speaks JPEG, so a PNG still is a JPEG round-trip whether the caller wanted one or not; capturing at full quality keeps that intermediate from showing up as ringing in something the extension promises is lossless. Still not bit-exact — removing the round-trip needs `ScreenSnapshot` to hand back a CGImage, which is unit 7's surface.
- `?background=transparent` on a `.jpg` mats white rather than flattening to black, since JPEG carries no alpha.

## Scope notes

- The resize lives in `Server.swift` rather than inside `ScreenSnapshot.capture` **on purpose** — the same knobs are landing on that helper in parallel and this route surface has to be mergeable on its own. Flagged in a comment for the follow-up that collapses the duplication.
- `render-3d.png` is deliberately untouched: its `options.size ?? sourceSize` needs a method that only exists on unit 9's branch. The coordinator is taking that post-merge.
- Added a comment where `CaptureFit` and `DeviceScreenFit` now sit near each other. They spell the same three cases and mean completely different things (output canvas vs. 3D screen mesh) — the next reader will merge them by accident otherwise.

## Testing

`Tests/BaguetteTests/Server/ScreenshotRouteTests.swift` — 22 tests, driving the internal helpers with real bitmaps rather than standing up a server or needing a booted simulator. Covers defaults, each preset's output dimensions, contain-vs-cover by sampling the corner pixel, PNG/JPEG content types, all three 400 paths, and the bezel composite's dimensions at both 1x and 3x.

Full suite: **1522 tests green.** `make test-web` green apart from the pre-existing `safari-gesture-event-source.test.js` failure.

E2E on a booted iPhone 17 Pro Max (iOS 26.4):

```
screenshot.png?size=appstore-6.9        → 1290 x 2796  png
screenshot.jpg?size=square&fit=cover    → 2868 x 2868  jpeg
screenshot.jpg?size=800x600&fit=stretch →  800 x  600  jpeg
screenshot.jpg (no params)              → 1320 x 2868  jpeg  (unchanged)
screenshot-bezel.png                    → 1483 x 2984
screenshot-bezel.png?size=square        → 2984 x 2984
screenshot-bezel.png?buttons=false      → 1428 x 2984
?size=nonsense                          → 400 + the preset list
```

Bezel composite eyeballed: buttons present, screen sharp and on top of the off-glass, corners correctly clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)