### PR TITLE
fix(web): never stream a format the browser has no decoder for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ For releases prior to this changelog, see the
 
 ### Fixed
 
+- **Picking H.264 over a LAN address left the window black for good.**
+  WebCodecs is secure-context-only, so a page served over plain HTTP has
+  no `VideoDecoder` — but a stored format skipped the capability probe,
+  and nothing stopped H.264 being stored from a browser that couldn't
+  play it. Every later load then threw out of the page's boot before the
+  toolbar and unload handler were wired, blacking out phone and CarPlay
+  pane alike. `StreamFormat` now filters the stored preference against
+  what the browser can decode, the picker disables a codec it can't play,
+  and a decoder that won't construct falls back to MJPEG instead of
+  taking the page down. Fixes
+  [#71](https://github.com/tddworks/baguette/issues/71).
 - **Ending a CarPlay input session left the display alive and dead to
   touch.** `IndigoHIDInput.deinit` released the external plane's digitizer
   along with the pointer service, reasoning that a digitizer outliving its

--- a/Sources/Baguette/Resources/Web/sim-native.html
+++ b/Sources/Baguette/Resources/Web/sim-native.html
@@ -894,6 +894,11 @@
     background: var(--nv-accent); color: var(--nv-accent-text);
     box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25);
   }
+  /* A codec this browser has no decoder for. The `title` says why. */
+  #simNativeView .fmt-btn:disabled {
+    opacity: 0.35; cursor: not-allowed;
+  }
+  #simNativeView .fmt-btn:disabled:hover { color: var(--nv-fmt-btn-text); }
 
   /* Action buttons — Home / Screenshot / App-switcher. */
   #simNativeView .tb-actions {

--- a/Sources/Baguette/Resources/Web/sim-native.js
+++ b/Sources/Baguette/Resources/Web/sim-native.js
@@ -348,7 +348,11 @@
     //    shared right-edge stack.
     mountScreensRail();
 
-    // 5. Open stream — but only if there's a guest to stream. A
+    // 5. Settle the codec picker — it's on screen even when no session
+    //    ever starts, so a shutdown device can't be left offering H.264.
+    reflectFormat(currentFormat());
+
+    // 6. Open stream — but only if there's a guest to stream. A
     //    shutdown device has no framebuffer, no HID, and no
     //    PurpleWorkspacePort; opening the socket would just paint
     //    black forever with no hint as to why. Show the power card on
@@ -413,6 +417,7 @@
   // only two states. The user can reset to auto by deleting the
   // localStorage key in DevTools if needed.
   const THEME_KEY = 'baguette.simTheme';
+  const FORMAT_KEY = 'asc.simFormat';
 
   function applyStoredTheme() {
     const stored = localStorage.getItem(THEME_KEY);
@@ -497,7 +502,21 @@
       onLog: (msg) => console.log('[native]', msg),
       onText: onStreamText,
     });
-    session.start();
+    // `boot()` runs this before wiring the toolbar and unload handler,
+    // so a throw here killed the whole page, not just the canvas (#71).
+    try {
+      session.start();
+    } catch (err) {
+      console.warn('[native] ' + format + ' stream failed to start:',
+          (err && err.message) || err);
+      try { session.stop(); } catch (_) { /* ignore */ }
+      session = null;
+      if (format !== 'mjpeg') {
+        localStorage.removeItem(FORMAT_KEY);
+        startSession('mjpeg');
+      }
+      return;
+    }
     // Companion panes are the user's standing choice, not this
     // session's — but their sockets don't survive a phone-session
     // restart's teardown, so reopen whichever are showing.
@@ -1125,9 +1144,20 @@
     box.style.height = (frame.height * scaleY) + 'px';
   }
 
+  // Which pill is lit, and which isn't offerable at all.
   function reflectFormat(format) {
+    const caps = decodeCapabilities();
     document.querySelectorAll('#nativeFormatPicker .fmt-btn').forEach((b) => {
       b.classList.toggle('active', b.dataset.v === format);
+      const fmt = window.StreamFormat && window.StreamFormat.named(b.dataset.v);
+      const playable = !fmt || fmt.isPlayable(caps);
+      if (b.dataset.titleDefault == null) {
+        b.dataset.titleDefault = b.getAttribute('title') || '';
+      }
+      b.disabled = !playable;
+      b.title = playable ? b.dataset.titleDefault
+        : fmt.label + ' needs WebCodecs, which browsers only expose on a '
+          + 'secure origin. Open this page over HTTPS or on localhost.';
     });
   }
 
@@ -1186,16 +1216,20 @@
   // independently of the phone, which meant a session the user had set to
   // H.264 still carried uncapped full JPEGs on its companion sockets.
   //
-  // The stored value is whitelisted rather than trusted: `localStorage`
-  // outlives the build that wrote it, so a format this build no longer
-  // speaks would otherwise reach the socket's `format` parameter and the
-  // `FrameDecoder` pick. Anything unrecognised falls back to what the
-  // hardware can actually decode.
+  // `StreamFormat` filters the stored value against what this browser
+  // can decode, so nothing unplayable reaches the socket.
   function currentFormat() {
-    const stored = localStorage.getItem('asc.simFormat');
-    if (stored === 'avcc' || stored === 'mjpeg') return stored;
-    return window.FrameDecoder && window.FrameDecoder.isHardwareAvailable()
-        ? 'avcc' : 'mjpeg';
+    if (!window.StreamFormat) return 'mjpeg';
+    return window.StreamFormat
+        .pick(localStorage.getItem(FORMAT_KEY), decodeCapabilities()).id;
+  }
+
+  /** What this browser can play, as `StreamFormat` wants to be told it. */
+  function decodeCapabilities() {
+    return {
+      hardwareDecoder: !!(window.FrameDecoder
+          && window.FrameDecoder.isHardwareAvailable()),
+    };
   }
 
   // Toolbar icon strip scrolls horizontally when the window is too narrow
@@ -1632,17 +1666,20 @@
       if (!window.closed) location.href = '/simulators';
     };
     window.__nativeSetFormat = (next) => {
-      if (next !== 'avcc' && next !== 'mjpeg') return;
+      // Storing an undecodable format wedges the origin (#71). The
+      // button is already disabled; this is the second lock.
+      const wanted = window.StreamFormat && window.StreamFormat.named(next);
+      if (!wanted || !wanted.isPlayable(decodeCapabilities())) return;
       const current = currentFormat();
       const view = document.getElementById('simNativeView');
-      if (current === next && (session ||
+      if (current === wanted.id && (session ||
           (view && view.getAttribute('data-render3d') === 'open'))) return;
-      localStorage.setItem('asc.simFormat', next);
-      reflectFormat(next);
+      localStorage.setItem(FORMAT_KEY, wanted.id);
+      reflectFormat(wanted.id);
       if (view && view.getAttribute('data-render3d') === 'open') {
-        if (render3DPanel) render3DPanel.setFormat(next);
+        if (render3DPanel) render3DPanel.setFormat(wanted.id);
       } else {
-        startSession(next);
+        startSession(wanted.id);
       }
     };
     window.__nativeToggleTheme = () => {

--- a/Sources/Baguette/Resources/Web/sim-stream.html
+++ b/Sources/Baguette/Resources/Web/sim-stream.html
@@ -37,6 +37,9 @@
          background: var(--panel); color: var(--text);
          font: inherit; font-size: 12px; font-weight: 600; cursor: pointer; }
   .btn:hover { border-color: #cbd5e1; background: #f1f5f9; }
+  /* `.btn` sets its own colour and cursor, so disabled needs saying. */
+  .btn:disabled { opacity: 0.4; cursor: not-allowed; }
+  .btn:disabled:hover { border-color: var(--border); background: var(--panel); }
   .btn-sm { height: 28px; padding: 0 10px; font-size: 12px; }
   .btn-primary { background: var(--accent); border-color: var(--accent); color: #fff; }
   .btn-primary:hover { background: #1d4ed8; border-color: #1d4ed8; }

--- a/Sources/Baguette/Resources/Web/sim-stream.js
+++ b/Sources/Baguette/Resources/Web/sim-stream.js
@@ -147,6 +147,21 @@
     };
   }
 
+  /** Lights the running format; disables codecs with no decoder here. */
+  function reflectFormatPicker(format) {
+    const caps = decodeCapabilities();
+    document.querySelectorAll('#simFormatRow .simFmt').forEach((b) => {
+      b.classList.toggle('btn-primary', b.dataset.v === format);
+      const fmt = window.StreamFormat && window.StreamFormat.named(b.dataset.v);
+      const playable = !fmt || fmt.isPlayable(caps);
+      b.disabled = !playable;
+      if (!playable) {
+        b.title = fmt.label + ' needs WebCodecs, which browsers only expose '
+            + 'on a secure origin. Open this page over HTTPS or on localhost.';
+      }
+    });
+  }
+
   // --- Lifecycle ---
 
   async function startStream(udid, name) {
@@ -170,23 +185,6 @@
     });
     sim.mount(document.getElementById('simDeviceFrame'));
 
-    const format = pickFormat();
-    requestAnimationFrame(() => {
-      const caps = decodeCapabilities();
-      document.querySelectorAll('#simFormatRow .simFmt').forEach((b) => {
-        b.classList.toggle('btn-primary', b.dataset.v === format);
-        // Don't offer a codec this browser has no decoder for.
-        const fmt = window.StreamFormat && window.StreamFormat.named(b.dataset.v);
-        const playable = !fmt || fmt.isPlayable(caps);
-        b.disabled = !playable;
-        if (!playable) {
-          b.title = fmt.label + ' needs WebCodecs, which browsers only expose '
-              + 'on a secure origin. Open this page over HTTPS or on localhost.';
-        }
-      });
-    });
-    log(`Stream: ${format.toUpperCase()}${format === 'avcc' ? ' (hw-decoded)' : ''}`);
-
     // Text-frame router. The stream WS carries binary video frames
     // and JSON envelopes (describe_ui_result, paste_result, server
     // pushes). The accessibility inspector consumes
@@ -206,32 +204,47 @@
       return false;
     };
 
-    session = new window.StreamSession({
-      udid, format, version: 'v2',
-      canvas: sim.canvas,
-      onSize: (w, h) => {
-        const changed = w !== lastPaintedSize.w || h !== lastPaintedSize.h;
-        lastPaintedSize = { w, h };
-        // Ratio presets resolve against the source, so the hint moves
-        // when the stream scale does.
-        if (changed) renderCaptureSizeHint();
-      },
-      onFps:  (fps) => {
-        const el = document.getElementById('simStreamFps');
-        if (el) el.textContent = fps + ' fps';
-      },
-      onLog: log,
-      onText: onStreamText,
-    });
-    // A decoder that won't build must not stop the sidebar mounting.
-    try {
-      session.start();
-    } catch (err) {
-      log(`Stream failed to start: ${(err && err.message) || err}`, true);
-      try { session.stop(); } catch { /* ignore */ }
-      session = null;
-      if (format !== 'mjpeg') localStorage.removeItem(FORMAT_KEY);
+    // False when the decoder wouldn't construct; `session` stays null.
+    const openSession = (fmt) => {
+      session = new window.StreamSession({
+        udid, format: fmt, version: 'v2',
+        canvas: sim.canvas,
+        onSize: (w, h) => {
+          const changed = w !== lastPaintedSize.w || h !== lastPaintedSize.h;
+          lastPaintedSize = { w, h };
+          // Ratio presets resolve against the source, so the hint moves
+          // when the stream scale does.
+          if (changed) renderCaptureSizeHint();
+        },
+        onFps:  (fps) => {
+          const el = document.getElementById('simStreamFps');
+          if (el) el.textContent = fps + ' fps';
+        },
+        onLog: log,
+        onText: onStreamText,
+      });
+      try {
+        session.start();
+        return true;
+      } catch (err) {
+        log(`${fmt.toUpperCase()} stream failed to start: `
+            + `${(err && err.message) || err}`, true);
+        try { session.stop(); } catch { /* ignore */ }
+        session = null;
+        return false;
+      }
+    };
+
+    // A preference the decoder can't honour: drop it, retry on MJPEG (#71).
+    let format = pickFormat();
+    if (!openSession(format) && format !== 'mjpeg') {
+      localStorage.removeItem(FORMAT_KEY);
+      format = 'mjpeg';
+      openSession(format);
     }
+    log(`Stream: ${format.toUpperCase()}${format === 'avcc' ? ' (hw-decoded)' : ''}`);
+    // After the attempt — `format` may have fallen back.
+    requestAnimationFrame(() => reflectFormatPicker(format));
 
     gallery = new window.CaptureGallery({
       udid, screen: sim.screen.def, frameImg: sim._bezel.frameImg,

--- a/Sources/Baguette/Resources/Web/sim-stream.js
+++ b/Sources/Baguette/Resources/Web/sim-stream.js
@@ -34,6 +34,10 @@
   // same shape without asking twice.
   const CAPTURE_STORAGE_KEY = 'asc.capture.stream';
 
+  // Shared with the focus view (sim-native.js) — one stream-format
+  // preference per origin, whichever surface set it.
+  const FORMAT_KEY = 'asc.simFormat';
+
   // Recording state. BrowserRecorder spins up a compose canvas only
   // while active; references are pulled from what's already on the
   // page (frameImg from the SDK bezel, screen geometry from
@@ -128,10 +132,19 @@
     return _templatePromise;
   }
 
+  // Same filtered pick the focus view makes — see stream-format.js.
   function pickFormat() {
-    const stored = localStorage.getItem('asc.simFormat');
-    if (stored === 'avcc' || stored === 'mjpeg') return stored;
-    return window.FrameDecoder.isHardwareAvailable() ? 'avcc' : 'mjpeg';
+    if (!window.StreamFormat) return 'mjpeg';
+    return window.StreamFormat
+        .pick(localStorage.getItem(FORMAT_KEY), decodeCapabilities()).id;
+  }
+
+  /** What this browser can play, as `StreamFormat` wants to be told it. */
+  function decodeCapabilities() {
+    return {
+      hardwareDecoder: !!(window.FrameDecoder
+          && window.FrameDecoder.isHardwareAvailable()),
+    };
   }
 
   // --- Lifecycle ---
@@ -159,8 +172,17 @@
 
     const format = pickFormat();
     requestAnimationFrame(() => {
+      const caps = decodeCapabilities();
       document.querySelectorAll('#simFormatRow .simFmt').forEach((b) => {
         b.classList.toggle('btn-primary', b.dataset.v === format);
+        // Don't offer a codec this browser has no decoder for.
+        const fmt = window.StreamFormat && window.StreamFormat.named(b.dataset.v);
+        const playable = !fmt || fmt.isPlayable(caps);
+        b.disabled = !playable;
+        if (!playable) {
+          b.title = fmt.label + ' needs WebCodecs, which browsers only expose '
+              + 'on a secure origin. Open this page over HTTPS or on localhost.';
+        }
       });
     });
     log(`Stream: ${format.toUpperCase()}${format === 'avcc' ? ' (hw-decoded)' : ''}`);
@@ -201,7 +223,15 @@
       onLog: log,
       onText: onStreamText,
     });
-    session.start();
+    // A decoder that won't build must not stop the sidebar mounting.
+    try {
+      session.start();
+    } catch (err) {
+      log(`Stream failed to start: ${(err && err.message) || err}`, true);
+      try { session.stop(); } catch { /* ignore */ }
+      session = null;
+      if (format !== 'mjpeg') localStorage.removeItem(FORMAT_KEY);
+    }
 
     gallery = new window.CaptureGallery({
       udid, screen: sim.screen.def, frameImg: sim._bezel.frameImg,
@@ -415,10 +445,12 @@
 
   window._simSetFormat = (btn) => {
     if (!btn) return;
-    const fmt = btn.dataset.v;
-    if (fmt !== 'avcc' && fmt !== 'mjpeg') return;
-    if (localStorage.getItem('asc.simFormat') === fmt && btn.classList.contains('btn-primary')) return;
-    localStorage.setItem('asc.simFormat', fmt);
+    // Storing an undecodable format wedges the origin (#71).
+    const wanted = window.StreamFormat && window.StreamFormat.named(btn.dataset.v);
+    if (!wanted || !wanted.isPlayable(decodeCapabilities())) return;
+    const fmt = wanted.id;
+    if (localStorage.getItem(FORMAT_KEY) === fmt && btn.classList.contains('btn-primary')) return;
+    localStorage.setItem(FORMAT_KEY, fmt);
     document.querySelectorAll('#simFormatRow .simFmt').forEach((b) => b.classList.remove('btn-primary'));
     btn.classList.add('btn-primary');
     log(`Format → ${fmt.toUpperCase()}`);

--- a/Sources/Baguette/Resources/Web/sim.html
+++ b/Sources/Baguette/Resources/Web/sim.html
@@ -36,6 +36,7 @@
 
     1. sim-input.js       — SimInput / PinchOverlay / MouseGestureSource
     2. frame-decoder.js   — MJPEG / AVCC byte → frame strategy
+       stream-format.js   — which of the two a session may run at
     3. device-frame.js    — bezel + screen-area DOM construction
     4. capture-gallery.js — screenshot fetch + composite + thumbs
     5. stream-session.js  — WebSocket lifetime + paint loop
@@ -53,6 +54,9 @@
      happily answers with sim.html — leaving the browser to parse HTML
      as JS and throw `Unexpected token '<'`. -->
 <script src="/frame-decoder.js"></script>
+<!-- Filters the stored format against frame-decoder.js's capability
+     probe; must load before sim-stream.js / sim-native.js. -->
+<script src="/stream-format.js"></script>
 <!-- Shared capture-size vocabulary (Resources/Web/capture/). These must
      load BEFORE capture-gallery.js / recorder.js / sim-stream.js: the
      picker and both capture surfaces read `window.Baguette._CaptureSize`

--- a/Sources/Baguette/Resources/Web/stream-format.js
+++ b/Sources/Baguette/Resources/Web/stream-format.js
@@ -1,0 +1,77 @@
+// StreamFormat — which wire format a stream session runs at. Pure.
+//
+//   StreamFormat.pick(localStorage.getItem('asc.simFormat'),
+//                     { hardwareDecoder: FrameDecoder.isHardwareAvailable() })
+//
+// Capability filters, it doesn't just default: WebCodecs is
+// secure-context-only, so a plain-HTTP LAN origin has no `VideoDecoder`
+// and must never be handed `avcc`, stored preference or not (issue #71).
+(function (root) {
+  'use strict';
+
+  const IDS = ['avcc', 'mjpeg'];
+  const LABELS = { avcc: 'H.264', mjpeg: 'MJPEG' };
+
+  class StreamFormat {
+    /** @param {'avcc'|'mjpeg'} id the wire spelling, as sent on the URL */
+    constructor(id) {
+      this.id = id;
+    }
+
+    /** Every format this build speaks, best first. */
+    static get ids() {
+      return IDS.slice();
+    }
+
+    /** The named format, or `null` for a spelling this build doesn't speak. */
+    static named(id) {
+      return IDS.indexOf(id) >= 0 ? new StreamFormat(id) : null;
+    }
+
+    static avcc() {
+      return new StreamFormat('avcc');
+    }
+
+    static mjpeg() {
+      return new StreamFormat('mjpeg');
+    }
+
+    /** The stored preference, or the best playable format. Absent
+     *  `capabilities` reads as no decoder. */
+    static pick(stored, capabilities) {
+      const wanted = StreamFormat.named(stored);
+      if (wanted && wanted.isPlayable(capabilities)) return wanted;
+      return StreamFormat.best(capabilities);
+    }
+
+    /** The best format the browser can play, ignoring any preference. */
+    static best(capabilities) {
+      return StreamFormat.avcc().isPlayable(capabilities)
+        ? StreamFormat.avcc()
+        : StreamFormat.mjpeg();
+    }
+
+    /** True when playing this needs WebCodecs rather than an <img> decode. */
+    get needsHardwareDecoder() {
+      return this.id === 'avcc';
+    }
+
+    /** What the format picker calls this one. */
+    get label() {
+      return LABELS[this.id];
+    }
+
+    /** True when a browser with these capabilities could actually play it. */
+    isPlayable(capabilities) {
+      if (!this.needsHardwareDecoder) return true;
+      return !!(capabilities && capabilities.hardwareDecoder);
+    }
+
+    /** The wire spelling, so a format drops straight into a URL. */
+    toString() {
+      return this.id;
+    }
+  }
+
+  root.StreamFormat = StreamFormat;
+})(window);

--- a/Tests/Web/stream-format.test.js
+++ b/Tests/Web/stream-format.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { loadBrowserModule } = require('./helpers/load-browser-module.js');
+
+const WEB = path.join(__dirname, '..', '..', 'Sources', 'Baguette', 'Resources', 'Web');
+
+function load() {
+  return loadBrowserModule(path.join(WEB, 'stream-format.js')).StreamFormat;
+}
+
+test('StreamFormat', async (t) => {
+  await t.test('names the two formats the wire speaks', () => {
+    const StreamFormat = load();
+    assert.deepEqual(StreamFormat.ids, ['avcc', 'mjpeg']);
+    assert.equal(StreamFormat.named('avcc').id, 'avcc');
+    assert.equal(StreamFormat.named('mjpeg').id, 'mjpeg');
+  });
+
+  await t.test('refuses a spelling it does not speak', () => {
+    const StreamFormat = load();
+    assert.equal(StreamFormat.named('h265'), null);
+    assert.equal(StreamFormat.named(''), null);
+    assert.equal(StreamFormat.named(null), null);
+    assert.equal(StreamFormat.named(undefined), null);
+  });
+
+  await t.test('honours a stored H.264 choice when the browser can decode it', () => {
+    const StreamFormat = load();
+    assert.equal(StreamFormat.pick('avcc', { hardwareDecoder: true }).id, 'avcc');
+  });
+
+  // Issue #71: a stored `avcc` used to short-circuit the probe entirely.
+  await t.test('falls back to MJPEG when a stored H.264 choice cannot be decoded', () => {
+    const StreamFormat = load();
+    assert.equal(StreamFormat.pick('avcc', { hardwareDecoder: false }).id, 'mjpeg');
+  });
+
+  await t.test('honours a stored MJPEG choice whatever the browser can decode', () => {
+    const StreamFormat = load();
+    assert.equal(StreamFormat.pick('mjpeg', { hardwareDecoder: true }).id, 'mjpeg');
+    assert.equal(StreamFormat.pick('mjpeg', { hardwareDecoder: false }).id, 'mjpeg');
+  });
+
+  await t.test('with nothing stored, takes the best the browser can decode', () => {
+    const StreamFormat = load();
+    assert.equal(StreamFormat.pick(null, { hardwareDecoder: true }).id, 'avcc');
+    assert.equal(StreamFormat.pick(null, { hardwareDecoder: false }).id, 'mjpeg');
+  });
+
+  await t.test('treats a format this build no longer speaks as nothing stored', () => {
+    const StreamFormat = load();
+    assert.equal(StreamFormat.pick('hevc', { hardwareDecoder: true }).id, 'avcc');
+    assert.equal(StreamFormat.pick('hevc', { hardwareDecoder: false }).id, 'mjpeg');
+  });
+
+  await t.test('reads a missing capabilities argument as no decoder', () => {
+    const StreamFormat = load();
+    assert.equal(StreamFormat.pick('avcc').id, 'mjpeg');
+    assert.equal(StreamFormat.pick(null, {}).id, 'mjpeg');
+  });
+
+  await t.test('says which format needs a hardware decoder', () => {
+    const StreamFormat = load();
+    assert.equal(StreamFormat.named('avcc').needsHardwareDecoder, true);
+    assert.equal(StreamFormat.named('mjpeg').needsHardwareDecoder, false);
+  });
+
+  await t.test('says whether a browser could play it', () => {
+    const StreamFormat = load();
+    assert.equal(StreamFormat.named('avcc').isPlayable({ hardwareDecoder: true }), true);
+    assert.equal(StreamFormat.named('avcc').isPlayable({ hardwareDecoder: false }), false);
+    assert.equal(StreamFormat.named('mjpeg').isPlayable({ hardwareDecoder: false }), true);
+  });
+
+  await t.test('carries the label the picker shows', () => {
+    const StreamFormat = load();
+    assert.equal(StreamFormat.named('avcc').label, 'H.264');
+    assert.equal(StreamFormat.named('mjpeg').label, 'MJPEG');
+  });
+
+  await t.test('stringifies to the wire spelling', () => {
+    const StreamFormat = load();
+    assert.equal(String(StreamFormat.named('avcc')), 'avcc');
+    assert.equal(`${StreamFormat.named('mjpeg')}`, 'mjpeg');
+  });
+});


### PR DESCRIPTION
WebCodecs' `VideoDecoder` is a secure-context-only API, so a page served over plain HTTP to a LAN address — the whole point of `serve --host 192.168.0.4` — has no decoder at all, while `localhost` has one.

The capability probe existed and was correct. It was simply skipped whenever a format was already stored, and nothing stopped H.264 being stored from a browser that could not play it: the picker's button stayed live and both set-format entry points persisted whatever it said. One press therefore wedged that origin permanently — every later load picked `avcc`, threw `ReferenceError: VideoDecoder is not defined` out of `boot()` before the toolbar, unload handler, theme and drop zone were wired, and painted black rather than merely failing to decode. Phone and CarPlay pane alike: the pane is collateral from 0.1.96's move off a pinned MJPEG, but the phone could reach this in 0.1.91 too.

Capability is now a filter rather than a fallback. `StreamFormat` is the one place that decides, replacing the two divergent inline copies of the stored-format read:

  - a stored format is honoured only when this browser can play it, so a poisoned preference is inert instead of fatal;
  - `__nativeSetFormat` / `_simSetFormat` refuse to persist a format the browser cannot decode;
  - the picker disables H.264 and says why — a secure origin, not a bug in baguette — instead of accepting a press that cannot work;
  - a decoder that fails to construct drops the stored preference and retries on MJPEG rather than taking the page down with it, so an already-wedged origin heals on its next load.

Fixes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stream-format detection for H.264 and MJPEG playback.
  * Unsupported formats are disabled with explanatory tooltips.
  * Stream-format preferences are saved and restored when playable.
* **Bug Fixes**
  * Automatically falls back to MJPEG when H.264 cannot be decoded or startup fails.
  * Prevented unsupported saved formats from blocking stream initialization.
* **Tests**
  * Added coverage for format detection, preferences, fallbacks, and display behavior.
* **Documentation**
  * Documented the improved H.264 playback safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->