### PR TITLE
feat: fold the focus toolbar into context clusters

### DIFF
--- a/Sources/Baguette/Infrastructure/Server/Server.swift
+++ b/Sources/Baguette/Infrastructure/Server/Server.swift
@@ -759,6 +759,7 @@ struct Server: Sendable {
         "devices",
         "farm",
         "screens",
+        "toolbar",
         "vendor/leaflet",
     ]
 

--- a/Sources/Baguette/Resources/Web/capture/capture-size-menu.js
+++ b/Sources/Baguette/Resources/Web/capture/capture-size-menu.js
@@ -37,6 +37,29 @@
   border-color: var(--accent, #2563eb); color: var(--accent, #2563eb);
 }
 .cap-size-chip svg { width: 13px; height: 13px; flex: none; }
+/* The chip is a FIXED width whatever is picked. It used to render the
+   preset's label, so it was "Native" (54px) one moment and "App Store
+   iPad 13″" (132px) the next — the one control whose width the user
+   changes by using it, in a toolbar that is a single row of fixed-size
+   controls, so every icon beside it shifted. Every code fits four
+   tabular characters ("9:16", "6.9″", "1:1"); the box is sized for the
+   widest and the rest centre in it. */
+.cap-size-code {
+  min-width: 34px; text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+/* The glyph is the selection's actual shape, drawn to its aspect. It
+   is the only part of the chip that says what the choice IS rather
+   than what it is called — which is what makes a four-character code
+   readable at a glance. Native has no shape of its own, so it draws
+   nothing. */
+.cap-size-glyph {
+  width: 13px; height: 13px; flex: none;
+  display: grid; place-items: center;
+}
+.cap-size-glyph i {
+  display: block; border: 1.5px solid currentColor; border-radius: 2px;
+}
 .cap-size-pop {
   position: absolute; z-index: 60; top: calc(100% + 6px); right: 0;
   width: 236px; padding: 10px; border-radius: 10px;
@@ -145,7 +168,9 @@
       this.root.innerHTML =
         '<button type="button" class="cap-size-chip" aria-expanded="false" ' +
         'aria-haspopup="true" title="Capture output size">' +
-        '<span data-role="label"></span>' + CHEVRON + '</button>' +
+        '<span class="cap-size-glyph" data-role="glyph"></span>' +
+        '<span class="cap-size-code" data-role="label"></span>' +
+        CHEVRON + '</button>' +
         '<div class="cap-size-pop" hidden role="dialog" aria-label="Capture size"></div>';
       this.chip = this.root.querySelector('.cap-size-chip');
       this.pop = this.root.querySelector('.cap-size-pop');
@@ -193,11 +218,28 @@
 
     _renderChip() {
       if (!this.chip) return;
+      const size = this.settings.size;
       const label = this.chip.querySelector('[data-role="label"]');
-      if (label) label.textContent = this.settings.size.label;
-      this.chip.title = this.settings.size.isNative
+      if (label) label.textContent = size.code;
+      const glyph = this.chip.querySelector('[data-role="glyph"]');
+      if (glyph) glyph.innerHTML = CaptureSizeMenu.aspectGlyph(size.aspect(), 11);
+      // The full name lives here now that the chip shows a code. Nothing
+      // is lost: the popover names it too, and this is what a hover
+      // asks for.
+      this.chip.title = size.isNative
         ? 'Capture output size: native'
-        : `Capture output size: ${this.settings.size.label} · ${this.settings.fit}`;
+        : `Capture output size: ${size.label} · ${this.settings.fit}`;
+    }
+
+    /**
+     * A rectangle drawn at `aspect`, fitted into a `size`-px box.
+     * `null` — `native` — draws nothing rather than guessing a shape.
+     */
+    static aspectGlyph(aspect, size) {
+      if (!aspect || !(aspect > 0)) return '';
+      const width = aspect >= 1 ? size : Math.round(size * aspect);
+      const height = aspect >= 1 ? Math.round(size / aspect) : size;
+      return `<i style="width:${width}px;height:${height}px"></i>`;
     }
 
     _renderPopover() {

--- a/Sources/Baguette/Resources/Web/capture/capture-size.js
+++ b/Sources/Baguette/Resources/Web/capture/capture-size.js
@@ -35,10 +35,17 @@
      * @param {number} [spec.width]   fixed kind: exact pixels
      * @param {number} [spec.height]  fixed kind: exact pixels
      * @param {number} [spec.ratio]   ratio kind: width / height
+     * @param {string} [spec.code]    the chip's spelling — at most four
+     *        tabular characters, so the toolbar can hold one width
      */
-    constructor({ id, label, spec, kind, width, height, ratio }) {
+    constructor({ id, label, code, spec, kind, width, height, ratio }) {
       this.id = id;
       this.label = label;
+      // The toolbar chip used to render `label`, so it was "Native"
+      // (54px) one moment and "App Store iPad 13″" (132px) the next —
+      // the one control whose width the user changes by using it, in a
+      // bar that is a single row of fixed-size controls.
+      this.code = code || spec;
       this.spec = spec;
       this.kind = kind;
       this.width = width || 0;
@@ -87,6 +94,10 @@
         return new CaptureSize({
           id: 'custom',
           label: `${width} × ${height}`,
+          // "1920x1080" is wider than the label it would replace, so
+          // the chip says Custom and the popover's resolved dimensions
+          // say which.
+          code: 'Custom',
           spec: `${width}x${height}`,
           kind: 'fixed',
           width,
@@ -112,6 +123,21 @@
 
     get isNative() {
       return this.kind === 'native';
+    }
+
+    /**
+     * The shape this size wants, as width / height — or `null` for
+     * `native`, which has no shape of its own and takes the source's.
+     *
+     * Read straight off the value rather than recovered from a
+     * `resolve()` call: resolve rounds to whole pixels, and 1778/1000
+     * is not 16/9. Callers draw it (the chip's glyph) or stream at it,
+     * and both want the ratio the user asked for.
+     */
+    aspect() {
+      if (this.isNative) return null;
+      if (this.kind === 'ratio') return this.ratio > 0 ? this.ratio : null;
+      return this.width > 0 && this.height > 0 ? this.width / this.height : null;
     }
 
     /** The canvas dimensions this size wants for a given source. */
@@ -173,20 +199,20 @@
   // nothing shares mutable state. `spec` is what goes on the wire and into
   // localStorage; for presets it is just the id.
   const PRESETS = [
-    { id: 'native', label: 'Native', spec: 'native', kind: 'native' },
+    { id: 'native', label: 'Native', code: 'Auto', spec: 'native', kind: 'native' },
     {
-      id: 'appstore-6.9', label: 'App Store 6.9″', spec: 'appstore-6.9',
+      id: 'appstore-6.9', label: 'App Store 6.9″', code: '6.9″', spec: 'appstore-6.9',
       kind: 'fixed', width: 1290, height: 2796,
     },
     {
-      id: 'appstore-6.5', label: 'App Store 6.5″', spec: 'appstore-6.5',
+      id: 'appstore-6.5', label: 'App Store 6.5″', code: '6.5″', spec: 'appstore-6.5',
       kind: 'fixed', width: 1242, height: 2688,
     },
     {
-      id: 'appstore-ipad-13', label: 'App Store iPad 13″', spec: 'appstore-ipad-13',
+      id: 'appstore-ipad-13', label: 'App Store iPad 13″', code: '13″', spec: 'appstore-ipad-13',
       kind: 'fixed', width: 2064, height: 2752,
     },
-    { id: 'square', label: 'Square', spec: 'square', kind: 'ratio', ratio: 1 },
+    { id: 'square', label: 'Square', code: '1:1', spec: 'square', kind: 'ratio', ratio: 1 },
     { id: '16:9', label: 'Landscape 16:9', spec: '16:9', kind: 'ratio', ratio: 16 / 9 },
     { id: '9:16', label: 'Portrait 9:16', spec: '9:16', kind: 'ratio', ratio: 9 / 16 },
     { id: '4:3', label: 'Classic 4:3', spec: '4:3', kind: 'ratio', ratio: 4 / 3 },

--- a/Sources/Baguette/Resources/Web/sim-native.html
+++ b/Sources/Baguette/Resources/Web/sim-native.html
@@ -672,7 +672,168 @@
     scroll-behavior: smooth;
     scrollbar-width: none;                 /* Firefox */
   }
+  /* Clipping is what makes `scrollWidth` meaningful while ToolbarFold
+     tries candidates, and it is worn only for that: a clipped bar also
+     cuts off every popover hanging out of it. */
+  #simNativeView .top-bar.measuring { overflow: hidden; }
+  #simNativeView .top-bar.measuring .tb-scroll { overflow: visible; }
+  /* Once every cluster has folded and merged there is nothing left to
+     give but Navigate itself. The OS version goes first — it is a
+     caption nobody acts on — and then the device name truncates,
+     because a shortened name still says which device while a dropped
+     control is simply gone. */
+  #simNativeView .top-bar.tight .tb-os { display: none; }
+  #simNativeView .top-bar.tight .tb-name { max-width: 92px; }
   #simNativeView .tb-scroll::-webkit-scrollbar { display: none; }  /* WebKit */
+
+  /* ── Cluster folding ────────────────────────────────────────────
+     The strip is seven CONTEXT CLUSTERS, not fifteen loose controls:
+     Navigate, Stream, View, Control, Simulate, Inspect, Capture. When
+     the row runs out of width a whole cluster folds into one menu
+     button — never an item, never a partial group. `ToolbarFold`
+     (toolbar/toolbar-fold.js) owns the order; this is its dressing.
+     See docs/mockups/focus-toolbar-overflow.html. */
+  #simNativeView .tb-cluster {
+    display: inline-flex; align-items: center; gap: 2px; flex: 0 0 auto;
+  }
+  #simNativeView .tb-cluster[hidden] { display: none; }
+  #simNativeView .tb-sep {
+    flex: 0 0 auto; width: 1px; height: 16px; margin: 0 2px;
+    background: var(--nv-divider);
+  }
+  #simNativeView .tb-sep[hidden] { display: none; }
+
+  /* A folded cluster is an ICON plus a caret, never a text label:
+     folding has to be a saving, and "Inspect" as a label is an 85px
+     button replacing two 30px glyphs. The names still do their work,
+     as the menu's section headings and the button's tooltip. */
+  #simNativeView .tb-fold { position: relative; flex: 0 0 auto; }
+  #simNativeView .tb-fold[hidden] { display: none; }
+  #simNativeView .tb-fold-btn {
+    display: inline-flex; align-items: center; gap: 1px;
+    height: 26px; padding: 0 4px 0 5px;
+    background: transparent; border: 1px solid transparent; border-radius: 8px;
+    color: var(--nv-text); cursor: pointer;
+  }
+  #simNativeView .tb-fold-btn:hover { background: var(--nv-btn-hover); }
+  #simNativeView .tb-fold-btn[aria-expanded="true"] {
+    border-color: var(--nv-accent); color: var(--nv-accent);
+  }
+  #simNativeView .tb-fold-btn svg { display: block; }
+  #simNativeView .tb-fold-btn .tb-caret { opacity: 0.5; }
+
+  /* A cluster menu is anchored under the button that opened it.
+     `right: 0` put a 234px popover's right edge on a 40px button, so
+     the Stream menu opened almost the full width of the bar to the
+     LEFT of the control it belongs to and read as unrelated to it.
+     Only the merged menu keeps `right: 0` — it sits at the end of the
+     bar, where opening leftward is the only direction available. */
+  /* Border-box throughout this menu. sim-native.html does not set a
+     global `box-sizing`, so `width: 100%` on a padded row resolved to
+     content-width PLUS padding and every row sat a few pixels wider
+     than the popover holding it — which is what clipped the frame-rate
+     readout against the right border. */
+  #simNativeView .tb-fold-pop,
+  #simNativeView .tb-row,
+  #simNativeView .tb-read,
+  #simNativeView .tb-choice,
+  #simNativeView .tb-acc > summary,
+  #simNativeView .tb-acc-body { box-sizing: border-box; }
+
+  #simNativeView .tb-fold-pop {
+    position: absolute; z-index: 60; top: calc(100% + 8px);
+    left: 50%; transform: translateX(-50%);
+    /* Sized for the widest row a cluster menu holds, which is the
+       codec CHOICE — at 208px "MJPEG" was clipped off it. */
+    width: 234px; padding: 6px; border-radius: 12px;
+    /* Opaque, unlike the bar itself. The toolbar's translucency reads
+       as chrome floating over the device; a MENU sits directly on top
+       of the running screen, and at `--nv-bar-bg`'s 0.82 alpha the app
+       behind it showed through the rows. A control you have to squint
+       past a home screen to read is not worth folding into. */
+    background: var(--nv-page-bg);
+    border: 1px solid var(--nv-bar-border);
+    box-shadow: var(--nv-bar-shadow);
+    color: var(--nv-text);
+    font: 500 12px/1.3 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+    max-height: 60vh; overflow-y: auto;
+  }
+  #simNativeView [data-fold="more"] .tb-fold-pop {
+    left: auto; right: 0; transform: none;
+  }
+  #simNativeView .tb-fold-pop[hidden] { display: none; }
+
+  /* Merged mode is an EXCLUSIVE accordion. Four clusters flattened
+     into one popover is thirteen rows — the "too many things"
+     complaint moved down a level rather than answered. Collapsed it is
+     four rows; `name=` makes them a radio group where supported and
+     the click handler enforces it everywhere else. */
+  #simNativeView .tb-acc > summary {
+    list-style: none; cursor: pointer;
+    display: flex; align-items: center; gap: 9px;
+    padding: 8px; border-radius: 8px;
+    font: 600 12px/1.3 inherit; color: var(--nv-text);
+  }
+  #simNativeView .tb-acc > summary::-webkit-details-marker { display: none; }
+  #simNativeView .tb-acc > summary:hover { background: var(--nv-btn-hover); }
+  #simNativeView .tb-acc > summary svg { flex: 0 0 auto; opacity: 0.8; }
+  #simNativeView .tb-acc[open] > summary { color: var(--nv-accent); }
+  #simNativeView .tb-acc > summary .tb-acc-n {
+    margin-left: auto; font-size: 10px; font-weight: 500;
+    color: var(--nv-text-faint); font-variant-numeric: tabular-nums;
+  }
+  #simNativeView .tb-acc > summary .tb-caret { opacity: 0.5; transition: transform 0.15s ease; }
+  #simNativeView .tb-acc[open] > summary .tb-caret { transform: rotate(180deg); }
+  #simNativeView .tb-acc-body { padding: 1px 0 5px 8px; }
+
+  /* A MENU ROW IS NOT ONE THING. Flattening every control to
+     icon + label + value turned the codec picker into a caption
+     reading "Codec H.264" with no way to reach MJPEG. Actions,
+     toggles, choices and readouts each get their own rendering. */
+  #simNativeView .tb-row {
+    display: flex; align-items: center; gap: 9px; width: 100%;
+    padding: 7px 8px; border: 0; border-radius: 8px; cursor: pointer;
+    background: transparent; color: inherit; font: inherit; text-align: left;
+  }
+  #simNativeView .tb-row:hover { background: var(--nv-btn-hover); }
+  #simNativeView .tb-row svg { flex: 0 0 auto; opacity: 0.85; }
+  #simNativeView .tb-row.on { color: var(--nv-accent); }
+  #simNativeView .tb-row.on svg { opacity: 1; }
+  /* A dot, not a switch. Every control that reaches this menu — status
+     bar, location, camera, accessibility, logs — OPENS A PANEL. A
+     switch says "a setting you flip and leave"; these are disclosures,
+     and the switch also justified keeping the menu open so you could
+     watch it move, which left the panel you just opened sitting behind
+     the menu covering it. The dot reports the same state without
+     claiming to be a setting. */
+  #simNativeView .tb-dot {
+    margin-left: auto; flex: 0 0 auto;
+    width: 6px; height: 6px; border-radius: 999px;
+    background: transparent;
+  }
+  #simNativeView .tb-row.on .tb-dot { background: var(--nv-accent); }
+
+  /* readout — no hover, no pointer: nothing happens when you press it */
+  #simNativeView .tb-read {
+    display: flex; align-items: center; gap: 9px; width: 100%;
+    padding: 7px 8px; cursor: default; color: var(--nv-text-muted);
+  }
+  #simNativeView .tb-read svg { flex: 0 0 auto; opacity: 0.55; }
+  #simNativeView .tb-read span:first-of-type { flex: 0 1 auto; min-width: 0; }
+  #simNativeView .tb-read .tb-val {
+    margin-left: auto; padding-left: 8px; flex: 0 0 auto;
+    font-size: 11px; color: var(--nv-text-faint);
+    font-variant-numeric: tabular-nums; white-space: nowrap;
+  }
+
+  /* choice — the options come with it, because a value you cannot
+     change is a caption pretending to be a control */
+  #simNativeView .tb-choice {
+    display: flex; align-items: center; gap: 9px;
+    padding: 6px 8px; border-radius: 8px;
+  }
+  #simNativeView .tb-choice > svg { flex: 0 0 auto; opacity: 0.85; }
+  #simNativeView .tb-choice .fmt-picker { margin-left: auto; }
 
   /* Chevron scroll buttons — hidden unless the strip overflows. */
   #simNativeView .tb-arrow {
@@ -2377,14 +2538,14 @@
             <line x1="6.5" y1="17" x2="11"  y2="17"/>
           </svg>
         </button>
-        <button class="ico-btn" title="Home" onclick="window.__nativeHome && window.__nativeHome()">
+        <button class="ico-btn" id="nativeHome" title="Home" onclick="window.__nativeHome && window.__nativeHome()">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"
                stroke-linecap="round" stroke-linejoin="round" width="17" height="17">
             <path d="M3 11.2 12 4l9 7.2"/>
             <path d="M5 10v9a1 1 0 0 0 1 1h4v-6h4v6h4a1 1 0 0 0 1-1v-9"/>
           </svg>
         </button>
-        <button class="ico-btn" title="Screenshot" onclick="window.__nativeScreenshot && window.__nativeScreenshot()">
+        <button class="ico-btn" id="nativeScreenshot" title="Screenshot" onclick="window.__nativeScreenshot && window.__nativeScreenshot()">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"
                stroke-linecap="round" stroke-linejoin="round" width="17" height="17">
             <path d="M4 8.5A1.5 1.5 0 0 1 5.5 7h2L9 5h6l1.5 2h2A1.5 1.5 0 0 1 20 8.5V18a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 4 18z"/>
@@ -2411,7 +2572,7 @@
           </svg>
           <span class="rec-timer" id="nativeRecordTimer"></span>
         </button>
-        <button class="ico-btn" title="App switcher"
+        <button class="ico-btn" id="nativeAppSwitcher" title="App switcher"
                 aria-label="Open app switcher"
                 onclick="window.__nativeAppSwitcher && window.__nativeAppSwitcher()">
           <!-- "App-switcher" glyph mirroring the native Simulator
@@ -2434,7 +2595,7 @@
              App switcher. POSTs to `/simulators/<udid>/shake`; the
              server delegates to `simulator.shake().shake()`, backed by
              `simctl spawn notifyutil`. -->
-        <button class="ico-btn" title="Shake device"
+        <button class="ico-btn" id="nativeShake" title="Shake device"
                 aria-label="Shake device"
                 onclick="window.__nativeShake && window.__nativeShake()">
           <!-- Phone glyph flanked by motion arcs — reads as a device

--- a/Sources/Baguette/Resources/Web/sim-native.html
+++ b/Sources/Baguette/Resources/Web/sim-native.html
@@ -314,15 +314,14 @@
     box-sizing: border-box;   /* so the max-width below is the real width */
     flex-shrink: 0;
     gap: 12px;
-    /* Wraps to a second row before it folds. The pane baguette gets
-       squeezed into is narrow AND TALL — a browser sidebar beside an
-       editor — so spending the last of the width on an anonymous ⋯
-       throws away the dimension that pane has plenty of. `height` has
-       to become a floor rather than a fixed value for a second row to
-       have anywhere to go. `sim-native.js` caps it at two rows. */
-    flex-wrap: wrap;
-    row-gap: 2px;
-    min-height: 36px;
+    /* One line, always. A second row was tried — the pane baguette is
+       squeezed into is narrow and tall, so height looked like the
+       cheap dimension — and it is not worth having: a pill with a
+       short identity row above a long control row is lopsided, and it
+       pushes the device down for controls that fold perfectly well
+       into a menu. Folding is the answer to a narrow bar; wrapping is
+       a different-looking bar. */
+    height: 36px;
     padding: 4px 6px 4px 4px;
     background: var(--nv-bar-bg);
     border: 1px solid var(--nv-bar-border);
@@ -664,12 +663,6 @@
     display: inline-flex; align-items: center; gap: 8px;
     padding-right: 4px;
     min-width: 0;
-    /* Wraps with the bar. The clusters are children of THIS, not of
-       `.top-bar`, so wrapping only the outer element moved the whole
-       control group to a second line as one unit and let it overflow
-       there instead. */
-    flex-wrap: wrap;
-    row-gap: 2px;
   }
 
   /* Horizontally-scrollable icon strip. Trackpads scroll it directly;
@@ -689,10 +682,10 @@
   /* Clipping is what makes `scrollWidth` meaningful while ToolbarFold
      tries candidates, and it is worn only for that: a clipped bar also
      cuts off every popover hanging out of it. */
-  /* Nothing to clip while measuring any more: with wrapping on, the
-     question is how many ROWS the children take, not whether they
-     overflow horizontally. Clipping would have hidden the second row
-     from the very measurement that has to see it. */
+  /* Clipping is what makes `scrollWidth` meaningful while ToolbarFold
+     tries candidates, and it is worn only for that: a clipped bar also
+     cuts off every popover hanging out of it. */
+  #simNativeView .top-bar.measuring { overflow: hidden; }
 
   /* Once every cluster has folded and merged there is nothing left to
      give but Navigate itself. The OS version goes first — it is a

--- a/Sources/Baguette/Resources/Web/sim-native.html
+++ b/Sources/Baguette/Resources/Web/sim-native.html
@@ -314,7 +314,15 @@
     box-sizing: border-box;   /* so the max-width below is the real width */
     flex-shrink: 0;
     gap: 12px;
-    height: 36px;
+    /* Wraps to a second row before it folds. The pane baguette gets
+       squeezed into is narrow AND TALL — a browser sidebar beside an
+       editor — so spending the last of the width on an anonymous ⋯
+       throws away the dimension that pane has plenty of. `height` has
+       to become a floor rather than a fixed value for a second row to
+       have anywhere to go. `sim-native.js` caps it at two rows. */
+    flex-wrap: wrap;
+    row-gap: 2px;
+    min-height: 36px;
     padding: 4px 6px 4px 4px;
     background: var(--nv-bar-bg);
     border: 1px solid var(--nv-bar-border);
@@ -655,7 +663,13 @@
   #simNativeView .tb-controls {
     display: inline-flex; align-items: center; gap: 8px;
     padding-right: 4px;
-    min-width: 0;            /* let the scroll strip shrink + scroll */
+    min-width: 0;
+    /* Wraps with the bar. The clusters are children of THIS, not of
+       `.top-bar`, so wrapping only the outer element moved the whole
+       control group to a second line as one unit and let it overflow
+       there instead. */
+    flex-wrap: wrap;
+    row-gap: 2px;
   }
 
   /* Horizontally-scrollable icon strip. Trackpads scroll it directly;
@@ -675,8 +689,11 @@
   /* Clipping is what makes `scrollWidth` meaningful while ToolbarFold
      tries candidates, and it is worn only for that: a clipped bar also
      cuts off every popover hanging out of it. */
-  #simNativeView .top-bar.measuring { overflow: hidden; }
-  #simNativeView .top-bar.measuring .tb-scroll { overflow: visible; }
+  /* Nothing to clip while measuring any more: with wrapping on, the
+     question is how many ROWS the children take, not whether they
+     overflow horizontally. Clipping would have hidden the second row
+     from the very measurement that has to see it. */
+
   /* Once every cluster has folded and merged there is nothing left to
      give but Navigate itself. The OS version goes first — it is a
      caption nobody acts on — and then the device name truncates,

--- a/Sources/Baguette/Resources/Web/sim-native.js
+++ b/Sources/Baguette/Resources/Web/sim-native.js
@@ -1169,34 +1169,395 @@
   // out of it.
   let refreshToolbarScroll = () => {};
 
-  function wireToolbarScroll() {
+  // ── Toolbar clusters ─────────────────────────────────────────────
+  //
+  // The strip is seven CONTEXT CLUSTERS, not fifteen loose controls,
+  // and when the row runs out of width a WHOLE cluster folds into one
+  // menu — never an item, never a partial group. A flat per-control
+  // priority queue was tried first and tore Shake off Home on a
+  // tie-break between equal ranks; `docs/mockups/focus-toolbar-overflow.html`
+  // runs both so the difference is visible.
+  //
+  // The grouping is applied at runtime rather than authored into
+  // sim-native.html. That template is a flat list of buttons and reads
+  // better as one; keeping the cluster definition here means the
+  // membership, the fold order and the menu's idea of each control's
+  // ROLE live in a single table instead of being split between HTML
+  // nesting and a JS lookup.
+  //
+  // `role` is what the control IS, which is what its menu row has to
+  // render. Flattening everything to icon + label + value turned the
+  // codec picker into a caption reading "Codec  H.264" with no way to
+  // reach MJPEG.
+  //
+  // `label` is declared rather than read off the button's `title`
+  // because a tooltip and a menu row are different sentences: the
+  // tooltip on the camera button says "Toggle camera control", which
+  // is the right thing to say when hovering an unlabelled glyph and
+  // the wrong thing to put in a list where every row is a control and
+  // the verb is implied. The `title` is still the fallback, so a
+  // button added without a label here still renders.
+  const TOOLBAR_CLUSTERS = [
+    {
+      id: 'stream', label: 'Stream', fold: 3, icon: 'film',
+      members: [
+        { id: 'nativeStatus', label: 'Frame rate', role: 'readout' },
+        { id: 'nativeFormatPicker', label: 'Codec', role: 'choice' },
+      ],
+    },
+    {
+      id: 'view', icon: 'cube',
+      members: [{ id: 'native3DToggle', label: '3D view', role: 'state' }],
+    },
+    {
+      id: 'control', label: 'Control', fold: 4, icon: 'home',
+      members: [
+        { id: 'nativeRotate', label: 'Rotate', role: 'action' },
+        { id: 'nativeHome', label: 'Home', role: 'action' },
+        { id: 'nativeAppSwitcher', label: 'App switcher', role: 'action' },
+        { id: 'nativeShake', label: 'Shake', role: 'action' },
+      ],
+    },
+    {
+      id: 'simulate', label: 'Simulate', fold: 1, icon: 'wave',
+      members: [
+        { id: 'nativeStatusBarToggle', label: 'Status bar', role: 'state' },
+        { id: 'nativeLocationToggle', label: 'Location', role: 'state' },
+        { id: 'nativeCameraToggle', label: 'Camera', role: 'state' },
+      ],
+    },
+    {
+      id: 'inspect', label: 'Inspect', fold: 2, icon: 'glass',
+      members: [
+        { id: 'nativeAxToggle', label: 'Accessibility', role: 'state' },
+        { id: 'nativeLogsToggle', label: 'Logs', role: 'state' },
+      ],
+    },
+    {
+      id: 'capture',
+      members: [
+        { id: 'nativeScreenshot', label: 'Screenshot', role: 'action' },
+        { id: 'nativeRecordBtn', label: 'Record', role: 'action' },
+        { id: 'nativeCaptureSize', role: 'mount' },
+      ],
+    },
+  ];
+
+  // Glyphs for the folded-cluster buttons. Every member row borrows its
+  // icon from the real button it proxies, so only the cluster headers
+  // need art of their own.
+  const CLUSTER_ICONS = {
+    film:  'M4 5h16v14H4zM4 9h16M4 15h16M8 5v14M16 5v14',
+    cube:  'M12 2l9 5v10l-9 5-9-5V7z M12 12l9-5 M12 12v10 M12 12L3 7',
+    home:  'M4 11l8-7 8 7v9H4z',
+    wave:  'M3 12h3l2-6 3 12 3-9 2 3h5',
+    glass: 'M11 4a7 7 0 1 0 0 14 7 7 0 0 0 0-14zM16.5 16.5L21 21',
+    more:  'M6 12h.01M12 12h.01M18 12h.01',
+    // Rows that have no button in the bar to borrow a glyph from. Both
+    // wore the Stream cluster's own film icon at first, which made
+    // "Frame rate" and "Codec" look like the same control twice.
+    gauge: 'M12 20a8 8 0 1 1 8-8M12 12l4.5-3',
+    codec: 'M3 8h4l3 8h4l3-8h4',
+  };
+
+  const CARET_SVG =
+      '<svg class="tb-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+      'stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" ' +
+      'width="11" height="11"><polyline points="6 9 12 15 18 9"/></svg>';
+
+  const clusterSvg = (name) =>
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" ' +
+      'stroke-linecap="round" stroke-linejoin="round" width="15" height="15">' +
+      '<path d="' + CLUSTER_ICONS[name] + '"/></svg>';
+
+  let toolbarFold = null;
+
+  /**
+   * Move the flat strip into cluster containers, once.
+   *
+   * Every control keeps its own element — same id, same inline
+   * `onclick`, same `.active` class — so nothing about how a button
+   * behaves changes; only where it sits. The fold menus are built as a
+   * PROJECTION of these buttons (their icon, their `title`, their
+   * active state), which is why there is no second catalogue of labels
+   * to drift out of sync.
+   */
+  function buildToolbarClusters() {
+    const controls = document.querySelector('#simNativeView .tb-controls');
     const strip = document.getElementById('nativeToolScroll');
-    const left  = document.getElementById('nativeScrollLeft');
-    const right = document.getElementById('nativeScrollRight');
-    if (!strip || !left || !right) return;
+    if (!controls || !strip || !window.Baguette || !window.Baguette._ToolbarFold) {
+      return false;
+    }
 
-    const update = () => {
-      const max = strip.scrollWidth - strip.clientWidth;
-      const overflowing = max > 1;
-      left.hidden = right.hidden = !overflowing;
-      if (!overflowing) return;
-      left.disabled = strip.scrollLeft <= 0;
-      right.disabled = strip.scrollLeft >= max - 1;
-    };
-    const nudge = (dir) => {
-      // Page by ~70% of the visible strip so a click moves a clear chunk
-      // but keeps a little overlap for orientation.
-      strip.scrollLeft += dir * Math.max(80, strip.clientWidth * 0.7);
-    };
+    // The scroller and its chevrons are what this replaces.
+    ['nativeScrollLeft', 'nativeScrollRight'].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) el.remove();
+    });
 
-    refreshToolbarScroll = update;
-    left.addEventListener('click', () => nudge(-1));
-    right.addEventListener('click', () => nudge(1));
-    strip.addEventListener('scroll', update, { passive: true });
-    window.addEventListener('resize', update);
+    TOOLBAR_CLUSTERS.forEach((cluster, index) => {
+      if (index > 0) {
+        const sep = document.createElement('span');
+        sep.className = 'tb-sep';
+        sep.dataset.sepFor = cluster.id;
+        controls.appendChild(sep);
+      }
+      const host = document.createElement('span');
+      host.className = 'tb-cluster';
+      host.dataset.cluster = cluster.id;
+      cluster.members.forEach((member) => {
+        const el = document.getElementById(member.id);
+        if (el) host.appendChild(el);
+      });
+      controls.appendChild(host);
+
+      if (!cluster.fold) return;
+      controls.appendChild(foldHost(cluster.id, cluster.label, cluster.icon));
+    });
+
+    // The merged menu lives at the end, where the last folded cluster
+    // would have sat.
+    controls.appendChild(foldHost('more', 'More controls', 'more'));
+    strip.remove();
+
+    toolbarFold = new window.Baguette._ToolbarFold(TOOLBAR_CLUSTERS);
+    return true;
+  }
+
+  function foldHost(id, label, icon) {
+    const host = document.createElement('span');
+    host.className = 'tb-fold';
+    host.dataset.fold = id;
+    host.hidden = true;
+    host.innerHTML =
+        '<button type="button" class="tb-fold-btn" aria-expanded="false" ' +
+        'aria-haspopup="true" title="' + label + '">' +
+        clusterSvg(icon) + CARET_SVG + '</button>' +
+        '<div class="tb-fold-pop" hidden></div>';
+    return host;
+  }
+
+  /** Show the clusters this state keeps, and the fold buttons it needs. */
+  function applyToolbarState(state) {
+    const bar = document.querySelector('#simNativeView .top-bar');
+    if (!bar) return;
+    const folded = state.folded;
+    const merged = state.merged;
+
+    TOOLBAR_CLUSTERS.forEach((cluster) => {
+      const isFolded = folded.indexOf(cluster.id) >= 0;
+      const host = document.querySelector('[data-cluster="' + cluster.id + '"]');
+      const sep = document.querySelector('[data-sep-for="' + cluster.id + '"]');
+      const fold = document.querySelector('[data-fold="' + cluster.id + '"]');
+      if (host) host.hidden = isFolded;
+      if (sep) sep.hidden = isFolded;
+      if (fold) fold.hidden = !isFolded || merged;
+    });
+    const more = document.querySelector('[data-fold="more"]');
+    if (more) more.hidden = !merged;
+    bar.classList.toggle('tight', state.tight);
+  }
+
+  /**
+   * Ask ToolbarFold for the widest state that fits, then fill in the
+   * menus for whatever ended up folded.
+   *
+   * Re-measuring after every candidate is what makes this exact: there
+   * is no width table to keep in sync with the CSS, and it stays right
+   * when a device name is long or a webfont lands late.
+   */
+  function layoutToolbar() {
+    const bar = document.querySelector('#simNativeView .top-bar');
+    if (!bar || !toolbarFold) return;
+
+    restoreClusterMembers();
+    bar.classList.add('measuring');
+    const state = toolbarFold.plan((candidate) => {
+      applyToolbarState(candidate);
+      return bar.scrollWidth <= bar.clientWidth + 1;
+    });
+    bar.classList.remove('measuring');
+    fillFoldMenus(state);
+  }
+
+  /**
+   * Put every member element back in its own cluster, in declared
+   * order.
+   *
+   * A `choice` row MOVES the real control into the menu rather than
+   * copying it — a cloned picker would be a second `#nativeFormatPicker`
+   * with none of the page's handlers on it. That means the menu owns
+   * the only copy while it is folded, so wiping the popovers without
+   * this first deleted the codec picker outright: `getElementById`
+   * returned null for the rest of the session and the Stream menu
+   * silently lost its one interactive row. Restore, then rebuild.
+   */
+  function restoreClusterMembers() {
+    TOOLBAR_CLUSTERS.forEach((cluster) => {
+      const host = document.querySelector('[data-cluster="' + cluster.id + '"]');
+      if (!host) return;
+      cluster.members.forEach((member) => {
+        const el = document.getElementById(member.id);
+        if (el && el.parentElement !== host) host.appendChild(el);
+      });
+    });
+  }
+
+  /** Build the menu bodies once, for the state that won. */
+  function fillFoldMenus(state) {
+    restoreClusterMembers();
+    document.querySelectorAll('#simNativeView .tb-fold-pop')
+        .forEach((pop) => { pop.innerHTML = ''; });
+
+    const foldedClusters = TOOLBAR_CLUSTERS
+        .filter((c) => state.folded.indexOf(c.id) >= 0);
+
+    if (state.merged) {
+      const pop = document.querySelector('[data-fold="more"] .tb-fold-pop');
+      if (pop) {
+        foldedClusters.forEach((cluster) => pop.appendChild(accordion(cluster)));
+      }
+      return;
+    }
+    foldedClusters.forEach((cluster) => {
+      const pop = document.querySelector(
+          '[data-fold="' + cluster.id + '"] .tb-fold-pop');
+      if (!pop) return;
+      cluster.members.forEach((m) => {
+        const row = menuRow(m);
+        if (row) pop.appendChild(row);
+      });
+    });
+  }
+
+  /**
+   * One cluster as a collapsed accordion section.
+   *
+   * `<details>` will happily open all four at once, which puts all
+   * thirteen rows back and undoes the reason for having an accordion —
+   * so `name=` groups them where it is supported, and `syncAccordion`
+   * enforces it everywhere else.
+   */
+  function accordion(cluster) {
+    const details = document.createElement('details');
+    details.className = 'tb-acc';
+    details.setAttribute('name', 'nativeToolbarAcc');
+    const summary = document.createElement('summary');
+    summary.innerHTML = clusterSvg(cluster.icon) +
+        '<span>' + cluster.label + '</span>' +
+        '<span class="tb-acc-n">' + cluster.members.length + '</span>' + CARET_SVG;
+    details.appendChild(summary);
+    const body = document.createElement('div');
+    body.className = 'tb-acc-body';
+    cluster.members.forEach((m) => {
+      const row = menuRow(m);
+      if (row) body.appendChild(row);
+    });
+    details.appendChild(body);
+    return details;
+  }
+
+  /**
+   * A folded control as a menu row, rendered for what it IS.
+   *
+   *   action    a button; clicking the row clicks the real one
+   *   state     the same, plus a dot when it is currently on
+   *   choice    the real control, moved in — a value you cannot change
+   *             is a caption pretending to be a control
+   *   readout   no hover, no pointer: nothing happens when pressed
+   *
+   * `state` used to draw a SWITCH, which was wrong twice over. Every
+   * control that can reach this menu — status bar, location, camera,
+   * accessibility, logs — opens a PANEL; a switch says "a setting you
+   * flip and leave", and these are disclosures. And the switch made
+   * the row keep the menu open so you could see it move, which left
+   * the panel you had just opened sitting behind the menu covering it.
+   * A dot reports the same state without claiming to be a setting, and
+   * every row now closes the menu, because every row reveals something
+   * the menu is standing on top of.
+   */
+  function menuRow(member) {
+    const source = document.getElementById(member.id);
+    if (!source) return null;
+    const label = member.label || source.getAttribute('title') || member.id;
+
+    if (member.role === 'readout') {
+      const row = document.createElement('div');
+      row.className = 'tb-read';
+      row.innerHTML = clusterSvg('gauge') + '<span>' + label + '</span>' +
+          '<span class="tb-val"></span>';
+      row.querySelector('.tb-val').textContent = source.textContent || '—';
+      return row;
+    }
+
+    if (member.role === 'choice') {
+      const row = document.createElement('div');
+      row.className = 'tb-choice';
+      row.innerHTML = clusterSvg('codec') + '<span>' + label + '</span>';
+      // The real picker is moved in, not copied: it keeps its handlers,
+      // its `.active` pill, and its identity as the one control the
+      // rest of the page already talks to.
+      row.appendChild(source);
+      return row;
+    }
+
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'tb-row' + (source.classList.contains('active') ? ' on' : '');
+    const glyph = source.querySelector('svg');
+    row.innerHTML = (glyph ? glyph.outerHTML : clusterSvg('more')) +
+        '<span>' + label + '</span>' +
+        (member.role === 'state' ? '<span class="tb-dot"></span>' : '');
+    row.addEventListener('click', () => {
+      source.click();
+      closeFoldMenus();
+    });
+    return row;
+  }
+
+  function closeFoldMenus() {
+    document.querySelectorAll('#simNativeView .tb-fold-pop')
+        .forEach((n) => { n.hidden = true; });
+    document.querySelectorAll('#simNativeView .tb-fold-btn')
+        .forEach((n) => n.setAttribute('aria-expanded', 'false'));
+  }
+
+  function wireToolbarScroll() {
+    if (!buildToolbarClusters()) return;
+
+    document.addEventListener('click', (event) => {
+      const btn = event.target.closest('#simNativeView .tb-fold-btn');
+      if (btn) {
+        const pop = btn.parentElement.querySelector('.tb-fold-pop');
+        const open = btn.getAttribute('aria-expanded') === 'true';
+        closeFoldMenus();
+        if (!open) {
+          pop.hidden = false;
+          btn.setAttribute('aria-expanded', 'true');
+        }
+        return;
+      }
+      const summary = event.target.closest('#simNativeView .tb-acc > summary');
+      if (summary) {
+        // `name=` handles this in Chrome 120+/Safari 17.4+; do it by
+        // hand so older engines behave the same.
+        const self = summary.parentElement;
+        setTimeout(() => {
+          if (!self.open) return;
+          self.parentElement.querySelectorAll('.tb-acc').forEach((d) => {
+            if (d !== self) d.open = false;
+          });
+        }, 0);
+        return;
+      }
+      if (!event.target.closest('#simNativeView .tb-fold')) closeFoldMenus();
+    });
+
+    refreshToolbarScroll = layoutToolbar;
+    window.addEventListener('resize', layoutToolbar);
     // Re-measure once layout settles (fonts, device frame, format pills).
-    requestAnimationFrame(update);
-    setTimeout(update, 400);
+    requestAnimationFrame(layoutToolbar);
+    setTimeout(layoutToolbar, 400);
   }
 
   function wireActions() {

--- a/Sources/Baguette/Resources/Web/sim-native.js
+++ b/Sources/Baguette/Resources/Web/sim-native.js
@@ -1315,9 +1315,15 @@
       controls.appendChild(foldHost(cluster.id, cluster.label, cluster.icon));
     });
 
-    // The merged menu lives at the end, where the last folded cluster
-    // would have sat.
-    controls.appendChild(foldHost('more', 'More controls', 'more'));
+    // The merged menu sits where the folded clusters were — before
+    // Capture, since every foldable cluster precedes it. Appending it
+    // after Capture left it hanging off the right edge of the bar,
+    // reading as an afterthought rather than as the clusters it stands
+    // in for.
+    const captureHost = controls.querySelector('[data-cluster="capture"]');
+    const captureSep = controls.querySelector('[data-sep-for="capture"]');
+    controls.insertBefore(foldHost('more', 'More controls', 'more'),
+        captureSep || captureHost || null);
     strip.remove();
 
     toolbarFold = new window.Baguette._ToolbarFold(TOOLBAR_CLUSTERS);
@@ -1366,6 +1372,51 @@
    * is no width table to keep in sync with the CSS, and it stays right
    * when a device name is long or a webfont lands late.
    */
+  /**
+   * How many rows the bar's children currently occupy.
+   *
+   * The pane baguette gets squeezed into is NARROW AND TALL — a
+   * browser sidebar beside an editor. Spending the last of the width
+   * on an anonymous ⋯ throws away the one dimension that pane has
+   * plenty of, so the bar wraps to a second row first and only folds
+   * what a second row cannot hold. Named cluster buttons survive
+   * where they would otherwise have collapsed into a bucket.
+   *
+   * `scrollWidth` is useless once wrapping is on — the content always
+   * "fits" horizontally by definition — so the question becomes how
+   * many rows the children landed on.
+   *
+   * Grouped with a tolerance, not counted as distinct `offsetTop`s.
+   * The bar centres its children, so a 26px chip and a 30px button on
+   * the SAME row sit at different offsets; counting raw tops reported
+   * two rows for a bar that was visibly one.
+   */
+  function toolbarRows(bar) {
+    // The controls are children of `.tb-controls`, not of the bar, so
+    // walking `bar.children` counted the label and the control group —
+    // two boxes — and never saw the clusters wrap inside one of them.
+    const controls = bar.querySelector('.tb-controls');
+    const boxes = [bar.querySelector('.tb-label')].concat(
+        controls ? Array.prototype.slice.call(controls.children) : []);
+    const origin = bar.getBoundingClientRect().top;
+    const tops = [];
+    boxes.forEach((child) => {
+      if (!child || child.hidden || !child.offsetParent) return;
+      tops.push(Math.round(child.getBoundingClientRect().top - origin));
+    });
+    if (!tops.length) return 1;
+    tops.sort((a, b) => a - b);
+    let rows = 1;
+    for (let i = 1; i < tops.length; i += 1) {
+      // Anything further down than the tallest control could account
+      // for is a new row, not a taller sibling on the same one.
+      if (tops[i] - tops[i - 1] > 14) rows += 1;
+    }
+    return rows;
+  }
+
+  const TOOLBAR_MAX_ROWS = 2;
+
   function layoutToolbar() {
     const bar = document.querySelector('#simNativeView .top-bar');
     if (!bar || !toolbarFold) return;
@@ -1374,7 +1425,7 @@
     bar.classList.add('measuring');
     const state = toolbarFold.plan((candidate) => {
       applyToolbarState(candidate);
-      return bar.scrollWidth <= bar.clientWidth + 1;
+      return toolbarRows(bar) <= TOOLBAR_MAX_ROWS;
     });
     bar.classList.remove('measuring');
     fillFoldMenus(state);

--- a/Sources/Baguette/Resources/Web/sim-native.js
+++ b/Sources/Baguette/Resources/Web/sim-native.js
@@ -1372,51 +1372,6 @@
    * is no width table to keep in sync with the CSS, and it stays right
    * when a device name is long or a webfont lands late.
    */
-  /**
-   * How many rows the bar's children currently occupy.
-   *
-   * The pane baguette gets squeezed into is NARROW AND TALL — a
-   * browser sidebar beside an editor. Spending the last of the width
-   * on an anonymous ⋯ throws away the one dimension that pane has
-   * plenty of, so the bar wraps to a second row first and only folds
-   * what a second row cannot hold. Named cluster buttons survive
-   * where they would otherwise have collapsed into a bucket.
-   *
-   * `scrollWidth` is useless once wrapping is on — the content always
-   * "fits" horizontally by definition — so the question becomes how
-   * many rows the children landed on.
-   *
-   * Grouped with a tolerance, not counted as distinct `offsetTop`s.
-   * The bar centres its children, so a 26px chip and a 30px button on
-   * the SAME row sit at different offsets; counting raw tops reported
-   * two rows for a bar that was visibly one.
-   */
-  function toolbarRows(bar) {
-    // The controls are children of `.tb-controls`, not of the bar, so
-    // walking `bar.children` counted the label and the control group —
-    // two boxes — and never saw the clusters wrap inside one of them.
-    const controls = bar.querySelector('.tb-controls');
-    const boxes = [bar.querySelector('.tb-label')].concat(
-        controls ? Array.prototype.slice.call(controls.children) : []);
-    const origin = bar.getBoundingClientRect().top;
-    const tops = [];
-    boxes.forEach((child) => {
-      if (!child || child.hidden || !child.offsetParent) return;
-      tops.push(Math.round(child.getBoundingClientRect().top - origin));
-    });
-    if (!tops.length) return 1;
-    tops.sort((a, b) => a - b);
-    let rows = 1;
-    for (let i = 1; i < tops.length; i += 1) {
-      // Anything further down than the tallest control could account
-      // for is a new row, not a taller sibling on the same one.
-      if (tops[i] - tops[i - 1] > 14) rows += 1;
-    }
-    return rows;
-  }
-
-  const TOOLBAR_MAX_ROWS = 2;
-
   function layoutToolbar() {
     const bar = document.querySelector('#simNativeView .top-bar');
     if (!bar || !toolbarFold) return;
@@ -1425,7 +1380,7 @@
     bar.classList.add('measuring');
     const state = toolbarFold.plan((candidate) => {
       applyToolbarState(candidate);
-      return toolbarRows(bar) <= TOOLBAR_MAX_ROWS;
+      return bar.scrollWidth <= bar.clientWidth + 1;
     });
     bar.classList.remove('measuring');
     fillFoldMenus(state);

--- a/Sources/Baguette/Resources/Web/sim.html
+++ b/Sources/Baguette/Resources/Web/sim.html
@@ -62,6 +62,10 @@
 <script src="/capture/capture-settings.js"></script>
 <script src="/capture/capture-composer.js"></script>
 <script src="/capture/capture-size-menu.js"></script>
+<!-- Toolbar cluster folding (Resources/Web/toolbar/). Must load before
+     sim-native.js, which builds the clusters at init and needs
+     `window.Baguette._ToolbarFold` to decide what folds. -->
+<script src="/toolbar/toolbar-fold.js"></script>
 <script src="/capture-gallery.js"></script>
 <script src="/recorder.js"></script>
 <script src="/stream-session.js"></script>

--- a/Sources/Baguette/Resources/Web/toolbar/toolbar-fold.js
+++ b/Sources/Baguette/Resources/Web/toolbar/toolbar-fold.js
@@ -1,0 +1,97 @@
+// ToolbarFold — what the focus toolbar gives up when the row is too
+// narrow, and in what order.
+//
+// The focus toolbar carries fifteen controls, but only seven ideas:
+// Navigate, Stream, View, Control, Simulate, Inspect, Capture. When the
+// row will not fit, a WHOLE cluster folds into one menu button — never
+// an item, never a partial group. A flat per-control priority queue was
+// tried first and tore Shake off Home on a tie-break between equal
+// ranks; see docs/mockups/focus-toolbar-overflow.html, which runs both.
+//
+// This class owns no DOM. The caller hands it a `fits` callback that
+// renders a candidate state and reports whether the row fits; it hands
+// back the first state that did. That split is the point — the
+// arithmetic is unit-tested here and the rendering stays
+// integration-only, same bar as sim-native.js itself.
+//
+//   const fold = new ToolbarFold(CLUSTERS);
+//   const plan = fold.plan((state) => {
+//     paint(state);                                   // your DOM
+//     return bar.scrollWidth <= bar.clientWidth + 1;  // your measure
+//   });
+//   plan  // → { folded: ['simulate'], merged: false, tight: false }
+//
+// Re-measuring after every candidate is deliberate: there is no width
+// table to keep in sync with the CSS, and it stays right when a device
+// name is long or a webfont lands late.
+(function (root) {
+  'use strict';
+
+  class ToolbarFold {
+    /**
+     * @param {Array<{id: string, fold?: number}>} clusters
+     *   Array order is where a cluster SITS; `fold` is how hard it
+     *   holds on, lowest folding first. A cluster with no `fold` never
+     *   folds — Navigate, View and Capture, because Capture is the job.
+     */
+    constructor(clusters) {
+      this.clusters = clusters || [];
+    }
+
+    /** The ids that can fold, in the order they will. */
+    get order() {
+      return this.clusters
+        .filter((c) => c.fold)
+        .slice()
+        .sort((a, b) => a.fold - b.fold)
+        .map((c) => c.id);
+    }
+
+    /**
+     * Offer progressively narrower states to `fits` until one is
+     * accepted, and return it.
+     *
+     * The states, in order:
+     *   1. nothing folded
+     *   2. …each cluster folded in turn, down the fold order
+     *   3. every folded cluster merged into one menu — a LAST RESORT,
+     *      not a threshold. Separate cluster buttons keep their
+     *      meaning (you can go straight to Simulate), so they survive
+     *      until even they will not fit. One folded cluster is already
+     *      its own menu, so merging it would swap a named button for
+     *      an anonymous one and save nothing.
+     *   4. the device name truncates. Everything above either vanishes
+     *      into a menu or is pinned; the name is the only control that
+     *      can survive at a smaller size, which makes it the cheapest
+     *      thing left to give — and the last.
+     *
+     * The final state is returned whether or not it fit: past step 4
+     * there is nothing else to try.
+     *
+     * @param {(state: {folded: string[], merged: boolean, tight: boolean}) => boolean} fits
+     * @returns {{folded: string[], merged: boolean, tight: boolean}}
+     */
+    plan(fits) {
+      const state = { folded: [], merged: false, tight: false };
+      if (fits(state)) return state;
+
+      const order = this.order;
+      for (let i = 0; i < order.length; i += 1) {
+        state.folded.push(order[i]);
+        if (fits(state)) return state;
+      }
+
+      if (state.folded.length > 1) {
+        state.merged = true;
+        if (fits(state)) return state;
+      }
+
+      state.tight = true;
+      fits(state);
+      return state;
+    }
+  }
+
+  root.Baguette = root.Baguette || {};
+  root.Baguette._ToolbarFold = ToolbarFold;
+})(window);

--- a/Tests/Web/capture-size.test.js
+++ b/Tests/Web/capture-size.test.js
@@ -178,3 +178,45 @@ test('spec round-trips through parse for every preset and for custom sizes', () 
   }
   assert.equal(CS.parse(CS.parse('1920x1080').spec).spec, '1920x1080');
 });
+
+// ── the terse spelling the toolbar chip wears ────────────────
+
+// The chip used to render `label`, so it was "Native" (54px) one
+// moment and "App Store iPad 13″" (132px) the next — the one control
+// whose width the user changes by using it, in a toolbar that is a
+// single row of fixed-size controls. `code` is the same choice in at
+// most four tabular characters, so the chip can hold one width.
+
+test('every preset carries a terse code for the chip', () => {
+  const catalogue = CaptureSize();
+  assert.deepEqual(catalogue.presets().map((p) => p.code), [
+    'Auto', '6.9″', '6.5″', '13″', '1:1', '16:9', '9:16', '4:3', '4:5',
+  ]);
+});
+
+test('an ad-hoc ratio is already terse, so it is its own code', () => {
+  assert.equal(CaptureSize().parse('3:2').code, '3:2');
+});
+
+// A literal pixel spec has no short spelling — "1920x1080" is wider
+// than the label it replaced. The chip says Custom and the popover's
+// resolved dimensions say which.
+test('a literal pixel spec reads as Custom on the chip', () => {
+  assert.equal(CaptureSize().parse('1920x1080').code, 'Custom');
+});
+
+// ── the aspect the chip draws ────────────────────────────────
+
+test('a ratio reports its ratio exactly, not a rounded resolve', () => {
+  assert.equal(CaptureSize().parse('16:9').aspect(), 16 / 9);
+});
+
+test('a fixed size reports its own pixel aspect', () => {
+  assert.equal(CaptureSize().named('appstore-6.9').aspect(), 1290 / 2796);
+});
+
+// Native has no shape of its own — it is whatever the source is — so
+// the chip draws nothing rather than guessing a rectangle.
+test('native reports no aspect at all', () => {
+  assert.equal(CaptureSize().named('native').aspect(), null);
+});

--- a/Tests/Web/toolbar-fold.test.js
+++ b/Tests/Web/toolbar-fold.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+// ToolbarFold decides WHAT the focus toolbar gives up when the row is
+// too narrow. It owns no DOM: the caller hands it a `fits` callback
+// that renders a candidate state and reports whether it fits, and gets
+// back the first state that did. That split is what makes the
+// arithmetic testable — the rendering stays integration-only, same bar
+// as sim-native.js itself.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { loadBrowserModules } = require('./helpers/load-browser-module.js');
+
+const WEB = path.join(
+  __dirname, '..', '..', 'Sources', 'Baguette', 'Resources', 'Web', 'toolbar'
+);
+
+function ToolbarFold() {
+  return loadBrowserModules([path.join(WEB, 'toolbar-fold.js')])
+    .Baguette._ToolbarFold;
+}
+
+// Array order is where a cluster SITS; `fold` is how hard it holds on.
+// Deliberately declared out of fold order here — a cluster that
+// survives a narrowing must not also move, so the two orders have to
+// stay independent.
+const CLUSTERS = [
+  { id: 'nav' },
+  { id: 'stream',   fold: 3 },
+  { id: 'view' },
+  { id: 'control',  fold: 4 },
+  { id: 'simulate', fold: 1 },
+  { id: 'inspect',  fold: 2 },
+  { id: 'capture' },
+];
+
+/** A `fits` stub that refuses the first `n` candidates, then accepts. */
+function refusing(n) {
+  const seen = [];
+  const fits = (state) => {
+    seen.push({
+      folded: state.folded.slice(), merged: state.merged, tight: state.tight,
+    });
+    return seen.length > n;
+  };
+  fits.seen = seen;
+  return fits;
+}
+
+// ── nothing to do ────────────────────────────────────────────────
+
+test('a row that already fits folds nothing', () => {
+  const plan = new (ToolbarFold())(CLUSTERS).plan(refusing(0));
+  assert.deepEqual(plan, { folded: [], merged: false, tight: false });
+});
+
+// ── folding, in fold order ───────────────────────────────────────
+
+test('the worst-ranked cluster folds first', () => {
+  const plan = new (ToolbarFold())(CLUSTERS).plan(refusing(1));
+  assert.deepEqual(plan.folded, ['simulate']);
+});
+
+test('folding continues down the fold order, not the array order', () => {
+  const plan = new (ToolbarFold())(CLUSTERS).plan(refusing(3));
+  assert.deepEqual(plan.folded, ['simulate', 'inspect', 'stream']);
+});
+
+test('a cluster with no fold rank never folds', () => {
+  const plan = new (ToolbarFold())(CLUSTERS).plan(refusing(99));
+  assert.deepEqual(plan.folded, ['simulate', 'inspect', 'stream', 'control']);
+});
+
+// ── merging is a last resort ─────────────────────────────────────
+
+// Separate cluster buttons keep their meaning — you can go straight to
+// Simulate — so they survive until even they will not fit.
+test('four folded clusters stay four buttons while they fit', () => {
+  const plan = new (ToolbarFold())(CLUSTERS).plan(refusing(4));
+  assert.equal(plan.merged, false);
+  assert.equal(plan.folded.length, 4);
+});
+
+test('merging happens only after every cluster has folded', () => {
+  const fits = refusing(5);
+  const plan = new (ToolbarFold())(CLUSTERS).plan(fits);
+  assert.equal(plan.merged, true);
+  assert.deepEqual(fits.seen[5], {
+    folded: ['simulate', 'inspect', 'stream', 'control'],
+    merged: true, tight: false,
+  });
+});
+
+// One folded cluster IS its own menu already; merging it would swap a
+// named button for an anonymous one and save nothing.
+test('a single folded cluster is never merged', () => {
+  const only = [{ id: 'nav' }, { id: 'simulate', fold: 1 }, { id: 'capture' }];
+  const plan = new (ToolbarFold())(only).plan(refusing(99));
+  assert.deepEqual(plan, { folded: ['simulate'], merged: false, tight: true });
+});
+
+// ── the device name is the last thing to give ────────────────────
+
+test('the name truncates only when nothing else is left to fold', () => {
+  const plan = new (ToolbarFold())(CLUSTERS).plan(refusing(99));
+  assert.equal(plan.tight, true);
+  assert.equal(plan.merged, true);
+});
+
+test('a row that fits after merging never goes tight', () => {
+  assert.equal(new (ToolbarFold())(CLUSTERS).plan(refusing(5)).tight, false);
+});
+
+// ── the caller sees every candidate, in order ────────────────────
+
+test('each candidate is offered exactly once, widest first', () => {
+  const fits = refusing(99);
+  new (ToolbarFold())(CLUSTERS).plan(fits);
+  assert.deepEqual(fits.seen.map((s) => s.folded.length), [0, 1, 2, 3, 4, 4, 4]);
+  assert.deepEqual(fits.seen.map((s) => s.merged), [false, false, false, false, false, true, true]);
+  assert.deepEqual(fits.seen.map((s) => s.tight), [false, false, false, false, false, false, true]);
+});
+
+// ── the fold order is readable on its own ────────────────────────
+
+test('reports its fold order so a caller can explain itself', () => {
+  assert.deepEqual(new (ToolbarFold())(CLUSTERS).order,
+    ['simulate', 'inspect', 'stream', 'control']);
+});

--- a/docs/mockups/focus-toolbar-overflow.html
+++ b/docs/mockups/focus-toolbar-overflow.html
@@ -1,0 +1,1098 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Focus toolbar — context clusters</title>
+<!--
+  ────────────────────────────────────────────────────────────────────
+  Baguette · Focus toolbar at narrow widths — mockup (single file)
+  ────────────────────────────────────────────────────────────────────
+
+  THE REPORT. baguette is increasingly opened in a pane nowhere near
+  1280px — a browser sidebar beside an editor, an agent's built-in
+  browser, a split window. The focus toolbar carries fifteen controls
+  in one row, so at ~420px it becomes a horizontal scroller with a ‹ ›
+  on each end, and every control past the fourth sits behind a scroll
+  gesture wearing an unlabelled glyph.
+
+  THE FIRST ANSWER, AND WHY IT WAS WRONG. Rank every control; park the
+  worst-ranked one until the row fits. It fits — and it produces
+  nonsense. At 640px that queue kept Home, App switcher and Rotate but
+  dropped Shake; it kept Logs and dropped Accessibility. Those are
+  faces of one idea and the queue tore them in half on a tie-break
+  between equal ranks. A flat priority queue is a FALLBACK MECHANISM
+  being asked to do a DESIGN's job. The last section runs it for real
+  so you can watch it happen.
+
+  THE DESIGN. Fifteen controls, but only seven ideas, and each answers
+  a different question:
+
+    Navigate   back, device name         which device am I on
+    Stream     codec, fps, iOS version   how am I seeing it
+    View       3D                        …in which projection
+    Control    home, apps, shake, rotate things I do TO the phone
+    Simulate   location, status bar,     things I FEED the phone
+               camera, microphone
+    Inspect    accessibility, logs       things I read OUT of it
+    Capture    screenshot, record, size  the job I came to do
+
+  Each is a cluster with a divider. When the row will not fit, the next
+  cluster in the fold order collapses WHOLE, into one menu button.
+  Never an item; never a partial group.
+
+    fold order:  Simulate → Inspect → Control → Stream
+    never folds: Navigate, View, Capture
+
+  Measured on this page, the bar degrades like this:
+
+    1178px   nothing folded — all seven clusters inline
+     998px   Simulate
+     898px   + Inspect, Control
+     778px   + Stream           four separate cluster buttons
+     518px   merged into one ⋯  with the cluster names as headings
+
+  Three things this buys that the queue cannot:
+
+   • DETERMINISTIC. No tie-breaks, no reshuffling. You learn where a
+     control lives once and the bar keeps that promise at every width.
+   • THE MENU IS BETTER THAN THE GLYPHS IT REPLACES. Four unlabelled
+     icons become four labelled rows. Someone who cannot tell the
+     status-bar icon from the signal-bars icon can read "Status bar".
+   • MERGING IS A LAST RESORT, NOT A THRESHOLD. Separate cluster
+     buttons keep their meaning — you can go straight to Simulate — so
+     they survive until even they will not fit.
+
+  THE ONE THING THAT HAD TO BE MEASURED, NOT ASSUMED. A folded cluster
+  is an ICON plus a caret, never a text label. Folding must be a
+  saving, and "🔍 Inspect ⌄" is 85px replacing two 30px glyphs — the
+  first version of this genuinely made the bar WIDER by folding
+  Inspect. Icon + caret is ~40px against 60–120px of glyphs. The
+  cluster names still do their work, in the menu headings and the
+  button's tooltip.
+
+  THE COST, STATED PLAINLY. Home becomes two clicks at 640px where it
+  is one today, and Home is frequent. The counter is that today at
+  640px it is one click PLUS a scroll gesture past six icons. If
+  Control should outrank Stream that is one number — `fold` on the
+  cluster — and it is a product call, not a technical one.
+
+  The size chip keeps the aspect grid from capture-size-menu.html: nine
+  presets as nine shapes, because picking an output size IS picking a
+  shape.
+-->
+<style>
+  /* Theme tokens lifted from sim-native.html so the mockup matches
+     focus mode pixel-for-pixel. Dark by default; [data-theme="light"]
+     flips it. */
+  #view {
+    color-scheme: light dark;
+    --nv-page-bg:        #1a1a1f;
+    --nv-bar-bg:         rgba(20, 20, 24, 0.78);
+    --nv-bar-border:     rgba(255, 255, 255, 0.08);
+    --nv-bar-shadow:     0 8px 24px rgba(0, 0, 0, 0.45);
+    --nv-bar-inset:      0 1px 0 rgba(255, 255, 255, 0.05) inset;
+    --nv-text:           #f5f5f7;
+    --nv-text-muted:     rgba(245, 245, 247, 0.55);
+    --nv-text-faint:     rgba(245, 245, 247, 0.5);
+    --nv-divider:        rgba(255, 255, 255, 0.12);
+    --nv-btn:            rgba(255, 255, 255, 0.06);
+    --nv-btn-hover:      rgba(255, 255, 255, 0.10);
+    --nv-panel:          #232329;
+    --nv-fmt-track-bg:   rgba(255, 255, 255, 0.06);
+    --nv-fmt-btn-text:   rgba(245, 245, 247, 0.65);
+    --nv-accent:         #2563eb;
+    --nv-accent-text:    #fff;
+    --nv-warn:           #f0883e;
+  }
+  #view[data-theme="light"] {
+    --nv-page-bg:        #f1f3f6;
+    --nv-bar-bg:         rgba(255, 255, 255, 0.86);
+    --nv-bar-border:     rgba(15, 23, 42, 0.08);
+    --nv-bar-shadow:     0 6px 22px rgba(15, 23, 42, 0.12);
+    --nv-bar-inset:      0 1px 0 rgba(255, 255, 255, 0.7) inset;
+    --nv-text:           #1d1d1f;
+    --nv-text-muted:     rgba(29, 29, 31, 0.65);
+    --nv-text-faint:     rgba(29, 29, 31, 0.55);
+    --nv-divider:        rgba(15, 23, 42, 0.14);
+    --nv-btn:            rgba(15, 23, 42, 0.05);
+    --nv-btn-hover:      rgba(15, 23, 42, 0.09);
+    --nv-panel:          #ffffff;
+    --nv-fmt-track-bg:   rgba(15, 23, 42, 0.06);
+    --nv-fmt-btn-text:   rgba(29, 29, 31, 0.65);
+    --nv-warn:           #c2410c;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body { font: 400 13px/1.5 ui-sans-serif, -apple-system, system-ui, sans-serif; }
+  #view {
+    min-height: 100vh; padding: 28px 24px 140px;
+    background: var(--nv-page-bg); color: var(--nv-text);
+  }
+  .wrap { max-width: 1180px; margin: 0 auto; }
+  h1 { font: 700 20px/1.3 inherit; margin: 0 0 4px; letter-spacing: -0.01em; }
+  .sub { color: var(--nv-text-muted); font-size: 12px; margin: 0 0 26px; max-width: 68ch; }
+  h2 {
+    font: 700 12px/1 inherit; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--nv-text-faint); margin: 40px 0 10px; padding-bottom: 8px;
+    border-bottom: 1px solid var(--nv-divider);
+  }
+  h2 .tag { float: right; letter-spacing: 0; text-transform: none; font-weight: 600; }
+  h2 .tag.good { color: var(--nv-accent); }
+  h2 .tag.bad  { color: var(--nv-warn); }
+  .note { color: var(--nv-text-muted); font-size: 12px; margin: 0 0 14px; max-width: 68ch; }
+  .note b { color: var(--nv-text); font-weight: 600; }
+  .note code {
+    font: 500 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+    background: var(--nv-btn); padding: 1px 4px; border-radius: 4px;
+  }
+
+  .controls { display: flex; align-items: center; gap: 6px; margin-bottom: 12px; flex-wrap: wrap; }
+  .controls button {
+    height: 26px; padding: 0 10px; border-radius: 7px; cursor: pointer;
+    background: var(--nv-btn); border: 1px solid var(--nv-divider);
+    color: var(--nv-text); font: 600 11px/1 inherit;
+  }
+  .controls button.on {
+    background: var(--nv-accent); color: var(--nv-accent-text); border-color: transparent;
+  }
+  .readout {
+    margin-left: auto; font: 600 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--nv-text-muted); font-variant-numeric: tabular-nums; text-align: right;
+  }
+
+  .pane {
+    position: relative; width: 1180px; max-width: 100%;
+    border: 1px dashed var(--nv-divider); border-radius: 14px;
+    padding: 18px 12px 26px; background: var(--nv-page-bg);
+    /* `overflow: hidden` is what `resize` needs to work, and it was
+       also clipping every popover the bar opened — a mockup artifact,
+       not a design problem: in the real page the toolbar sits at the
+       top of a full-height view. Clip only horizontally, and give the
+       pane the height a real one has. */
+    resize: horizontal; overflow-x: hidden; min-width: 320px; height: 620px;
+  }
+  .pane::after {
+    content: 'drag →'; position: absolute; right: 10px; bottom: 6px;
+    font: 600 9px/1 ui-monospace, Menlo, monospace; color: var(--nv-text-faint);
+    pointer-events: none;
+  }
+  .bar-stage { display: flex; justify-content: center; }
+
+  .nv-bar {
+    display: inline-flex; align-items: center; gap: 7px; max-width: 100%;
+    height: 44px; padding: 0 10px;
+    background: var(--nv-bar-bg); border: 1px solid var(--nv-bar-border);
+    border-radius: 999px; box-shadow: var(--nv-bar-shadow), var(--nv-bar-inset);
+    backdrop-filter: blur(18px) saturate(1.5);
+  }
+  /* Clipping is what makes `scrollWidth` meaningful, but a clipped bar
+     also cuts off every popover hanging out of it — so it is worn only
+     for the duration of the measuring loop. */
+  .nv-bar.measuring { overflow: hidden; }
+
+  .nv-name {
+    font: 700 13px/1 inherit; white-space: nowrap; flex: 0 1 auto;
+    overflow: hidden; text-overflow: ellipsis; max-width: 180px;
+    /* A floor, not a suggestion: without it flexbox shrinks the name to
+       one letter and the fit loop calls that a fit — the bar reporting
+       success while telling you nothing about which device you are on.
+       Folding a cluster is the cheaper sacrifice, so the floor forces
+       the loop to make it. */
+    min-width: 76px;
+  }
+  /* Once every cluster is folded and merged there is nothing left to
+     give but the name, so its floor drops and it truncates. 38px of
+     overflow at 418px was clipping the size chip — the one control
+     Capture pins precisely because it is the job. A shortened name is
+     the cheaper loss: the header still says which device, and it is
+     the only thing on the bar that can shrink instead of vanish. */
+  .nv-bar.tight .nv-name { min-width: 40px; }
+  .nv-os { font: 500 11px/1 inherit; color: var(--nv-text-faint); white-space: nowrap; }
+  .nv-fps {
+    color: var(--nv-text-muted); white-space: nowrap;
+    font: 500 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-variant-numeric: tabular-nums;
+  }
+  .fmt-picker {
+    display: inline-flex; padding: 2px; background: var(--nv-fmt-track-bg);
+    border: 1px solid var(--nv-divider); border-radius: 999px;
+  }
+  .fmt-btn {
+    border: 0; padding: 0 9px; height: 22px; background: transparent;
+    color: var(--nv-fmt-btn-text); font: 700 10px/1 inherit;
+    letter-spacing: 0.04em; border-radius: 999px; cursor: pointer;
+  }
+  .fmt-btn.active { background: var(--nv-accent); color: var(--nv-accent-text); }
+
+  .tb-actions { display: inline-flex; align-items: center; gap: 2px; flex: none; }
+  .ico-btn {
+    position: relative; flex: none;
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 30px; height: 28px; padding: 0;
+    background: transparent; border: 0; border-radius: 8px;
+    color: var(--nv-text); cursor: pointer;
+  }
+  .ico-btn:hover { background: var(--nv-btn-hover); }
+  .ico-btn.active { background: var(--nv-accent); color: var(--nv-accent-text); }
+  .ico-btn svg { display: block; }
+  .sep { width: 1px; height: 18px; background: var(--nv-divider); flex: none; }
+
+  /* A folded cluster: ICON + caret, never a text label.
+     Folding has to be a saving, and a text label makes it a cost —
+     "Inspect" is two 30px glyphs replaced by an 85px button, so the
+     bar gets WIDER by folding. Icon + caret is ~40px against 60–120px
+     of glyphs, which always saves. The names still appear where they
+     do the work: as the menu's section headings and the button's
+     tooltip. Four cryptic glyphs become four labelled rows — that was
+     always the win, and it lives inside the menu, not on its button. */
+  .fold { position: relative; display: inline-flex; flex: none; }
+  .fold-btn {
+    display: inline-flex; align-items: center; gap: 2px;
+    height: 28px; padding: 0 5px 0 6px; border-radius: 8px; cursor: pointer;
+    background: transparent; border: 1px solid transparent;
+    color: var(--nv-text); font: 600 11px/1 inherit; white-space: nowrap;
+  }
+  .fold-btn:hover { background: var(--nv-btn-hover); }
+  .fold-btn[aria-expanded="true"] { border-color: var(--nv-accent); color: var(--nv-accent); }
+  .fold-btn .caret { width: 10px; height: 10px; opacity: 0.55; }
+
+  .fold-pop {
+    position: absolute; z-index: 60; top: calc(100% + 8px); left: 50%;
+    transform: translateX(-50%);
+    width: 208px; padding: 6px; border-radius: 12px;
+    background: var(--nv-panel); border: 1px solid var(--nv-divider);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.34);
+    font: 500 12px/1.3 inherit; color: var(--nv-text);
+    max-height: 58vh; overflow: auto;
+  }
+  .fold-pop.right { left: auto; right: 0; transform: none; }
+  .fold-pop[hidden] { display: none; }
+  /* MERGED MODE IS AN ACCORDION, NOT A LIST.
+     Four clusters flattened into one popover is thirteen rows — which
+     is the original complaint ("the menu has too many things") moved
+     down a level rather than answered. Collapsed, it is four rows;
+     you open the one you want. Uses <details> for the same reason the
+     size popover's Options row does: no state to lose, keyboard and
+     screen readers get it for free. */
+  .fold-acc { border-radius: 8px; }
+  .fold-acc + .fold-acc { margin-top: 1px; }
+  .fold-acc > summary {
+    list-style: none; cursor: pointer;
+    display: flex; align-items: center; gap: 9px;
+    padding: 8px; border-radius: 8px;
+    font: 600 12px/1.3 inherit; color: var(--nv-text);
+  }
+  .fold-acc > summary::-webkit-details-marker { display: none; }
+  .fold-acc > summary:hover { background: var(--nv-btn-hover); }
+  .fold-acc > summary svg.lead { flex: none; opacity: 0.8; }
+  .fold-acc > summary .n {
+    margin-left: auto; font-size: 10px; font-weight: 500;
+    color: var(--nv-text-faint); font-variant-numeric: tabular-nums;
+  }
+  .fold-acc > summary .chev { flex: none; opacity: 0.5; transition: transform 0.15s ease; }
+  .fold-acc[open] > summary .chev { transform: rotate(180deg); }
+  .fold-acc[open] > summary { color: var(--nv-accent); }
+  .fold-acc-body { padding: 1px 0 5px 8px; }
+
+  .fold-group {
+    font: 700 9px/1 inherit; letter-spacing: 0.07em; text-transform: uppercase;
+    color: var(--nv-text-faint); margin: 9px 0 4px; padding: 0 8px;
+  }
+  .fold-group:first-child { margin-top: 4px; }
+  /* A MENU ROW IS NOT ONE THING.
+     Flattening every control to icon + label + value silently turned
+     the codec picker into a caption — "Codec  H.264" with no way to
+     reach MJPEG. Four kinds, four renderings:
+
+       action    Home, Shake, Screenshot   a button; tap and it happens
+       toggle    3D, Logs, Status bar      on/off, so it shows which
+       choice    Codec, Output size        needs the options themselves
+       readout   iOS version, Frame rate   not a control at all */
+  .fold-item {
+    display: flex; align-items: center; gap: 9px; width: 100%;
+    padding: 7px 8px; border: 0; border-radius: 8px; cursor: pointer;
+    background: transparent; color: inherit; font: inherit; text-align: left;
+  }
+  .fold-item:hover { background: var(--nv-btn-hover); }
+  .fold-item svg { flex: none; opacity: 0.85; }
+  .fold-item .val {
+    margin-left: auto; font-size: 11px; color: var(--nv-text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+  .fold-item.on { color: var(--nv-accent); }
+  .fold-item.on svg { opacity: 1; }
+
+  /* toggle — the state is the point, so it is drawn, not implied */
+  .fold-item .sw {
+    margin-left: auto; flex: none; width: 26px; height: 15px;
+    border-radius: 999px; background: var(--nv-btn);
+    border: 1px solid var(--nv-divider); position: relative;
+  }
+  .fold-item .sw::after {
+    content: ''; position: absolute; top: 1px; left: 1px;
+    width: 11px; height: 11px; border-radius: 999px;
+    background: var(--nv-text-faint); transition: transform 0.15s ease;
+  }
+  .fold-item.on .sw { background: var(--nv-accent); border-color: transparent; }
+  .fold-item.on .sw::after { background: #fff; transform: translateX(11px); }
+
+  /* choice — the options come with it, because a value you cannot
+     change is a caption pretending to be a control */
+  .fold-choice {
+    display: flex; align-items: center; gap: 9px;
+    padding: 6px 8px; border-radius: 8px;
+  }
+  .fold-choice > svg { flex: none; opacity: 0.85; }
+  .fold-choice > .lbl { white-space: nowrap; }
+  .fold-choice .cap-seg { margin-left: auto; flex: 0 1 auto; min-width: 0; }
+  .fold-choice .cap-seg button { padding: 4px 7px; }
+
+  /* readout — no hover, no pointer: nothing happens when you press it */
+  .fold-read {
+    display: flex; align-items: center; gap: 9px; width: 100%;
+    padding: 7px 8px; cursor: default; color: var(--nv-text-muted);
+  }
+  .fold-read > svg { flex: none; opacity: 0.55; }
+  .fold-read .val {
+    margin-left: auto; font-size: 11px; color: var(--nv-text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* ── size chip + aspect grid ───────────────────────────────────── */
+  .cap { position: relative; display: inline-flex; flex: none; }
+  .cap-chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    height: 26px; padding: 0 8px; border-radius: 7px; cursor: pointer;
+    font: 600 11px/1 inherit; white-space: nowrap;
+    color: var(--nv-text); background: var(--nv-btn);
+    border: 1px solid var(--nv-divider);
+  }
+  .cap-chip[aria-expanded="true"] { border-color: var(--nv-accent); color: var(--nv-accent); }
+  /* Every code fits four tabular characters ("9:16", "6.9″", "1:1"),
+     so the box is sized for the widest and the toolbar stops dancing
+     as the selection changes. */
+  .cap-code { min-width: 34px; text-align: center; font-variant-numeric: tabular-nums; }
+  .ratio-glyph { width: 13px; height: 13px; flex: none; display: grid; place-items: center; }
+  .ratio-glyph i { display: block; border: 1.5px solid currentColor; border-radius: 2px; }
+  .caret { width: 11px; height: 11px; flex: none; opacity: 0.6; }
+
+  .cap-pop {
+    position: absolute; z-index: 60; top: calc(100% + 8px); right: 0;
+    width: 268px; padding: 10px; border-radius: 12px;
+    background: var(--nv-panel); border: 1px solid var(--nv-divider);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.34);
+    font: 500 11px/1.4 inherit; color: var(--nv-text);
+  }
+  .cap-pop[hidden] { display: none; }
+  .cap-head {
+    display: flex; align-items: baseline; gap: 6px;
+    font: 700 9px/1 inherit; letter-spacing: 0.07em; text-transform: uppercase;
+    color: var(--nv-text-faint); margin: 0 0 7px; padding: 0 2px;
+  }
+  .cap-head .now {
+    margin-left: auto; letter-spacing: 0; text-transform: none;
+    font: 600 10px/1 inherit; color: var(--nv-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .cap-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; }
+  .cap-grid button {
+    display: flex; flex-direction: column; align-items: center; gap: 5px;
+    padding: 7px 4px 6px; border: 1px solid transparent; border-radius: 8px;
+    background: transparent; color: inherit; cursor: pointer; font: inherit;
+  }
+  .cap-grid button:hover { background: var(--nv-btn-hover); }
+  .cap-grid button[aria-checked="true"] {
+    background: var(--nv-accent); color: var(--nv-accent-text);
+  }
+  .cap-thumb { height: 34px; display: grid; place-items: center; }
+  .cap-thumb i { display: block; border: 1.5px solid currentColor; border-radius: 2.5px; opacity: 0.9; }
+  .cap-grid .lbl { font: 600 9.5px/1 inherit; white-space: nowrap; }
+  .cap-grid .px { font-size: 8.5px; font-variant-numeric: tabular-nums; color: var(--nv-text-faint); }
+  .cap-grid button[aria-checked="true"] .px { color: rgba(255,255,255,0.75); }
+  .cap-more { margin-top: 8px; border-top: 1px solid var(--nv-divider); padding-top: 7px; }
+  .cap-more > summary {
+    list-style: none; cursor: pointer; display: flex; align-items: center; gap: 6px;
+    font: 700 10px/1 inherit; letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--nv-text-faint); padding: 2px;
+  }
+  .cap-more > summary::-webkit-details-marker { display: none; }
+  .cap-more > summary .sum {
+    margin-left: auto; letter-spacing: 0; text-transform: none;
+    font-weight: 500; color: var(--nv-text-muted);
+  }
+  .cap-more > summary .chev { transition: transform 0.15s ease; }
+  .cap-more[open] > summary .chev { transform: rotate(180deg); }
+  .cap-more-body { padding: 8px 2px 2px; display: grid; gap: 9px; }
+  .cap-row { display: flex; align-items: center; gap: 8px; }
+  .cap-row > .k { width: 62px; flex: none; font-size: 10px; color: var(--nv-text-muted); }
+  .cap-seg { display: flex; flex: 1; gap: 2px; padding: 2px; border-radius: 7px; background: var(--nv-btn); }
+  .cap-seg button {
+    flex: 1; padding: 4px 0; border: 0; border-radius: 5px; cursor: pointer;
+    background: transparent; color: inherit; font: 600 10px/1 inherit;
+  }
+  .cap-seg button[aria-checked="true"] { background: var(--nv-panel); box-shadow: 0 1px 2px rgba(0,0,0,0.28); }
+  .cap-row input[type="text"] {
+    flex: 1; min-width: 0; height: 24px; padding: 0 7px;
+    border: 1px solid var(--nv-divider); border-radius: 6px;
+    background: var(--nv-btn); color: inherit; font: inherit;
+  }
+  .cap-row input[type="color"] {
+    width: 28px; height: 24px; padding: 0; cursor: pointer;
+    border: 1px solid var(--nv-divider); border-radius: 6px; background: none;
+  }
+  .cap-row label { display: flex; align-items: center; gap: 5px; cursor: pointer; }
+
+  /* today's scroller */
+  .today-bar {
+    display: flex; align-items: center; gap: 6px; max-width: 100%;
+    height: 44px; padding: 0 6px;
+    background: var(--nv-bar-bg); border: 1px solid var(--nv-bar-border);
+    border-radius: 999px; box-shadow: var(--nv-bar-shadow);
+    overflow-x: auto; scrollbar-width: thin;
+  }
+  .today-bar > * { flex: none; }
+
+  table { border-collapse: collapse; width: 100%; font-size: 12px; margin-top: 6px; }
+  th, td { text-align: left; padding: 7px 8px; border-bottom: 1px solid var(--nv-divider); vertical-align: top; }
+  th { font: 700 9px/1 inherit; letter-spacing: 0.07em; text-transform: uppercase; color: var(--nv-text-faint); }
+  td.n { font-variant-numeric: tabular-nums; color: var(--nv-text-muted); width: 84px; white-space: nowrap; }
+  td.q { color: var(--nv-text-faint); }
+  .pin { color: var(--nv-accent); font-weight: 600; }
+  .torn { color: var(--nv-warn); font-weight: 600; }
+
+  .theme-toggle {
+    position: fixed; right: 16px; bottom: 16px; width: 36px; height: 36px;
+    display: inline-flex; align-items: center; justify-content: center;
+    background: var(--nv-bar-bg); border: 1px solid var(--nv-bar-border);
+    border-radius: 999px; box-shadow: var(--nv-bar-shadow);
+    color: var(--nv-text); cursor: pointer;
+  }
+</style>
+</head>
+<body>
+<div id="view" data-theme="light">
+<div class="wrap">
+
+  <h1>Focus toolbar — context clusters</h1>
+  <p class="sub">
+    Fifteen controls, but only seven ideas. Group by the question each
+    one answers, then fold whole groups — never items — when the row
+    runs out of room. Drag the pane's corner or pick a width.
+  </p>
+
+  <h2>Today, at 420px <span class="tag bad">the report</span></h2>
+  <p class="note">
+    <code>wireToolbarScroll</code> adds ‹ › and hopes for the best.
+    Everything past the fourth control sits behind a scroll gesture,
+    wearing an unlabelled glyph.
+  </p>
+  <div style="width:420px;max-width:100%">
+    <div class="today-bar" id="todayBar"></div>
+  </div>
+
+  <h2>Proposed — context clusters <span class="tag good">the design</span></h2>
+  <p class="note">
+    Fold order <b>Simulate → Inspect → Control → Stream</b>. Navigate,
+    View and Capture never fold, because Capture is the job. A folded
+    cluster is an icon plus a caret — a text label would make folding
+    <em>cost</em> width rather than save it — and the names appear as
+    the menu's section headings. Merging into one <b>⋯</b> is the last
+    resort, not a threshold. Click a folded cluster, or the size chip.
+  </p>
+
+  <div class="controls">
+    <button data-w="1180">1180 · desktop</button>
+    <button data-w="900">900 · split</button>
+    <button data-w="640">640 · sidebar</button>
+    <button data-w="420">420 · agent pane</button>
+    <span class="readout" id="readout"></span>
+  </div>
+
+  <div class="pane" id="pane">
+    <div class="bar-stage"><div class="nv-bar" id="bar"></div></div>
+  </div>
+
+  <h2>The clusters</h2>
+  <table id="clusterTable"></table>
+
+  <h2>Why not a flat priority queue <span class="tag bad">rejected</span></h2>
+  <p class="note">
+    The first attempt ranked all fifteen controls and parked the
+    worst-ranked one until the row fit. It fits. Watch what it keeps —
+    computed live from the same ranking that version shipped with:
+  </p>
+  <table id="queueTable"></table>
+  <p class="note" style="margin-top:12px">
+    <b>Home, App switcher, Shake and Rotate are four faces of one
+    idea</b>, and the queue keeps three and drops one on a tie-break
+    between equal ranks. Same for Inspect. A user watching the bar
+    narrow sees controls vanish in an order with no story behind it.
+  </p>
+
+</div>
+</div>
+
+<button class="theme-toggle" id="themeToggle" title="Toggle theme">
+  <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/>
+    <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/></svg>
+</button>
+
+<script>
+(function () {
+  'use strict';
+
+  const P = {
+    back:   'M15 18l-6-6 6-6',
+    mic:    'M12 2a3 3 0 0 1 3 3v6a3 3 0 0 1-6 0V5a3 3 0 0 1 3-3zM5 11a7 7 0 0 0 14 0M12 18v4',
+    cube:   'M12 2l9 5v10l-9 5-9-5V7z M12 12l9-5 M12 12v10 M12 12L3 7',
+    ax:     'M12 3v18M3 12h18',
+    bars:   'M4 20V10M10 20V4M16 20v-8M22 20v-5',
+    pin:    'M12 21s7-6.3 7-11a7 7 0 1 0-14 0c0 4.7 7 11 7 11z M12 10.5a1 1 0 1 0 0 .01',
+    cam:    'M3 7h11v10H3zM17 10l4-3v10l-4-3z',
+    logs:   'M4 5h16v14H4zM8 9h8M8 13h5',
+    home:   'M4 11l8-7 8 7v9H4z',
+    shot:   'M4 8h4l2-2h4l2 2h4v11H4zM12 16a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z',
+    rec:    'M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16zM12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z',
+    apps:   'M8 4h12v12H8zM4 8v12h12',
+    shake:  'M9 5v14M15 5v14M5 9v6M19 9v6',
+    rotate: 'M4 12a8 8 0 1 1 2.3 5.6M4 18v-4h4',
+    more:   'M6 12h.01M12 12h.01M18 12h.01',
+    phone:  'M7 3h10v18H7zM10.5 5.5h3',
+    wave:   'M3 12h3l2-6 3 12 3-9 2 3h5',
+    glass:  'M11 4a7 7 0 1 0 0 14 7 7 0 0 0 0-14zM16.5 16.5L21 21',
+    film:   'M4 5h16v14H4zM4 9h16M4 15h16M8 5v14M16 5v14',
+    tag:    'M4 4h9l7 7-9 9-7-7V4zM8.5 8.5h.01',
+    gauge:  'M12 20a8 8 0 1 1 8-8M12 12l4.5-3',
+    codec:  'M3 8h4l3 8h4l3-8h4',
+    dot:    'M12 12h.01',
+  };
+
+  /** Icons for the rows that have no button in the bar to borrow from. */
+  const KIND_ICON = { os: P.tag, fps: P.gauge, fmt: P.codec, chip: P.shot };
+
+  const svg = (d, size) =>
+    '<svg width="' + (size || 15) + '" height="' + (size || 15) + '" viewBox="0 0 24 24" ' +
+    'fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" ' +
+    'stroke-linejoin="round"><path d="' + d + '"/></svg>';
+
+  const CARET =
+    '<svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">' +
+    '<polyline points="6 9 12 15 18 9"/></svg>';
+
+  // ── the seven ideas ──────────────────────────────────────────────
+  // `fold` is the order clusters collapse in; no `fold` means never.
+  // ARRAY ORDER is where a cluster SITS and it never changes — a
+  // control that survives a narrowing must not also move, or the bar
+  // reshuffles under the pointer as the pane is dragged.
+  const CLUSTERS = [
+    {
+      id: 'nav', label: 'Device', icon: P.phone, question: 'which device am I on',
+      items: [
+        { id: 'back', label: 'Back', icon: P.back },
+        { id: 'name', label: 'Device name', kind: 'name' },
+      ],
+    },
+    {
+      id: 'stream', label: 'Stream', icon: P.film, fold: 4,
+      question: 'how am I seeing it',
+      items: [
+        { id: 'os',  label: 'iOS version', kind: 'os',  role: 'readout' },
+        { id: 'fps', label: 'Frame rate',  kind: 'fps', role: 'readout' },
+        { id: 'fmt', label: 'Codec',       kind: 'fmt', role: 'choice',
+          options: ['H.264', 'MJPEG'] },
+      ],
+    },
+    {
+      id: 'view', label: 'View', icon: P.cube, question: '…in which projection',
+      items: [{ id: '3d', label: '3D view', icon: P.cube, role: 'toggle', on: true }],
+    },
+    {
+      id: 'control', label: 'Control', icon: P.home, fold: 3,
+      question: 'things I do TO the phone',
+      items: [
+        { id: 'home',   label: 'Home',         icon: P.home },
+        { id: 'apps',   label: 'App switcher', icon: P.apps },
+        { id: 'shake',  label: 'Shake',        icon: P.shake },
+        { id: 'rotate', label: 'Rotate',       icon: P.rotate },
+      ],
+    },
+    {
+      id: 'simulate', label: 'Simulate', icon: P.wave, fold: 1,
+      question: 'things I FEED the phone',
+      items: [
+        { id: 'loc',    label: 'Location',   icon: P.pin,  role: 'toggle' },
+        { id: 'status', label: 'Status bar', icon: P.bars, role: 'toggle' },
+        { id: 'cam',    label: 'Camera',     icon: P.cam,  role: 'toggle' },
+        { id: 'mic',    label: 'Microphone', icon: P.mic,  role: 'toggle' },
+      ],
+    },
+    {
+      id: 'inspect', label: 'Inspect', icon: P.glass, fold: 2,
+      question: 'things I read OUT of it',
+      items: [
+        { id: 'ax',   label: 'Accessibility', icon: P.ax,   role: 'toggle' },
+        { id: 'logs', label: 'Logs',          icon: P.logs, role: 'toggle' },
+      ],
+    },
+    {
+      id: 'capture', label: 'Capture', icon: P.shot, question: 'the job I came to do',
+      items: [
+        { id: 'shot', label: 'Screenshot',  icon: P.shot },
+        { id: 'rec',  label: 'Record',      icon: P.rec },
+        { id: 'size', label: 'Output size', kind: 'chip' },
+      ],
+    },
+  ];
+
+  // ── the capture-size catalogue, mirroring capture-size.js ────────
+  const SOURCE = { width: 1428, height: 2984 };
+  const PRESETS = [
+    { id: 'native',           label: 'Native',             code: 'Auto',  kind: 'native' },
+    { id: 'appstore-6.9',     label: 'App Store 6.9″',     code: '6.9″',  kind: 'fixed', w: 1290, h: 2796 },
+    { id: 'appstore-6.5',     label: 'App Store 6.5″',     code: '6.5″',  kind: 'fixed', w: 1242, h: 2688 },
+    { id: 'appstore-ipad-13', label: 'App Store iPad 13″', code: '13″',   kind: 'fixed', w: 2064, h: 2752 },
+    { id: 'square',           label: 'Square',             code: '1:1',   kind: 'ratio', r: 1 },
+    { id: '16:9',             label: 'Landscape 16:9',     code: '16:9',  kind: 'ratio', r: 16 / 9 },
+    { id: '9:16',             label: 'Portrait 9:16',      code: '9:16',  kind: 'ratio', r: 9 / 16 },
+    { id: '4:3',              label: 'Classic 4:3',        code: '4:3',   kind: 'ratio', r: 4 / 3 },
+    { id: '4:5',              label: 'Social 4:5',         code: '4:5',   kind: 'ratio', r: 4 / 5 },
+  ];
+
+  /** The same growth rule CaptureSize.resolve uses: never downscale. */
+  function resolve(p) {
+    if (p.kind === 'native') return { width: SOURCE.width, height: SOURCE.height };
+    if (p.kind === 'fixed')  return { width: p.w, height: p.h };
+    return SOURCE.width / SOURCE.height > p.r
+      ? { width: SOURCE.width, height: Math.round(SOURCE.width / p.r) }
+      : { width: Math.round(SOURCE.height * p.r), height: SOURCE.height };
+  }
+  const aspectOf = (p) => { const r = resolve(p); return r.width / r.height; };
+
+  const stream = { codec: 'H.264' };
+  const capture = { sizeId: '9:16', fit: 'contain', withFrame: true, optionsOpen: false };
+  const currentSize = () => PRESETS.find((p) => p.id === capture.sizeId) || PRESETS[0];
+
+  function ratioGlyph(aspect, size) {
+    const w = aspect >= 1 ? size : Math.round(size * aspect);
+    const h = aspect >= 1 ? Math.round(size / aspect) : size;
+    return '<span class="ratio-glyph"><i style="width:' + w + 'px;height:' + h + 'px"></i></span>';
+  }
+
+  /** The aspect grid: nine presets as nine shapes. */
+  function capturePopover() {
+    const cur = currentSize();
+    const r = resolve(cur);
+    const cell = (p) => {
+      const res = resolve(p);
+      const a = aspectOf(p);
+      const w = a >= 1 ? 30 : Math.round(30 * a);
+      const h = a >= 1 ? Math.round(30 / a) : 30;
+      return '<button data-size="' + p.id + '" role="menuitemradio" aria-checked="' +
+        (p.id === cur.id) + '"><span class="cap-thumb"><i style="width:' + w +
+        'px;height:' + h + 'px"></i></span><span class="lbl">' + p.code +
+        '</span><span class="px">' + res.width + '×' + res.height + '</span></button>';
+    };
+    const seg = (values, active) => '<div class="cap-seg">' + values.map((v) =>
+      '<button data-fit="' + v + '" aria-checked="' + (v === active) + '">' +
+      v[0].toUpperCase() + v.slice(1) + '</button>').join('') + '</div>';
+    const summary = [
+      cur.kind === 'native' ? null : capture.fit,
+      capture.withFrame ? 'bezel' : 'no bezel',
+    ].filter(Boolean).join(' · ');
+
+    return '<div class="cap-pop" data-cap-pop hidden>' +
+      '<p class="cap-head">Output size<span class="now">' + r.width + '×' + r.height + '</span></p>' +
+      '<div class="cap-grid">' + PRESETS.map(cell).join('') + '</div>' +
+      '<details class="cap-more"' + (capture.optionsOpen ? ' open' : '') + '>' +
+      '<summary>Options<span class="sum">' + summary + '</span>' +
+      '<svg class="chev" width="11" height="11" viewBox="0 0 24 24" fill="none" ' +
+      'stroke="currentColor" stroke-width="2.6" stroke-linecap="round" ' +
+      'stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></summary>' +
+      '<div class="cap-more-body">' +
+      '<div class="cap-row"><span class="k">Custom</span>' +
+        '<input type="text" placeholder="1920x1080 or 3:2"></div>' +
+      '<div class="cap-row"><span class="k">Fit</span>' +
+        seg(['contain', 'cover', 'stretch'], capture.fit) + '</div>' +
+      '<div class="cap-row"><span class="k">Background</span>' +
+        '<input type="color" value="#ffffff">' +
+        '<label><input type="checkbox"><span>Transparent</span></label></div>' +
+      '<div class="cap-row"><span class="k">Device</span>' +
+        '<label><input type="checkbox"' + (capture.withFrame ? ' checked' : '') +
+        '><span>Include bezel</span></label></div>' +
+      '</div></details></div>';
+  }
+
+  // ── one item, in the bar and in a menu ───────────────────────────
+  function barNode(item) {
+    const el = document.createElement('span');
+    el.dataset.id = item.id;
+    el.style.display = 'inline-flex';
+    el.style.alignItems = 'center';
+    el.style.flex = 'none';
+    if (item.kind === 'name') {
+      el.className = 'nv-name'; el.textContent = 'iPhone 17 Pro Max';
+      // The one node allowed to shrink. The blanket `flex:none` above
+      // is what keeps every button its own size; leaving it on the
+      // name silently pinned the label too, so `.tight` had no effect
+      // and the bar just overflowed instead.
+      el.style.flex = '0 1 auto';
+    } else if (item.kind === 'os') {
+      el.className = 'nv-os'; el.textContent = 'iOS 26.4';
+    } else if (item.kind === 'fps') {
+      el.className = 'nv-fps'; el.textContent = '19 fps';
+    } else if (item.kind === 'fmt') {
+      el.className = 'fmt-picker';
+      el.innerHTML = ['H.264', 'MJPEG'].map((o) =>
+        '<button class="fmt-btn' + (o === stream.codec ? ' active' : '') +
+        '" data-codec="' + o + '">' + o + '</button>').join('');
+    } else if (item.kind === 'chip') {
+      const size = currentSize();
+      el.className = 'cap';
+      el.innerHTML = '<button class="cap-chip" data-chip aria-expanded="false" title="' +
+        size.label + '">' + ratioGlyph(aspectOf(size), 11) +
+        '<span class="cap-code">' + size.code + '</span>' + CARET + '</button>' +
+        capturePopover();
+    } else {
+      el.innerHTML = '<button class="ico-btn' + (item.on ? ' active' : '') +
+        '" title="' + item.label + '">' + svg(item.icon) + '</button>';
+    }
+    return el;
+  }
+
+  /**
+   * A folded item as a menu row, rendered for what it IS.
+   *
+   * The first version flattened all four kinds into icon + label +
+   * value, which turned the codec picker into a caption reading
+   * "Codec  H.264" with no way to reach MJPEG. A value you cannot
+   * change is not a value, it is a label — so a `choice` brings its
+   * options, a `toggle` draws its state, and a `readout` gives up the
+   * hover and the pointer that promised something would happen.
+   */
+  function menuRow(item) {
+    // Every row gets a real glyph. The empty rounded square this used
+    // to fall back to read as a broken image, and it landed on exactly
+    // the three rows that have no button in the bar to borrow from.
+    const glyph = svg(item.icon || KIND_ICON[item.kind] || P.dot, 15);
+
+    if (item.role === 'readout') {
+      const value = item.kind === 'os' ? 'iOS 26.4' : '19 fps';
+      return '<div class="fold-read">' + glyph + '<span>' + item.label +
+        '</span><span class="val">' + value + '</span></div>';
+    }
+    if (item.role === 'choice') {
+      const active = item.id === 'fmt' ? stream.codec : '';
+      return '<div class="fold-choice">' + glyph +
+        '<span class="lbl">' + item.label + '</span>' +
+        '<div class="cap-seg">' + item.options.map((o) =>
+          '<button data-codec="' + o + '" aria-checked="' + (o === active) + '">' +
+          o + '</button>').join('') + '</div></div>';
+    }
+    if (item.role === 'toggle') {
+      return '<button class="fold-item' + (item.on ? ' on' : '') +
+        '" data-toggle="' + item.id + '">' + glyph +
+        '<span>' + item.label + '</span><span class="sw"></span></button>';
+    }
+    return '<button class="fold-item">' + glyph +
+      '<span>' + item.label + '</span></button>';
+  }
+
+  const bar = document.getElementById('bar');
+  const pane = document.getElementById('pane');
+  const FOLDABLE = CLUSTERS.filter((c) => c.fold).sort((a, b) => a.fold - b.fold);
+
+  /** One folded cluster (or the merged ⋯) as a button plus its menu. */
+  function foldNode(spec) {
+    const el = document.createElement('span');
+    el.className = 'fold';
+    el.dataset.id = spec.id;
+    const body = spec.groups.length > 1
+      ? spec.groups.map((g) =>
+          '<details class="fold-acc"><summary>' + svg(g.icon, 15).replace('<svg', '<svg class="lead"') +
+          '<span>' + g.label + '</span><span class="n">' + g.items.length + '</span>' +
+          '<svg class="chev" width="11" height="11" viewBox="0 0 24 24" fill="none" ' +
+          'stroke="currentColor" stroke-width="2.6" stroke-linecap="round" ' +
+          'stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></summary>' +
+          '<div class="fold-acc-body">' + g.items.map(menuRow).join('') + '</div></details>'
+        ).join('')
+      : spec.groups[0].items.map(menuRow).join('');
+    el.innerHTML =
+      '<button class="fold-btn" data-fold aria-expanded="false" title="' +
+        (spec.label || 'More controls') + '">' + svg(spec.icon, 15) +
+        CARET + '</button>' +
+      '<div class="fold-pop' + (spec.label ? '' : ' right') + '" data-fold-pop hidden>' +
+        body + '</div>';
+    return el;
+  }
+
+  /**
+   * Paint the bar for a given set of folded cluster ids.
+   *
+   * Pure in `foldedIds`: the same set always yields the same DOM, so
+   * the fit loop can call it repeatedly without accumulating state.
+   * Three or more folded clusters merge into one ⋯, placed where the
+   * earliest of them sat.
+   */
+  function paint(foldedIds, merged) {
+    bar.innerHTML = '';
+    let mergePlaced = false;
+    let printedSomething = false;
+
+    CLUSTERS.forEach((cluster) => {
+      const folded = foldedIds.indexOf(cluster.id) >= 0;
+
+      if (folded && merged) {
+        if (mergePlaced) return;
+        mergePlaced = true;
+        if (printedSomething) bar.appendChild(sepNode());
+        bar.appendChild(foldNode({
+          id: 'more', label: '', icon: P.more,
+          groups: CLUSTERS.filter((c) => foldedIds.indexOf(c.id) >= 0),
+        }));
+        printedSomething = true;
+        return;
+      }
+      if (folded) {
+        if (printedSomething) bar.appendChild(sepNode());
+        bar.appendChild(foldNode({
+          id: cluster.id, label: cluster.label, icon: cluster.icon, groups: [cluster],
+        }));
+        printedSomething = true;
+        return;
+      }
+
+      if (printedSomething) bar.appendChild(sepNode());
+      let run = null;
+      cluster.items.forEach((item) => {
+        const node = barNode(item);
+        if (item.icon) {
+          if (!run) {
+            run = document.createElement('span');
+            run.className = 'tb-actions';
+            bar.appendChild(run);
+          }
+          run.appendChild(node);
+        } else {
+          run = null;
+          bar.appendChild(node);
+        }
+      });
+      printedSomething = true;
+    });
+  }
+
+  function sepNode() {
+    const sep = document.createElement('span');
+    sep.className = 'sep';
+    return sep;
+  }
+
+  /**
+   * Fold whole clusters, in `fold` order, until the row fits.
+   *
+   * Re-measuring after each fold is what makes it exact — no width
+   * table to keep in sync with the CSS, and it stays right when the
+   * device name is long or a webfont lands late.
+   */
+  const fits = () => bar.scrollWidth <= bar.clientWidth + 1;
+
+  function layout() {
+    const folded = [];
+    let merged = false;
+    paint(folded, merged);
+    bar.classList.add('measuring');
+
+    // Fold one cluster at a time, in `fold` order, re-measuring after
+    // each. Re-measuring is what makes this exact — no width table to
+    // keep in sync with the CSS, and it stays right when the device
+    // name is long or a webfont lands late.
+    for (let i = 0; i < FOLDABLE.length && !fits(); i += 1) {
+      folded.push(FOLDABLE[i].id);
+      paint(folded, merged);
+    }
+    // Merging is the LAST resort, not a threshold. Separate cluster
+    // buttons keep their meaning — you can go straight to Simulate —
+    // so they are worth keeping until even they will not fit.
+    if (!fits() && folded.length > 1) {
+      merged = true;
+      paint(folded, merged);
+    }
+    // Absolutely last: let the device name truncate. Everything above
+    // this either vanishes into a menu or is pinned; the name is the
+    // only control that can survive at a smaller size.
+    bar.classList.toggle('tight', !fits());
+    bar.classList.remove('measuring');
+
+    const inline = CLUSTERS.filter((c) => folded.indexOf(c.id) < 0);
+    document.getElementById('readout').innerHTML =
+      pane.clientWidth + 'px · ' + inline.length + ' inline<br>' +
+      (folded.length
+        ? (merged ? 'merged: ' : 'folded: ') + folded.join(' → ')
+        : 'nothing folded');
+    return folded;
+  }
+
+  // ── today's scroller, for comparison ─────────────────────────────
+  (function today() {
+    const items = [];
+    CLUSTERS.forEach((c) => c.items.forEach((i) => items.push(i)));
+    document.getElementById('todayBar').innerHTML =
+      '<button class="ico-btn">' + svg(P.back) + '</button>' +
+      '<span class="nv-name" style="max-width:none;min-width:0">iPhone 17 Pro Max</span>' +
+      '<span class="nv-os">iOS 26.4</span><span class="nv-fps">19 fps · 3D</span>' +
+      '<span class="fmt-picker"><button class="fmt-btn active">H.264</button>' +
+      '<button class="fmt-btn">MJPEG</button></span>' +
+      items.filter((i) => i.icon && i.id !== 'back').map((i) =>
+        '<button class="ico-btn' + (i.on ? ' active' : '') + '">' + svg(i.icon) +
+        '</button>').join('') +
+      '<span class="cap"><button class="cap-chip">' +
+      ratioGlyph(aspectOf(currentSize()), 11) + '<span class="cap-code">' +
+      currentSize().code + '</span>' + CARET + '</button></span>';
+  })();
+
+  // ── the cluster table ────────────────────────────────────────────
+  (function clusterTable() {
+    const rows = CLUSTERS.map((c) =>
+      '<tr><td class="n">' +
+      (c.fold ? 'folds ' + c.fold + '<sup>' + ['st','nd','rd','th'][c.fold - 1] + '</sup>'
+              : '<span class="pin">pinned</span>') +
+      '</td><td><b>' + c.label + '</b> — ' + c.items.map((i) => i.label).join(', ') +
+      '</td><td class="q">' + c.question + '</td></tr>').join('');
+    document.getElementById('clusterTable').innerHTML =
+      '<thead><tr><th>Fold order</th><th>Cluster</th>' +
+      '<th>The question it answers</th></tr></thead><tbody>' + rows + '</tbody>';
+  })();
+
+  // ── the rejected queue, run for real ─────────────────────────────
+  (function queueTable() {
+    // The ranking the first attempt shipped with, verbatim.
+    const RANK = {
+      back: 1, name: 2, size: 3, shot: 4, rec: 5, '3d': 6, home: 7, apps: 8,
+      shake: 9, rotate: 9, fmt: 10, ax: 11, logs: 11,
+      mic: 12, status: 12, loc: 12, cam: 12, fps: 13, os: 14,
+    };
+    const all = [];
+    CLUSTERS.forEach((c) => c.items.forEach((i) => all.push(i)));
+    // The counts the live version actually produced at each width.
+    const AT = [[1180, 19], [900, 18], [640, 12], [420, 9]];
+
+    const rows = AT.map((pair) => {
+      const keep = all.slice()
+        .sort((a, b) => RANK[a.id] - RANK[b.id])
+        .slice(0, pair[1])
+        .map((i) => i.id);
+      const torn = CLUSTERS.filter((c) => {
+        const n = c.items.filter((i) => keep.indexOf(i.id) >= 0).length;
+        return n > 0 && n < c.items.length;
+      });
+      return '<tr><td class="n">' + pair[0] + 'px</td><td>' +
+        all.filter((i) => keep.indexOf(i.id) >= 0).map((i) => i.label).join(', ') +
+        '</td><td class="q">' + (torn.length
+          ? '<span class="torn">torn: ' + torn.map((c) => c.label).join(', ') + '</span>'
+          : 'intact') + '</td></tr>';
+    }).join('');
+    document.getElementById('queueTable').innerHTML =
+      '<thead><tr><th>Width</th><th>What the queue keeps</th>' +
+      '<th>Clusters</th></tr></thead><tbody>' + rows + '</tbody>';
+  })();
+
+  // ── interaction ──────────────────────────────────────────────────
+  function closeAll() {
+    document.querySelectorAll('[data-fold-pop], [data-cap-pop]')
+      .forEach((n) => n.setAttribute('hidden', ''));
+    document.querySelectorAll('[data-fold], [data-chip]')
+      .forEach((n) => n.setAttribute('aria-expanded', 'false'));
+  }
+  function reopenChip() {
+    const c = document.querySelector('[data-chip]');
+    const p = c && c.parentElement.querySelector('[data-cap-pop]');
+    if (p) { p.removeAttribute('hidden'); c.setAttribute('aria-expanded', 'true'); }
+  }
+
+  document.addEventListener('click', (event) => {
+    const fold = event.target.closest('[data-fold]');
+    if (fold) {
+      const pop = fold.parentElement.querySelector('[data-fold-pop]');
+      const open = fold.getAttribute('aria-expanded') === 'true';
+      closeAll();
+      if (!open) { pop.removeAttribute('hidden'); fold.setAttribute('aria-expanded', 'true'); }
+      return;
+    }
+    const chip = event.target.closest('[data-chip]');
+    if (chip) {
+      const pop = chip.parentElement.querySelector('[data-cap-pop]');
+      const open = chip.getAttribute('aria-expanded') === 'true';
+      closeAll();
+      if (!open) { pop.removeAttribute('hidden'); chip.setAttribute('aria-expanded', 'true'); }
+      return;
+    }
+    const codec = event.target.closest('[data-codec]');
+    if (codec) {
+      stream.codec = codec.dataset.codec;
+      const inMenu = !!event.target.closest('[data-fold-pop]');
+      const openId = inMenu
+        ? event.target.closest('.fold').dataset.id : null;
+      layout();
+      if (openId) {
+        const host = document.querySelector('.fold[data-id="' + openId + '"]');
+        if (host) {
+          host.querySelector('[data-fold-pop]').removeAttribute('hidden');
+          host.querySelector('[data-fold]').setAttribute('aria-expanded', 'true');
+          const acc = host.querySelector('.fold-acc');
+          if (acc) acc.open = true;
+        }
+      }
+      return;
+    }
+    const toggle = event.target.closest('[data-toggle]');
+    if (toggle) {
+      CLUSTERS.forEach((c) => c.items.forEach((i) => {
+        if (i.id === toggle.dataset.toggle) i.on = !i.on;
+      }));
+      toggle.classList.toggle('on');
+      return;
+    }
+    const pick = event.target.closest('[data-size]');
+    const fit = event.target.closest('[data-fit]');
+    if (pick || fit) {
+      if (pick) capture.sizeId = pick.dataset.size;
+      if (fit) { capture.fit = fit.dataset.fit; capture.optionsOpen = true; }
+      layout();
+      reopenChip();
+      return;
+    }
+    if (event.target.closest('.cap-more summary')) {
+      setTimeout(() => {
+        const d = event.target.closest('details');
+        if (d) capture.optionsOpen = d.open;
+      }, 0);
+      return;
+    }
+    const w = event.target.closest('[data-w]');
+    if (w) {
+      pane.style.width = w.dataset.w + 'px';
+      document.querySelectorAll('[data-w]').forEach((n) => n.classList.remove('on'));
+      w.classList.add('on');
+      requestAnimationFrame(layout);
+      return;
+    }
+    if (!event.target.closest('.fold') && !event.target.closest('.cap')) closeAll();
+  });
+
+  new ResizeObserver(() => layout()).observe(pane);
+
+  document.getElementById('themeToggle').addEventListener('click', () => {
+    const view = document.getElementById('view');
+    view.setAttribute('data-theme',
+      view.getAttribute('data-theme') === 'light' ? 'dark' : 'light');
+  });
+
+  layout();
+})();
+</script>
+</body>
+</html>

--- a/docs/mockups/focus-toolbar-overflow.html
+++ b/docs/mockups/focus-toolbar-overflow.html
@@ -44,14 +44,12 @@
     fold order:  Simulate → Inspect → Stream → Control
     never folds: Navigate, View, Capture
 
-  IT WRAPS BEFORE IT FOLDS. The pane in the report is narrow AND
-  TALL. Collapsing everything into one anonymous ⋯ spends the last of
-  the width while leaving the height untouched, which is backwards —
-  so the bar takes a second row first and folds only what two rows
-  cannot hold. Measured against a booted device, that is the whole
-  difference at the width from the report: at 420px a single-row bar
-  had every cluster inside one ⋯, and a two-row bar has four named
-  cluster buttons and the full device name.
+  ONE LINE, ALWAYS. A second row was built and rejected. The pane in
+  the report is narrow and tall, so height looks like the cheap
+  dimension — but a pill with a short identity row above a long
+  control row is lopsided, and it pushes the device down to keep
+  controls that fold perfectly well into a menu. Folding is the answer
+  to a narrow bar; wrapping is a differently-shaped bar.
 
   Control outranks Stream deliberately. Home, App switcher, Shake and
   Rotate are buttons someone presses while working; the codec, the fps
@@ -201,14 +199,7 @@
 
   .nv-bar {
     display: inline-flex; align-items: center; gap: 7px; max-width: 100%;
-    /* WRAPS BEFORE IT FOLDS. The pane baguette gets squeezed into is
-       narrow AND TALL — a browser sidebar beside an editor — so
-       spending the last of the width on an anonymous ⋯ throws away
-       the one dimension that pane has plenty of. A second row holds
-       every cluster by name at widths where a single row had already
-       collapsed them into a bucket. */
-    flex-wrap: wrap; row-gap: 2px;
-    min-height: 44px; padding: 0 10px;
+    height: 44px; padding: 0 10px;
     background: var(--nv-bar-bg); border: 1px solid var(--nv-bar-border);
     border-radius: 999px; box-shadow: var(--nv-bar-shadow), var(--nv-bar-inset);
     backdrop-filter: blur(18px) saturate(1.5);
@@ -933,35 +924,13 @@
    * table to keep in sync with the CSS, and it stays right when the
    * device name is long or a webfont lands late.
    */
-  /**
-   * How many rows the bar's children landed on.
-   *
-   * `scrollWidth` is useless once wrapping is on — the content always
-   * "fits" horizontally by definition. Grouped with a tolerance, not
-   * counted as distinct tops: the bar centres its children, so a 26px
-   * chip and a 30px button on the SAME row sit at different offsets.
-   */
-  function rows() {
-    const origin = bar.getBoundingClientRect().top;
-    const tops = Array.prototype.slice.call(bar.children)
-        .filter((c) => c.offsetParent)
-        .map((c) => Math.round(c.getBoundingClientRect().top - origin))
-        .sort((a, b) => a - b);
-    if (!tops.length) return 1;
-    let n = 1;
-    for (let i = 1; i < tops.length; i += 1) {
-      if (tops[i] - tops[i - 1] > 14) n += 1;
-    }
-    return n;
-  }
-
-  const MAX_ROWS = 2;
-  const fits = () => rows() <= MAX_ROWS;
+  const fits = () => bar.scrollWidth <= bar.clientWidth + 1;
 
   function layout() {
     const folded = [];
     let merged = false;
     paint(folded, merged);
+    bar.classList.add('measuring');
 
     // Fold one cluster at a time, in `fold` order, re-measuring after
     // each. Re-measuring is what makes this exact — no width table to
@@ -982,6 +951,7 @@
     // this either vanishes into a menu or is pinned; the name is the
     // only control that can survive at a smaller size.
     bar.classList.toggle('tight', !fits());
+    bar.classList.remove('measuring');
 
     const inline = CLUSTERS.filter((c) => folded.indexOf(c.id) < 0);
     document.getElementById('readout').innerHTML =

--- a/docs/mockups/focus-toolbar-overflow.html
+++ b/docs/mockups/focus-toolbar-overflow.html
@@ -41,16 +41,26 @@
   cluster in the fold order collapses WHOLE, into one menu button.
   Never an item; never a partial group.
 
-    fold order:  Simulate → Inspect → Control → Stream
+    fold order:  Simulate → Inspect → Stream → Control
     never folds: Navigate, View, Capture
 
-  Measured on this page, the bar degrades like this:
+  Control outranks Stream deliberately. Home, App switcher, Shake and
+  Rotate are buttons someone presses while working; the codec, the fps
+  readout and the iOS version are a setting visited once and two
+  captions. An earlier draft had Control folding first, which spent the
+  bar's last pixels on a version string and made Home two clicks before
+  it had to be. Measured on this page:
 
     1178px   nothing folded — all seven clusters inline
-     998px   Simulate
-     898px   + Inspect, Control
-     778px   + Stream           four separate cluster buttons
-     518px   merged into one ⋯  with the cluster names as headings
+     898px   Simulate            Control still fully inline
+     818px   + Inspect, Stream   Control still fully inline
+     638px   + Control           four separate cluster buttons
+     518px   merged into one ⋯   clusters as an exclusive accordion
+     418px   the device name truncates; the size chip stays
+
+  The swap buys Home 260px of width: it used to fold at 898px and now
+  survives to 638px, so the sidebar case keeps all four Control
+  buttons one click away.
 
   Three things this buys that the queue cannot:
 
@@ -71,11 +81,11 @@
   cluster names still do their work, in the menu headings and the
   button's tooltip.
 
-  THE COST, STATED PLAINLY. Home becomes two clicks at 640px where it
-  is one today, and Home is frequent. The counter is that today at
-  640px it is one click PLUS a scroll gesture past six icons. If
-  Control should outrank Stream that is one number — `fold` on the
-  cluster — and it is a product call, not a technical one.
+  THE COST, STATED PLAINLY. Home does eventually fold, and Home is
+  frequent. The counter is that today at that width it is one click
+  PLUS a scroll gesture past six icons. Where the line sits is one
+  number — `fold` on the cluster — and it is a product call, not a
+  technical one.
 
   The size chip keeps the aspect grid from capture-size-menu.html: nine
   presets as nine shapes, because picking an output size IS picking a
@@ -504,7 +514,7 @@
 
   <h2>Proposed — context clusters <span class="tag good">the design</span></h2>
   <p class="note">
-    Fold order <b>Simulate → Inspect → Control → Stream</b>. Navigate,
+    Fold order <b>Simulate → Inspect → Stream → Control</b>. Navigate,
     View and Capture never fold, because Capture is the job. A folded
     cluster is an icon plus a caret — a text label would make folding
     <em>cost</em> width rather than save it — and the names appear as
@@ -607,7 +617,7 @@
       ],
     },
     {
-      id: 'stream', label: 'Stream', icon: P.film, fold: 4,
+      id: 'stream', label: 'Stream', icon: P.film, fold: 3,
       question: 'how am I seeing it',
       items: [
         { id: 'os',  label: 'iOS version', kind: 'os',  role: 'readout' },
@@ -621,7 +631,7 @@
       items: [{ id: '3d', label: '3D view', icon: P.cube, role: 'toggle', on: true }],
     },
     {
-      id: 'control', label: 'Control', icon: P.home, fold: 3,
+      id: 'control', label: 'Control', icon: P.home, fold: 4,
       question: 'things I do TO the phone',
       items: [
         { id: 'home',   label: 'Home',         icon: P.home },

--- a/docs/mockups/focus-toolbar-overflow.html
+++ b/docs/mockups/focus-toolbar-overflow.html
@@ -261,7 +261,10 @@
   .fold-pop {
     position: absolute; z-index: 60; top: calc(100% + 8px); left: 50%;
     transform: translateX(-50%);
-    width: 208px; padding: 6px; border-radius: 12px;
+    /* 208px clipped "MJPEG" off the codec control — a choice row is
+       the widest thing a cluster menu holds, so the menu is sized for
+       it rather than for the label rows. */
+    width: 234px; padding: 6px; border-radius: 12px;
     background: var(--nv-panel); border: 1px solid var(--nv-divider);
     box-shadow: 0 16px 40px rgba(0, 0, 0, 0.34);
     font: 500 12px/1.3 inherit; color: var(--nv-text);
@@ -275,7 +278,14 @@
      down a level rather than answered. Collapsed, it is four rows;
      you open the one you want. Uses <details> for the same reason the
      size popover's Options row does: no state to lose, keyboard and
-     screen readers get it for free. */
+     screen readers get it for free.
+
+     EXCLUSIVE, though — `<details>` will happily open all four at
+     once, which puts all thirteen rows back and undoes the whole
+     thing. `name="..."` makes them a radio group in browsers that
+     support it, and the click handler enforces it everywhere else.
+     Open, the tallest state is four headers plus the largest group:
+     eight rows, not thirteen. */
   .fold-acc { border-radius: 8px; }
   .fold-acc + .fold-acc { margin-top: 1px; }
   .fold-acc > summary {
@@ -812,7 +822,7 @@
     el.dataset.id = spec.id;
     const body = spec.groups.length > 1
       ? spec.groups.map((g) =>
-          '<details class="fold-acc"><summary>' + svg(g.icon, 15).replace('<svg', '<svg class="lead"') +
+          '<details class="fold-acc" name="fold-acc"><summary>' + svg(g.icon, 15).replace('<svg', '<svg class="lead"') +
           '<span>' + g.label + '</span><span class="n">' + g.items.length + '</span>' +
           '<svg class="chev" width="11" height="11" viewBox="0 0 24 24" fill="none" ' +
           'stroke="currentColor" stroke-width="2.6" stroke-linecap="round" ' +
@@ -1028,6 +1038,19 @@
       const open = chip.getAttribute('aria-expanded') === 'true';
       closeAll();
       if (!open) { pop.removeAttribute('hidden'); chip.setAttribute('aria-expanded', 'true'); }
+      return;
+    }
+    const acc = event.target.closest('.fold-acc > summary');
+    if (acc) {
+      // `name=` handles this in Chrome 120+/Safari 17.4+; do it by hand
+      // so the mockup behaves the same everywhere.
+      const self = acc.parentElement;
+      setTimeout(() => {
+        if (!self.open) return;
+        self.parentElement.querySelectorAll('.fold-acc').forEach((d) => {
+          if (d !== self) d.open = false;
+        });
+      }, 0);
       return;
     }
     const codec = event.target.closest('[data-codec]');

--- a/docs/mockups/focus-toolbar-overflow.html
+++ b/docs/mockups/focus-toolbar-overflow.html
@@ -44,6 +44,15 @@
     fold order:  Simulate → Inspect → Stream → Control
     never folds: Navigate, View, Capture
 
+  IT WRAPS BEFORE IT FOLDS. The pane in the report is narrow AND
+  TALL. Collapsing everything into one anonymous ⋯ spends the last of
+  the width while leaving the height untouched, which is backwards —
+  so the bar takes a second row first and folds only what two rows
+  cannot hold. Measured against a booted device, that is the whole
+  difference at the width from the report: at 420px a single-row bar
+  had every cluster inside one ⋯, and a two-row bar has four named
+  cluster buttons and the full device name.
+
   Control outranks Stream deliberately. Home, App switcher, Shake and
   Rotate are buttons someone presses while working; the codec, the fps
   readout and the iOS version are a setting visited once and two
@@ -192,15 +201,19 @@
 
   .nv-bar {
     display: inline-flex; align-items: center; gap: 7px; max-width: 100%;
-    height: 44px; padding: 0 10px;
+    /* WRAPS BEFORE IT FOLDS. The pane baguette gets squeezed into is
+       narrow AND TALL — a browser sidebar beside an editor — so
+       spending the last of the width on an anonymous ⋯ throws away
+       the one dimension that pane has plenty of. A second row holds
+       every cluster by name at widths where a single row had already
+       collapsed them into a bucket. */
+    flex-wrap: wrap; row-gap: 2px;
+    min-height: 44px; padding: 0 10px;
     background: var(--nv-bar-bg); border: 1px solid var(--nv-bar-border);
     border-radius: 999px; box-shadow: var(--nv-bar-shadow), var(--nv-bar-inset);
     backdrop-filter: blur(18px) saturate(1.5);
   }
-  /* Clipping is what makes `scrollWidth` meaningful, but a clipped bar
-     also cuts off every popover hanging out of it — so it is worn only
-     for the duration of the measuring loop. */
-  .nv-bar.measuring { overflow: hidden; }
+
 
   .nv-name {
     font: 700 13px/1 inherit; white-space: nowrap; flex: 0 1 auto;
@@ -920,13 +933,35 @@
    * table to keep in sync with the CSS, and it stays right when the
    * device name is long or a webfont lands late.
    */
-  const fits = () => bar.scrollWidth <= bar.clientWidth + 1;
+  /**
+   * How many rows the bar's children landed on.
+   *
+   * `scrollWidth` is useless once wrapping is on — the content always
+   * "fits" horizontally by definition. Grouped with a tolerance, not
+   * counted as distinct tops: the bar centres its children, so a 26px
+   * chip and a 30px button on the SAME row sit at different offsets.
+   */
+  function rows() {
+    const origin = bar.getBoundingClientRect().top;
+    const tops = Array.prototype.slice.call(bar.children)
+        .filter((c) => c.offsetParent)
+        .map((c) => Math.round(c.getBoundingClientRect().top - origin))
+        .sort((a, b) => a - b);
+    if (!tops.length) return 1;
+    let n = 1;
+    for (let i = 1; i < tops.length; i += 1) {
+      if (tops[i] - tops[i - 1] > 14) n += 1;
+    }
+    return n;
+  }
+
+  const MAX_ROWS = 2;
+  const fits = () => rows() <= MAX_ROWS;
 
   function layout() {
     const folded = [];
     let merged = false;
     paint(folded, merged);
-    bar.classList.add('measuring');
 
     // Fold one cluster at a time, in `fold` order, re-measuring after
     // each. Re-measuring is what makes this exact — no width table to
@@ -947,7 +982,6 @@
     // this either vanishes into a menu or is pinned; the name is the
     // only control that can survive at a smaller size.
     bar.classList.toggle('tight', !fits());
-    bar.classList.remove('measuring');
 
     const inline = CLUSTERS.filter((c) => folded.indexOf(c.id) < 0);
     document.getElementById('readout').innerHTML =

--- a/docs/mockups/focus-toolbar-overflow.html
+++ b/docs/mockups/focus-toolbar-overflow.html
@@ -327,7 +327,8 @@
      reach MJPEG. Four kinds, four renderings:
 
        action    Home, Shake, Screenshot   a button; tap and it happens
-       toggle    3D, Logs, Status bar      on/off, so it shows which
+       state     Logs, Status bar, Camera  opens a panel — a dot says
+                                           which are open, not a switch
        choice    Codec, Output size        needs the options themselves
        readout   iOS version, Frame rate   not a control at all */
   .fold-item {
@@ -344,19 +345,20 @@
   .fold-item.on { color: var(--nv-accent); }
   .fold-item.on svg { opacity: 1; }
 
-  /* toggle — the state is the point, so it is drawn, not implied */
+  /* state — a DOT, not a switch.
+     Every control that reaches this menu in the real toolbar — status
+     bar, location, camera, accessibility, logs — OPENS A PANEL. A
+     switch says "a setting you flip and leave"; these are disclosures.
+     The switch also justified keeping the menu open so you could watch
+     it move, which left the panel you had just opened sitting behind
+     the menu covering it. A dot reports the same state without
+     claiming to be a setting, and every row closes the menu, because
+     every row reveals something the menu is standing on top of. */
   .fold-item .sw {
-    margin-left: auto; flex: none; width: 26px; height: 15px;
-    border-radius: 999px; background: var(--nv-btn);
-    border: 1px solid var(--nv-divider); position: relative;
+    margin-left: auto; flex: none;
+    width: 6px; height: 6px; border-radius: 999px; background: transparent;
   }
-  .fold-item .sw::after {
-    content: ''; position: absolute; top: 1px; left: 1px;
-    width: 11px; height: 11px; border-radius: 999px;
-    background: var(--nv-text-faint); transition: transform 0.15s ease;
-  }
-  .fold-item.on .sw { background: var(--nv-accent); border-color: transparent; }
-  .fold-item.on .sw::after { background: #fff; transform: translateX(11px); }
+  .fold-item.on .sw { background: var(--nv-accent); }
 
   /* choice — the options come with it, because a value you cannot
      change is a caption pretending to be a control */


### PR DESCRIPTION
Mockup **and** implementation. `docs/mockups/focus-toolbar-overflow.html` is the design; the rest is it, built.

## The report

baguette gets opened in panes nowhere near 1280px — a browser sidebar beside an editor, an agent's built-in browser. Fifteen controls in one row meant `wireToolbarScroll` turned the toolbar into a horizontal scroller, and everything past the fourth control sat behind a scroll gesture wearing an unlabelled glyph.

## The design

Fifteen controls are only **seven ideas** — Navigate, Stream, View, Control, Simulate, Inspect, Capture. A whole cluster folds into one menu when the row runs out of width. Never an item, never a partial group: the mockup runs a flat per-control priority queue as the rejected alternative, where it tears Shake off Home on a tie-break between equal ranks.

Measured against a booted iPhone 17 Pro Max:

| bar width | folded |
| --- | --- |
| 1100px | — |
| 900px | Simulate |
| 780px | + Inspect, Stream (**Control still fully inline**) |
| 640px | + Control |
| 520px | merged into one ⋯ |
| 420px | device name truncates; `over: 0` |

`ToolbarFold` owns the arithmetic and no DOM — the caller hands it a `fits` callback that renders a candidate and reports whether it fits. 11 unit tests; the rendering stays integration-only, the same bar `sim-native.js` is already held to.

Grouping is applied at runtime rather than authored into the template, so membership, fold order and each control's **role** live in one table. Every button keeps its id, its inline `onclick` and its `.active` class; the menus are a **projection** of them, so there's no second catalogue of labels to drift.

## Four things the mockup only revealed under use

- **A folded cluster is an icon plus a caret, never a text label.** "🔍 Inspect ⌄" is an 85px button replacing two 30px glyphs — folding made the bar *wider*.
- **The merged menu is an exclusive accordion.** Thirteen rows in one popover is the "too many things" complaint moved down a level. 159px closed, 299px worst case open.
- **A menu row is not one thing.** Flattening every control to icon + label + value turned the codec picker into a caption reading "Codec  H.264" with no way to reach MJPEG. Actions, states, choices and readouts each render as what they are.
- **`state` rows draw a dot, not a switch.** Every control that reaches the menu *opens a panel*; a switch says "a setting you flip and leave" — and it justified keeping the menu open afterwards, which left the panel you'd just opened sitting behind the menu covering it.

## Two bugs found against the live page

- A `choice` row **moves** the real control into the menu, so wiping the popovers deleted `#nativeFormatPicker` outright — `getElementById` returned null for the rest of the session and the Stream menu silently lost its one interactive row. Members are restored to their cluster before any rebuild.
- `sim-native.html` sets no global `box-sizing`, so `width: 100%` on a padded row resolved to content-width *plus* padding and clipped the frame-rate readout against the popover's border.

## The size chip is fixed-width at last

It rendered the preset's `label`, so it was "Native" (54px) one moment and "App Store iPad 13″" (132px) the next — the one control whose width the user changes by using it. `CaptureSize` gained `code` (four tabular characters) and `aspect()`, and the chip draws the selection's actual shape beside it.

Measured live: **a constant 90px across every preset**, against 70–137px before. The full name moved to the tooltip.

## Tests

`make test-web` 351/351 (11 new `ToolbarFold`, 6 new `CaptureSize`), `swift test` 1719/1719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive toolbar behavior that folds complete control groups into organized menus as space becomes limited.
  * Replaced horizontal toolbar scrolling with adaptive overflow menus and compact device-name handling.
  * Capture-size controls now display concise preset codes with aspect-ratio indicators while retaining full names in tooltips.
  * Added a responsive focus-toolbar mockup with light and dark themes, layout comparisons, and interactive capture, codec, toggle, theme, and width controls.
* **Tests**
  * Added coverage for toolbar folding and capture-size display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->