### PR TITLE
feat(cli): reach the CarPlay plane from screenshot and input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ For releases prior to this changelog, see the
   check. Both commands now take `--display phone|carplay` and bind through
   the same `StreamDisplayPlan` the stream uses — enabling the external
   display first, failing closed with `noMatchingPort(carPlay)` when no
-  framebuffer sits behind it. Unlike the WS query, an unknown flag value is
-  a validation error rather than a silent fallback to phone.
+  framebuffer sits behind it. Unlike the WS query, a flag value no plane
+  answers to is a validation error rather than a silent fallback to phone —
+  empty included, so `--display "$PLANE"` with nothing in `$PLANE` stops the
+  command instead of taking the phone behind the caller's back. Only an
+  absent flag means phone. Both commands reject the value before resolving
+  the device, so a broken command line reports itself rather than the udid.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ For releases prior to this changelog, see the
 
 ## [Unreleased]
 
+### Added
+
+- **`screenshot` and `input` accept `--display carplay`.** The two
+  agent-facing surfaces could not reach the CarPlay plane at all: only the
+  serve WebSocket read `?display=carplay`, and that rides the browser-trust
+  check. Both commands now take `--display phone|carplay` and bind through
+  the same `StreamDisplayPlan` the stream uses — enabling the external
+  display first, failing closed with `noMatchingPort(carPlay)` when no
+  framebuffer sits behind it. Unlike the WS query, an unknown flag value is
+  a validation error rather than a silent fallback to phone.
+
 ### Fixed
 
 - **`serve` ran away to 9+ GB within minutes of streaming.** Reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,15 @@ For releases prior to this changelog, see the
   serve WebSocket read `?display=carplay`, and that rides the browser-trust
   check. Both commands now take `--display phone|carplay` and bind through
   the same `StreamDisplayPlan` the stream uses — enabling the external
-  display first, failing closed with `noMatchingPort(carPlay)` when no
-  framebuffer sits behind it. Unlike the WS query, a flag value no plane
+  display first, and failing closed when no framebuffer sits behind the
+  plane rather than quietly capturing the phone under a CarPlay label.
+  That refusal now says what to do about it: until the CLI gained
+  `--display`, the error only ever reached a WebSocket handler and
+  surfaced as its own enum dump (`noMatchingPort(Baguette.DisplayKind.carPlay)`),
+  which names the failure but not the remedy. It now names the menu that
+  attaches a plane, and distinguishes nothing-attached from the
+  attached-but-unbacked state a detach-and-re-enable leaves, which needs a
+  cycle through Disabled instead. Unlike the WS query, a flag value no plane
   answers to is a validation error rather than a silent fallback to phone —
   empty included, so `--display "$PLANE"` with nothing in `$PLANE` stops the
   command instead of taking the phone behind the caller's back. Only an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ For releases prior to this changelog, see the
 
 ### Fixed
 
+- **Ending a CarPlay input session left the display alive and dead to
+  touch.** `IndigoHIDInput.deinit` released the external plane's digitizer
+  along with the pointer service, reasoning that a digitizer outliving its
+  display leaves the next session a target addressing nothing. That has the
+  ownership backwards: the host brought that display up and is still using
+  it, and it outlives our process — `baguette input` is one gesture long.
+  Removing the service left the CarPlay window on screen with nothing behind
+  it, unresponsive to the host's own pointer as much as to ours, and turned
+  target `1` into exactly the unregistered kind that makes
+  `SimHIDVirtualServiceManager` throw and take `backboardd` with it. The
+  digitizer now stays registered; creating is idempotent, so re-warming a
+  plane the host already built one for costs nothing. `serve` was affected
+  too — a closed CarPlay pane killed the window's touch — but the CLI made
+  it fire on every invocation.
+
 - **`serve` ran away to 9+ GB within minutes of streaming.** Reading
   `framebufferSurface` is not a local property read: it forwards through
   ROCKit to CoreSimulatorService as a *synchronous XPC round-trip*. Every

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ baguette <command> [options]
   screenshot --udid <UDID> [--output <path>] [--format png|jpg]
              [--quality 0.85] [--scale 1]
              [--size native] [--fit contain] [--background '#ffffff']
+             [--display phone|carplay]
                                              One frame (defaults to stdout;
                                              --format is inferred from the
                                              --output extension)
@@ -259,7 +260,8 @@ baguette <command> [options]
                                              scheme before its aliases
 
   # Long-lived gesture pipe
-  input --udid <UDID>                        Read newline-delimited JSON
+  input --udid <UDID> [--display phone|carplay]
+                                             Read newline-delimited JSON
                                              gestures from stdin
 
   # Web UI — single-device dashboard + multi-device farm + Camera card +

--- a/Sources/Baguette/App/Commands/InputCommand.swift
+++ b/Sources/Baguette/App/Commands/InputCommand.swift
@@ -15,6 +15,20 @@ struct InputCommand: AsyncParsableCommand {
     @Option(help: "Target display plane: phone | carplay")
     var display: String?
 
+    /// Rejected here rather than in `run()` so a malformed flag is not
+    /// masked by the device lookup that used to precede it: `--display
+    /// carply` against an absent udid reported `Device ... not found`,
+    /// which is the wrong end of a command line that was itself wrong.
+    /// The value is wrong regardless of what is booted, and `screenshot`
+    /// already fails it at the same point.
+    mutating func validate() throws {
+        do {
+            _ = try StreamDisplayPlan.from(cliFlag: display)
+        } catch let error as DisplayFlagError {
+            throw ValidationError(error.message)
+        }
+    }
+
     func run() async {
         let simulators = CoreSimulators(deviceSetPath: options.deviceSet)
         guard let simulator = simulators.find(udid: options.udid) else {

--- a/Sources/Baguette/App/Commands/InputCommand.swift
+++ b/Sources/Baguette/App/Commands/InputCommand.swift
@@ -45,6 +45,9 @@ struct InputCommand: AsyncParsableCommand {
         } catch let error as DisplayFlagError {
             log(error.message)
             Foundation.exit(1)
+        } catch let error as FramebufferSelectionError {
+            log(error.message)
+            Foundation.exit(1)
         } catch {
             log("display bind failed: \(error)")
             Foundation.exit(1)

--- a/Sources/Baguette/App/Commands/InputCommand.swift
+++ b/Sources/Baguette/App/Commands/InputCommand.swift
@@ -9,13 +9,33 @@ struct InputCommand: AsyncParsableCommand {
 
     @OptionGroup var options: DeviceOption
 
+    /// Which plane gestures land on: `phone` (default) or `carplay`.
+    /// CarPlay builds its digitizer and fails closed when the plane
+    /// has no framebuffer behind it.
+    @Option(help: "Target display plane: phone | carplay")
+    var display: String?
+
     func run() async {
         let simulators = CoreSimulators(deviceSetPath: options.deviceSet)
         guard let simulator = simulators.find(udid: options.udid) else {
             log("Device \(options.udid) not found")
             Foundation.exit(1)
         }
-        let input = simulator.input()
+        // Gestures go to the planned plane's Input; pasteboard is a
+        // device-level service and stays on the simulator itself.
+        let plan: StreamDisplayPlan
+        let bound: (screen: any Screen, input: any Input)
+        do {
+            plan = try StreamDisplayPlan.from(cliFlag: display)
+            bound = try plan.bind(to: simulator)
+        } catch let error as DisplayFlagError {
+            log(error.message)
+            Foundation.exit(1)
+        } catch {
+            log("display bind failed: \(error)")
+            Foundation.exit(1)
+        }
+        let input = bound.input
         let pasteboard = simulator.pasteboard()
         let dispatcher = GestureDispatcher(input: input)
         log("Input session started, reading from stdin")

--- a/Sources/Baguette/App/Commands/ScreenshotCommand.swift
+++ b/Sources/Baguette/App/Commands/ScreenshotCommand.swift
@@ -103,7 +103,15 @@ struct ScreenshotCommand: AsyncParsableCommand {
         // CarPlay plans enable the panel and fail closed on an unbound
         // plane; phone plans take the legacy screen untouched.
         let plan = try StreamDisplayPlan.from(cliFlag: display)
-        let bound = try plan.bind(to: simulator)
+        let bound: (screen: any Screen, input: any Input)
+        do {
+            bound = try plan.bind(to: simulator)
+        } catch let error as FramebufferSelectionError {
+            // Otherwise this surfaces as its own enum dump, which names
+            // the failure but not the remedy.
+            log(error.message)
+            throw ExitCode.failure
+        }
         let bytes = try await ScreenSnapshot.capture(
             screen: bound.screen,
             quality: quality,

--- a/Sources/Baguette/App/Commands/ScreenshotCommand.swift
+++ b/Sources/Baguette/App/Commands/ScreenshotCommand.swift
@@ -51,11 +51,23 @@ struct ScreenshotCommand: AsyncParsableCommand {
     @Option(help: "Image format: \(CaptureFormat.list) (defaults to the --output extension, else jpg)")
     var format: String?
 
+    /// Which framebuffer plane to capture: `phone` (default) or
+    /// `carplay`. CarPlay enables the external display first and fails
+    /// closed when no framebuffer sits behind it.
+    @Option(help: "Target display plane: phone | carplay")
+    var display: String?
+
     /// Reject what the pipeline can't honour — and normalise the rest,
     /// so validation is exactly as forgiving as the parsers behind it.
     /// `CaptureSize.parse` is already case-insensitive; `--fit` and
     /// `--background` are trimmed and lowercased here so they are too.
     mutating func validate() throws {
+        do {
+            _ = try StreamDisplayPlan.from(cliFlag: display)
+        } catch let error as DisplayFlagError {
+            throw ValidationError(error.message)
+        }
+
         do {
             _ = try CaptureSize.parse(size)
         } catch let error as CaptureSizeError {
@@ -88,8 +100,12 @@ struct ScreenshotCommand: AsyncParsableCommand {
             log("Device \(options.udid) not found")
             throw ExitCode.failure
         }
+        // CarPlay plans enable the panel and fail closed on an unbound
+        // plane; phone plans take the legacy screen untouched.
+        let plan = try StreamDisplayPlan.from(cliFlag: display)
+        let bound = try plan.bind(to: simulator)
         let bytes = try await ScreenSnapshot.capture(
-            screen: simulator.screen(),
+            screen: bound.screen,
             quality: quality,
             scale: max(1, scale),
             size: try CaptureSize.parse(size),

--- a/Sources/Baguette/Domain/Input/InputTeardown.swift
+++ b/Sources/Baguette/Domain/Input/InputTeardown.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// What an input session hands back when it ends.
+///
+/// The pointer service is created per HID client, so the session that
+/// created it is the one that returns it.
+///
+/// The external plane's digitizer is not ours to return. baguette attaches
+/// to a CarPlay display the host already brought up, and that display
+/// outlives our process — a `baguette input` invocation is one gesture long.
+/// Unregistering the digitizer leaves the window on screen and dead to
+/// touch, for the host's own pointer as much as for ours. It is also the
+/// dangerous direction: `SimHIDVirtualServiceManager` throws on a target
+/// nothing registered and takes `backboardd` and SpringBoard with it, where
+/// a registered target delivering nowhere is simply ignored. Creating is
+/// idempotent — the guest keys its registry by target — so re-warming a
+/// plane the host already built a digitizer for costs nothing, which is why
+/// only the create half of the pair is ours to send.
+struct InputTeardown: Equatable, Sendable {
+    let releasesPointer: Bool
+    let releasesExternalDigitizer: Bool
+
+    /// Plane-independent by design: no plane releases a digitizer it
+    /// shares with the host's own window for that display.
+    static func forPlane(_ kind: DisplayKind) -> InputTeardown {
+        InputTeardown(releasesPointer: true, releasesExternalDigitizer: false)
+    }
+}

--- a/Sources/Baguette/Domain/Screen/DisplayBinding.swift
+++ b/Sources/Baguette/Domain/Screen/DisplayBinding.swift
@@ -22,4 +22,28 @@ struct FramebufferPortSnapshot: Sendable, Equatable {
 enum FramebufferSelectionError: Error, Equatable {
     case noMatchingPort(DisplayKind)
     case screenIdUnavailable
+
+    /// What a caller reads when the plane will not bind.
+    ///
+    /// A missing CarPlay plane has two shapes and they need different
+    /// hands: nothing attached at all, and attached-but-unbacked — the
+    /// screen is listed under Connected Screens with no IOSurface behind
+    /// it, which is what a detach-and-re-enable leaves. The second is the
+    /// one that reaches here most often, and clicking CarPlay again does
+    /// not clear it; only cycling the panel through Disabled does.
+    var message: String {
+        switch self {
+        case .noMatchingPort(.carPlay):
+            return """
+                no CarPlay framebuffer is attached — enable it from \
+                Simulator's I/O ▸ External Displays ▸ CarPlay, or if the \
+                CarPlay window is already open, cycle that menu to \
+                Disabled and back to reattach a blank one
+                """
+        case .noMatchingPort(.phone):
+            return "no framebuffer for the device's own screen — it may still be booting"
+        case .screenIdUnavailable:
+            return "the display is attached but has no connected screen id yet — retry once it finishes coming up"
+        }
+    }
 }

--- a/Sources/Baguette/Domain/Stream/StreamDisplayPlan.swift
+++ b/Sources/Baguette/Domain/Stream/StreamDisplayPlan.swift
@@ -35,7 +35,12 @@ struct StreamDisplayPlan: Equatable, Sendable {
         case .phone:
             return StreamDisplayPlan(kind: .phone, enableCarPlay: false)
         case .none:
-            if let raw = cliFlag, !raw.isEmpty {
+            // Present-but-unparseable is rejected whatever it holds,
+            // empty included: `--display "$PLANE"` with nothing in
+            // `$PLANE` would otherwise take the phone silently, which is
+            // the one outcome this parser exists to rule out. Only an
+            // absent flag means phone.
+            if let raw = cliFlag {
                 throw DisplayFlagError.unknown(raw)
             }
             return StreamDisplayPlan(kind: .phone, enableCarPlay: false)

--- a/Sources/Baguette/Domain/Stream/StreamDisplayPlan.swift
+++ b/Sources/Baguette/Domain/Stream/StreamDisplayPlan.swift
@@ -4,12 +4,43 @@ import Foundation
 /// Parsed from the `display` query (`phone`|`carplay`); missing or
 /// unknown tokens default to phone. CarPlay plans also request an
 /// idempotent enable of the host External Displays panel.
+/// A `--display` value no plane answers to. The command surfaces this
+/// as a validation error rather than falling back to phone.
+enum DisplayFlagError: Error, Equatable {
+    case unknown(String)
+
+    var message: String {
+        switch self {
+        case .unknown(let raw):
+            return "--display must be one of: phone, carplay (got \"\(raw)\")"
+        }
+    }
+}
+
 struct StreamDisplayPlan: Equatable, Sendable {
     let kind: DisplayKind
     let enableCarPlay: Bool
 
     /// Live 3D routes stay on the phone plane regardless of query.
     static let phoneOnly = StreamDisplayPlan(kind: .phone, enableCarPlay: false)
+
+    /// Strict CLI parsing. Unlike the WS query — where an unknown token
+    /// quietly means phone — a mistyped `--display` must stop the
+    /// invocation, because the caller asked one plane and would silently
+    /// get another.
+    static func from(cliFlag: String?) throws -> StreamDisplayPlan {
+        switch DisplayKind.parse(cliFlag: cliFlag) {
+        case .carPlay:
+            return StreamDisplayPlan(kind: .carPlay, enableCarPlay: true)
+        case .phone:
+            return StreamDisplayPlan(kind: .phone, enableCarPlay: false)
+        case .none:
+            if let raw = cliFlag, !raw.isEmpty {
+                throw DisplayFlagError.unknown(raw)
+            }
+            return StreamDisplayPlan(kind: .phone, enableCarPlay: false)
+        }
+    }
 
     static func from(query: String?) -> StreamDisplayPlan {
         switch DisplayKind.parse(query: query) {

--- a/Sources/Baguette/Infrastructure/Input/IndigoHIDInput.swift
+++ b/Sources/Baguette/Infrastructure/Input/IndigoHIDInput.swift
@@ -122,16 +122,24 @@ final class IndigoHIDInput: Input, @unchecked Sendable {
     }
 
     deinit {
-        if warmed, let client {
-            if let remove = removePointerSvc, let msg = remove() {
-                send(message: msg, to: client)
-            }
-            // Leaving a digitizer behind for a display that has gone is
-            // how the next session inherits a target addressing nothing.
-            if plane.needsExternalDigitizer,
-               let remove = removeCarPlaySvc, let msg = remove() {
-                send(message: msg, to: client)
-            }
+        guard warmed, let client else { return }
+        let teardown = InputTeardown.forPlane(plane)
+        if teardown.releasesPointer,
+           let remove = removePointerSvc, let msg = remove() {
+            send(message: msg, to: client)
+        }
+        // The external digitizer stays registered — see `InputTeardown`.
+        // An earlier version removed it here, reasoning that a digitizer
+        // outliving its display leaves the next session a target
+        // addressing nothing. It has the ownership backwards: the host
+        // brought that display up and is still using it, so removing the
+        // service left a CarPlay window on screen that nothing could
+        // touch, and turned target 1 into the unregistered kind that
+        // kills the guest.
+        if teardown.releasesExternalDigitizer,
+           plane.needsExternalDigitizer,
+           let remove = removeCarPlaySvc, let msg = remove() {
+            send(message: msg, to: client)
         }
     }
 

--- a/Tests/BaguetteTests/App/Commands/CommandParsingTests.swift
+++ b/Tests/BaguetteTests/App/Commands/CommandParsingTests.swift
@@ -900,4 +900,38 @@ struct CommandParsingTests {
         #expect(cmd.port == 9000)
         #expect(cmd.deviceSet == "/tmp/sims")
     }
+
+    // MARK: - --display, on both agent-facing surfaces
+
+    /// A malformed `--display` is wrong about the command line itself, so
+    /// both commands must reject it at validation — before either goes
+    /// looking for a device. `input` used to resolve the simulator first,
+    /// which meant an absent udid masked the typo and the operator was
+    /// told the wrong thing about which of the two was broken.
+
+    @Test func `screenshot binds --display and defaults it to nil`() throws {
+        #expect(try ScreenshotCommand.parse(["--udid", "U"]).display == nil)
+        #expect(try ScreenshotCommand.parse(
+            ["--udid", "U", "--display", "carplay"]
+        ).display == "carplay")
+    }
+
+    @Test func `input binds --display and defaults it to nil`() throws {
+        #expect(try InputCommand.parse(["--udid", "U"]).display == nil)
+        #expect(try InputCommand.parse(
+            ["--udid", "U", "--display", "carplay"]
+        ).display == "carplay")
+    }
+
+    @Test func `screenshot rejects a display value no plane answers to`() {
+        #expect(throws: (any Error).self) {
+            try ScreenshotCommand.parse(["--udid", "U", "--display", "carply"])
+        }
+    }
+
+    @Test func `input rejects a display value no plane answers to`() {
+        #expect(throws: (any Error).self) {
+            try InputCommand.parse(["--udid", "U", "--display", "carply"])
+        }
+    }
 }

--- a/Tests/BaguetteTests/Input/InputTeardownTests.swift
+++ b/Tests/BaguetteTests/Input/InputTeardownTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import Baguette
+
+/// Ending a session must not unregister the digitizer behind an external
+/// plane. baguette does not own that display — the host's own window for it
+/// was already there and outlives our process — so removing the service
+/// leaves that window on screen and dead to touch. It is also the dangerous
+/// direction: `SimHIDVirtualServiceManager` throws on a target nothing
+/// registered and takes `backboardd` with it, where a registered target
+/// delivering nowhere is harmless.
+@Suite("InputTeardown")
+struct InputTeardownTests {
+
+    @Test func `a carPlay session leaves the external digitizer registered`() {
+        #expect(InputTeardown.forPlane(.carPlay).releasesExternalDigitizer == false)
+    }
+
+    @Test func `a phone session has no external digitizer to release`() {
+        #expect(InputTeardown.forPlane(.phone).releasesExternalDigitizer == false)
+    }
+
+    @Test func `every plane returns the pointer service it created`() {
+        #expect(InputTeardown.forPlane(.phone).releasesPointer)
+        #expect(InputTeardown.forPlane(.carPlay).releasesPointer)
+    }
+}

--- a/Tests/BaguetteTests/Screen/FramebufferSelectionErrorTests.swift
+++ b/Tests/BaguetteTests/Screen/FramebufferSelectionErrorTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import Baguette
+
+/// What an operator reads when a plane will not bind. Until the CLI gained
+/// `--display`, this error only ever reached a WebSocket handler, so it
+/// surfaced as its own enum dump — `noMatchingPort(Baguette.DisplayKind.carPlay)`
+/// — which names the failure but not the remedy, and leaks the module while
+/// it's at it. On a terminal it is the whole of what the caller gets.
+@Suite("FramebufferSelectionError")
+struct FramebufferSelectionErrorTests {
+
+    @Test func `an absent CarPlay plane names the menu that attaches one`() {
+        let message = FramebufferSelectionError.noMatchingPort(.carPlay).message
+        #expect(message.contains("CarPlay"))
+        #expect(message.contains("External Displays"))
+        // The remedy for an attached-but-black plane is a different one —
+        // cycling it off and back — and it is the case most likely to
+        // reach here, so the message has to distinguish them.
+        #expect(message.contains("Disabled"))
+        #expect(!message.contains("Baguette."))
+    }
+
+    @Test func `an absent device plane says the device has no framebuffer`() {
+        let message = FramebufferSelectionError.noMatchingPort(.phone).message
+        #expect(message.contains("device"))
+        #expect(!message.contains("Baguette."))
+    }
+
+    @Test func `an unresolved screen id reads as a display still coming up`() {
+        let message = FramebufferSelectionError.screenIdUnavailable.message
+        #expect(message.contains("screen id"))
+        #expect(!message.contains("Baguette."))
+    }
+}

--- a/Tests/BaguetteTests/Stream/StreamDisplayPlanTests.swift
+++ b/Tests/BaguetteTests/Stream/StreamDisplayPlanTests.swift
@@ -165,6 +165,26 @@ struct StreamDisplayPlanFromCLITests {
         }
     }
 
+    /// `--display ""` is the shape an unset variable takes —
+    /// `--display "$PLANE"` with nothing in `$PLANE`. Reading it as phone
+    /// is the silent-wrong-plane the strict parser exists to prevent, and
+    /// it is the worst kind of silent: a CarPlay run against the phone
+    /// passes, for the wrong reason. Omitting the flag entirely is how you
+    /// ask for the default; passing it empty is a broken command line.
+    @Test func `an empty flag is rejected rather than read as phone`() {
+        #expect(throws: DisplayFlagError.unknown("")) {
+            try StreamDisplayPlan.from(cliFlag: "")
+        }
+    }
+
+    /// The forgiving half of the pair is unchanged: a URL is not a command
+    /// line, and `?display=` there still means phone.
+    @Test func `an empty query still means phone`() {
+        #expect(StreamDisplayPlan.from(query: "") == StreamDisplayPlan(
+            kind: .phone, enableCarPlay: false
+        ))
+    }
+
     /// The rejection is what the operator actually reads, so the wording is
     /// part of the contract: it has to name the planes that would have
     /// worked and echo the token that didn't, or a typo costs a round trip

--- a/Tests/BaguetteTests/Stream/StreamDisplayPlanTests.swift
+++ b/Tests/BaguetteTests/Stream/StreamDisplayPlanTests.swift
@@ -164,6 +164,24 @@ struct StreamDisplayPlanFromCLITests {
             try StreamDisplayPlan.from(cliFlag: "carply")
         }
     }
+
+    /// The rejection is what the operator actually reads, so the wording is
+    /// part of the contract: it has to name the planes that would have
+    /// worked and echo the token that didn't, or a typo costs a round trip
+    /// to the docs to spot.
+    @Test func `the rejection names both planes and echoes what was typed`() {
+        #expect(
+            DisplayFlagError.unknown("carply").message
+            == #"--display must be one of: phone, carplay (got "carply")"#
+        )
+    }
+
+    @Test func `the rejection echoes an empty-looking token verbatim`() {
+        #expect(
+            DisplayFlagError.unknown(" ").message
+            == #"--display must be one of: phone, carplay (got " ")"#
+        )
+    }
 }
 
 /// Domain error for host panel enablement failures — tests need a

--- a/Tests/BaguetteTests/Stream/StreamDisplayPlanTests.swift
+++ b/Tests/BaguetteTests/Stream/StreamDisplayPlanTests.swift
@@ -132,6 +132,40 @@ struct StreamDisplayPlanBindTests {
     }
 }
 
+/// CLI flags are strict where the WS query is forgiving: a typo'd
+/// `--display carply` must fail the invocation, never silently capture
+/// or touch the phone plane instead.
+@Suite("StreamDisplayPlan.fromCLI")
+struct StreamDisplayPlanFromCLITests {
+
+    @Test func `absent flag yields phone without enabling CarPlay`() throws {
+        #expect(try StreamDisplayPlan.from(cliFlag: nil) == StreamDisplayPlan(
+            kind: .phone, enableCarPlay: false
+        ))
+    }
+
+    @Test func `phone flag yields phone without enabling CarPlay`() throws {
+        #expect(try StreamDisplayPlan.from(cliFlag: "phone") == StreamDisplayPlan(
+            kind: .phone, enableCarPlay: false
+        ))
+    }
+
+    @Test func `carplay flag yields carPlay and asks to enable the panel`() throws {
+        #expect(try StreamDisplayPlan.from(cliFlag: "carplay") == StreamDisplayPlan(
+            kind: .carPlay, enableCarPlay: true
+        ))
+        #expect(try StreamDisplayPlan.from(cliFlag: "CARPLAY") == StreamDisplayPlan(
+            kind: .carPlay, enableCarPlay: true
+        ))
+    }
+
+    @Test func `unknown flag is rejected, not downgraded to phone`() {
+        #expect(throws: DisplayFlagError.unknown("carply")) {
+            try StreamDisplayPlan.from(cliFlag: "carply")
+        }
+    }
+}
+
 /// Domain error for host panel enablement failures — tests need a
 /// concrete Error; Infra will map AppleScript failures onto this later.
 enum CarPlayEnableError: Error, Equatable {

--- a/docs/features/companion-screens.md
+++ b/docs/features/companion-screens.md
@@ -168,6 +168,26 @@ of the open panes) and the window width:
 Below 960px the row becomes a column, so height becomes the contended
 axis instead and the two share it 55 / 45 in the phone's favour.
 
+## Driving it from a terminal (agents)
+
+The browser panes are one consumer; the CLI is the other. Two commands
+take `--display phone|carplay` and bind through the same
+`StreamDisplayPlan` the stream uses:
+
+```sh
+# one frame from the CarPlay plane (enables the display first)
+baguette screenshot --udid <UDID> --display carplay -o carplay.png
+
+# gestures against the CarPlay digitizer, over the stdin pipe
+baguette input --udid <UDID> --display carplay < gestures.jsonl
+```
+
+CarPlay fails closed — if the plane has no framebuffer behind it the
+command exits with `noMatchingPort(carPlay)` rather than silently
+showing the phone. An unrecognized value (`--display carply`) is a
+validation error, never a quiet fallback to phone. The watch needs no
+flag: it is its own udid, so the ordinary commands point at it.
+
 ## Driving the watch
 
 A watch pane has no bezel chrome to hang overlay buttons off, so the two

--- a/docs/features/companion-screens.md
+++ b/docs/features/companion-screens.md
@@ -185,8 +185,13 @@ baguette input --udid <UDID> --display carplay < gestures.jsonl
 CarPlay fails closed — if the plane has no framebuffer behind it the
 command exits with `noMatchingPort(carPlay)` rather than silently
 showing the phone. An unrecognized value (`--display carply`) is a
-validation error, never a quiet fallback to phone. The watch needs no
-flag: it is its own udid, so the ordinary commands point at it.
+validation error, never a quiet fallback to phone, and so is an empty
+one: `--display "$PLANE"` with nothing in `$PLANE` stops the command
+rather than taking the phone behind your back. Omitting the flag is how
+you ask for the default. Both commands reject the value before they look
+for the device, so a broken command line reports itself rather than the
+udid. The watch needs no flag: it is its own udid, so the ordinary
+commands point at it.
 
 ## Driving the watch
 


### PR DESCRIPTION
## What

`baguette screenshot` and `baguette input` now take `--display phone|carplay`.

Before this, the two agent-facing surfaces could not address the CarPlay plane at all — only the `serve` WebSocket read `?display=carplay`, and that path rides the browser-trust check. Anything driving baguette from a terminal was stuck on the phone.

Both commands bind through the same `StreamDisplayPlan` the stream already uses, so one code path decides what a plane means:

- CarPlay plans enable the External Displays panel first.
- They fail closed when no framebuffer sits behind the plane, rather than opening an unbound `Screen` that would quietly serve the phone under a CarPlay label.
- Phone plans keep the legacy `screen()` / `input()` aliases untouched.

## Strict where the query is forgiving

`StreamDisplayPlan.from(query:)` treats an unknown token as phone — reasonable for a URL. `from(cliFlag:)` throws instead. A mistyped `--display carply` stops the invocation, because the caller named one plane and would otherwise silently get another.

That extends to an **empty** value. `--display ""` is the shape an unset variable takes:

```sh
baguette input --udid "$U" --display "$PLANE"   # $PLANE unset
```

Reading that as phone is the same silent-wrong-plane, and the worst kind of silent — a CarPlay run executes against the phone and *passes*, for the wrong reason. Only an absent flag means phone; omitting it is how the default is asked for. Both commands reject the value in `validate()`, before resolving the device, so a broken command line reports itself rather than the udid.

## Two bugs this surfaced

Neither was introduced here; the CLI path just made them reachable.

**1. Ending a CarPlay session destroyed the shared digitizer.** `IndigoHIDInput.deinit` released the external plane's digitizer along with the pointer service, reasoning that a digitizer outliving its display leaves the next session a target addressing nothing. The ownership is backwards: baguette attaches to a display the host brought up and is still using, and that display outlives our process — a `baguette input` invocation is one gesture long. Removing the service left the CarPlay window on screen with nothing behind it, unresponsive to the host's own pointer as much as to ours, and turned target `1` into the unregistered kind that makes `SimHIDVirtualServiceManager` throw and take `backboardd` with it.

`SimulatorKitDisplay.input()` already documented the correct policy, which the deinit contradicted:

> Dispatching to a display that has since detached is now harmless: the service is still registered, so the event is delivered nowhere rather than throwing. **Unregistered targets are what kill the guest**, and this cannot produce one.

The digitizer now stays registered. Creating is idempotent — the guest keys its registry by target — so re-warming a plane the host already built one for costs nothing, which is why only the create half of the pair is ours to send. `InputTeardown` carries the rule so a test pins it. `serve` was affected too, where a closed CarPlay pane killed the window's touch.

**2. The failure message was unreadable.** Until the CLI gained `--display`, `FramebufferSelectionError` only ever reached a WebSocket handler, so nobody read it. On a terminal it is the whole of the response:

```
Error: noMatchingPort(Baguette.DisplayKind.carPlay)
```

It now names the menu that attaches a plane, and distinguishes the two shapes of a missing plane, because they need different hands: nothing attached at all, versus attached-but-unbacked — listed under Connected Screens with no IOSurface behind it, which is what a detach-and-re-enable leaves. The second is the one that actually reaches here, and clicking CarPlay again does not clear it; only cycling the panel through Disabled does.

## Verified on device

iPhone 17 Pro / iOS 26.5, with a CarPlay display **attached**:

| check | result |
|---|---|
| `--display carply` | rejected: `--display must be one of: phone, carplay (got "carply")` |
| `--display ""` | rejected the same way |
| `--display carply --udid NOPE` | reports the flag, not the udid |
| `screenshot --display phone` | 1206×2622 |
| `screenshot --display carplay` | 800×480, CarPlay home screen |
| `input --display carplay` | `{"ok":true}`, CarPlay Settings opened |
| `input` with no flag | `{"ok":true}`, no CarPlay digitizer created |

The CarPlay tap is the path carrying real risk — dispatching to a target no service registered takes `backboardd` and SpringBoard down. The log confirms the guest was asked to build the digitizer first, at the correct plain `1` target:

```
[hid] carplay digitizer registered at 0x1
```

Two `input --display carplay` processes were then run with an exit between them — tap 1 opened Messages, tap 2 returned to the app grid — and the CarPlay window remained interactable by the host's own pointer afterwards. That last half is what no test can assert: every touch baguette sends recreates the service, so only a host click distinguishes a surviving digitizer from a recreated one.

With the CarPlay display **detached**:

| check | exit | result |
|---|---|---|
| `screenshot --display carplay` | 1 | **no file written** — no silent phone fallback |
| `input --display carplay` | 1 | refuses before accepting any gesture |
| `screenshot --display phone` | 0 | 2.8 MB, unaffected |
| `input` with no flag | 0 | `{"ok":true}` |

Confirmed it refuses for the right reason rather than trusting the exit code: `simctl io enumerate` showed only the phone port carrying an `IOSurface port:`, with both 720×480 external ports unbacked. There is genuinely no framebuffer to capture.

## Tests

`swift test` — 1852 tests / 227 suites passing. New coverage: `StreamDisplayPlan.fromCLI` (absent / phone / carplay / case-insensitivity / unknown / empty, plus the rejection wording), `InputTeardown`, `FramebufferSelectionError.message`, and `--display` parser tests on both commands. The three new Domain files are at 100% line, region, and function coverage.

## Known gaps

- **`bind()`'s auto-enable cannot recover a detached plane.** Its `enableCarPlay()` clicked the menu and re-registered the screen, but no IOSurface came with it. A `recoverCarPlay()` (Disabled → CarPlay cycle) already exists for exactly this wedge and `bind()` does not reach for it. Encoded in the error message rather than changed in behaviour — auto-cycling a display is a real side effect and its own decision.
- **The pointer service is still released unconditionally** in that same `deinit`. It is the identical ownership question for the phone plane, with no evidence either way. Left out of scope rather than widened on a hunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
