### PR TITLE
Add tests for device matching and bundle listing in LiveDeviceModels

### DIFF
--- a/Tests/BaguetteTests/Render/LiveDeviceModelsTests.swift
+++ b/Tests/BaguetteTests/Render/LiveDeviceModelsTests.swift
@@ -99,7 +99,7 @@ struct LiveDeviceModelsTests {
         let models = try LiveDeviceModels(rootURLs: [overrideRoot, bundledRoot])
         let all = try models.all()
 
-        #expect(all.map(\.definition.id).sorted() == ["phone", "tablet"])
+        #expect(all.map(\.definition.id.rawValue).sorted() == ["phone", "tablet"])
         #expect(all.first { $0.definition.id == "phone" }?.definition.displayName == "Override")
     }
 }


### PR DESCRIPTION
This pull request makes a small improvement to a test in `LiveDeviceModelsTests.swift` by ensuring that device model IDs are compared as their raw string values, which increases type safety and clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a rendering test to compare installed bundle identifiers consistently, improving test reliability without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->